### PR TITLE
feat: Support for Performance Bonuses

### DIFF
--- a/backend/src/controllers/payrollBonusController.ts
+++ b/backend/src/controllers/payrollBonusController.ts
@@ -1,0 +1,273 @@
+import { Request, Response } from 'express';
+import { PayrollBonusService } from '../services/payrollBonusService';
+import logger from '../utils/logger';
+
+export class PayrollBonusController {
+  static async createPayrollRun(req: Request, res: Response): Promise<void> {
+    try {
+      const { organizationId, periodStart, periodEnd, assetCode } = req.body;
+
+      if (!organizationId || !periodStart || !periodEnd) {
+        res.status(400).json({
+          error: 'Missing required fields: organizationId, periodStart, periodEnd',
+        });
+        return;
+      }
+
+      const payrollRun = await PayrollBonusService.createPayrollRun(
+        organizationId,
+        new Date(periodStart),
+        new Date(periodEnd),
+        assetCode || 'XLM'
+      );
+
+      res.status(201).json({
+        success: true,
+        data: payrollRun,
+      });
+    } catch (error) {
+      logger.error('Failed to create payroll run', error);
+      res.status(500).json({
+        error: 'Failed to create payroll run',
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  static async getPayrollRun(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const summary = await PayrollBonusService.getPayrollRunSummary(parseInt(id, 10));
+
+      if (!summary) {
+        res.status(404).json({ error: 'Payroll run not found' });
+        return;
+      }
+
+      res.json({
+        success: true,
+        data: summary,
+      });
+    } catch (error) {
+      logger.error('Failed to get payroll run', error);
+      res.status(500).json({
+        error: 'Failed to get payroll run',
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  static async listPayrollRuns(req: Request, res: Response): Promise<void> {
+    try {
+      const { organizationId, page, limit } = req.query;
+
+      if (!organizationId) {
+        res.status(400).json({ error: 'Missing required parameter: organizationId' });
+        return;
+      }
+
+      const result = await PayrollBonusService.listPayrollRuns(
+        parseInt(organizationId as string, 10),
+        parseInt(page as string, 10) || 1,
+        parseInt(limit as string, 10) || 20
+      );
+
+      res.json({
+        success: true,
+        data: result,
+      });
+    } catch (error) {
+      logger.error('Failed to list payroll runs', error);
+      res.status(500).json({
+        error: 'Failed to list payroll runs',
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  static async addBonusItem(req: Request, res: Response): Promise<void> {
+    try {
+      const { payrollRunId, employeeId, amount, description } = req.body;
+
+      if (!payrollRunId || !employeeId || !amount) {
+        res.status(400).json({
+          error: 'Missing required fields: payrollRunId, employeeId, amount',
+        });
+        return;
+      }
+
+      const item = await PayrollBonusService.addBonusItem({
+        payroll_run_id: payrollRunId,
+        employee_id: employeeId,
+        amount,
+        description,
+      });
+
+      res.status(201).json({
+        success: true,
+        data: item,
+      });
+    } catch (error) {
+      logger.error('Failed to add bonus item', error);
+      res.status(500).json({
+        error: 'Failed to add bonus item',
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  static async addBatchBonusItems(req: Request, res: Response): Promise<void> {
+    try {
+      const { payrollRunId, items } = req.body;
+
+      if (!payrollRunId || !items || !Array.isArray(items) || items.length === 0) {
+        res.status(400).json({
+          error: 'Missing required fields: payrollRunId, items (array)',
+        });
+        return;
+      }
+
+      for (const item of items) {
+        if (!item.employeeId || !item.amount) {
+          res.status(400).json({
+            error: 'Each item must have employeeId and amount',
+          });
+          return;
+        }
+      }
+
+      const formattedItems = items.map(item => ({
+        employee_id: item.employeeId,
+        amount: item.amount,
+        description: item.description,
+      }));
+
+      const insertedItems = await PayrollBonusService.addBatchBonusItems(
+        payrollRunId,
+        formattedItems
+      );
+
+      res.status(201).json({
+        success: true,
+        data: insertedItems,
+        count: insertedItems.length,
+      });
+    } catch (error) {
+      logger.error('Failed to add batch bonus items', error);
+      res.status(500).json({
+        error: 'Failed to add batch bonus items',
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  static async getPayrollItems(req: Request, res: Response): Promise<void> {
+    try {
+      const { payrollRunId } = req.params;
+      const { itemType } = req.query;
+
+      const items = await PayrollBonusService.getPayrollItems(
+        parseInt(payrollRunId, 10),
+        itemType as 'base' | 'bonus' | undefined
+      );
+
+      res.json({
+        success: true,
+        data: items,
+        count: items.length,
+      });
+    } catch (error) {
+      logger.error('Failed to get payroll items', error);
+      res.status(500).json({
+        error: 'Failed to get payroll items',
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  static async deletePayrollItem(req: Request, res: Response): Promise<void> {
+    try {
+      const { itemId } = req.params;
+      const deleted = await PayrollBonusService.deletePayrollItem(parseInt(itemId, 10));
+
+      if (!deleted) {
+        res.status(404).json({ error: 'Payroll item not found' });
+        return;
+      }
+
+      res.json({
+        success: true,
+        message: 'Payroll item deleted successfully',
+      });
+    } catch (error) {
+      logger.error('Failed to delete payroll item', error);
+      res.status(500).json({
+        error: 'Failed to delete payroll item',
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  static async updatePayrollRunStatus(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      const { status } = req.body;
+
+      if (!status || !['draft', 'pending', 'processing', 'completed', 'failed'].includes(status)) {
+        res.status(400).json({
+          error: 'Invalid status. Must be one of: draft, pending, processing, completed, failed',
+        });
+        return;
+      }
+
+      const payrollRun = await PayrollBonusService.updatePayrollRunStatus(
+        parseInt(id, 10),
+        status
+      );
+
+      if (!payrollRun) {
+        res.status(404).json({ error: 'Payroll run not found' });
+        return;
+      }
+
+      res.json({
+        success: true,
+        data: payrollRun,
+      });
+    } catch (error) {
+      logger.error('Failed to update payroll run status', error);
+      res.status(500).json({
+        error: 'Failed to update payroll run status',
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  static async getBonusHistory(req: Request, res: Response): Promise<void> {
+    try {
+      const { organizationId, page, limit } = req.query;
+
+      if (!organizationId) {
+        res.status(400).json({ error: 'Missing required parameter: organizationId' });
+        return;
+      }
+
+      const result = await PayrollBonusService.getOrganizationBonusHistory(
+        parseInt(organizationId as string, 10),
+        parseInt(page as string, 10) || 1,
+        parseInt(limit as string, 10) || 20
+      );
+
+      res.json({
+        success: true,
+        data: result,
+      });
+    } catch (error) {
+      logger.error('Failed to get bonus history', error);
+      res.status(500).json({
+        error: 'Failed to get bonus history',
+        message: (error as Error).message,
+      });
+    }
+  }
+}

--- a/backend/src/db/migrations/007_create_payroll_runs.sql
+++ b/backend/src/db/migrations/007_create_payroll_runs.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS payroll_runs (
+  id SERIAL PRIMARY KEY,
+  organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  batch_id VARCHAR(64) UNIQUE NOT NULL,
+  status VARCHAR(20) DEFAULT 'draft' CHECK (status IN ('draft', 'pending', 'processing', 'completed', 'failed')),
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  total_base_amount DECIMAL(20, 7) DEFAULT 0,
+  total_bonus_amount DECIMAL(20, 7) DEFAULT 0,
+  total_amount DECIMAL(20, 7) DEFAULT 0,
+  asset_code VARCHAR(12) NOT NULL DEFAULT 'XLM',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  processed_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS payroll_items (
+  id SERIAL PRIMARY KEY,
+  payroll_run_id INTEGER NOT NULL REFERENCES payroll_runs(id) ON DELETE CASCADE,
+  employee_id INTEGER NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+  item_type VARCHAR(20) NOT NULL CHECK (item_type IN ('base', 'bonus')),
+  amount DECIMAL(20, 7) NOT NULL,
+  description TEXT,
+  tx_hash VARCHAR(64),
+  status VARCHAR(20) DEFAULT 'pending' CHECK (status IN ('pending', 'completed', 'failed')),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_payroll_runs_org_id ON payroll_runs(organization_id);
+CREATE INDEX idx_payroll_runs_batch_id ON payroll_runs(batch_id);
+CREATE INDEX idx_payroll_runs_status ON payroll_runs(status);
+CREATE INDEX idx_payroll_runs_period ON payroll_runs(period_start, period_end);
+CREATE INDEX idx_payroll_items_run_id ON payroll_items(payroll_run_id);
+CREATE INDEX idx_payroll_items_employee_id ON payroll_items(employee_id);
+CREATE INDEX idx_payroll_items_type ON payroll_items(item_type);
+
+CREATE TRIGGER update_payroll_runs_updated_at BEFORE UPDATE ON payroll_runs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_payroll_items_updated_at BEFORE UPDATE ON payroll_items
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import paymentRoutes from './routes/paymentRoutes';
 import authRoutes from './routes/authRoutes';
 import assetRoutes from './routes/assetRoutes';
 import throttlingRoutes from './routes/throttlingRoutes';
+import payrollBonusRoutes from './routes/payrollBonusRoutes';
 import { initializeSocket, emitTransactionUpdate } from './services/socketService';
 import { HealthController } from './controllers/healthController';
 import { ThrottlingService } from './services/throttlingService';
@@ -32,6 +33,7 @@ app.use('/api/employees', employeeRoutes);
 app.use('/api/payments', throttlingMiddleware(), paymentRoutes);
 app.use('/api/assets', assetRoutes);
 app.use('/api/throttling', throttlingRoutes);
+app.use('/api/payroll-bonus', payrollBonusRoutes);
 
 // Transaction simulation endpoint (for testing WebSocket updates)
 app.post('/api/simulate-transaction-update', (req, res) => {

--- a/backend/src/routes/payrollBonusRoutes.ts
+++ b/backend/src/routes/payrollBonusRoutes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { PayrollBonusController } from '../controllers/payrollBonusController';
+
+const router = Router();
+
+router.post('/runs', PayrollBonusController.createPayrollRun);
+router.get('/runs', PayrollBonusController.listPayrollRuns);
+router.get('/runs/:id', PayrollBonusController.getPayrollRun);
+router.patch('/runs/:id/status', PayrollBonusController.updatePayrollRunStatus);
+router.post('/items/bonus', PayrollBonusController.addBonusItem);
+router.post('/items/bonus/batch', PayrollBonusController.addBatchBonusItems);
+router.get('/runs/:payrollRunId/items', PayrollBonusController.getPayrollItems);
+router.delete('/items/:itemId', PayrollBonusController.deletePayrollItem);
+router.get('/bonuses/history', PayrollBonusController.getBonusHistory);
+
+export default router;

--- a/backend/src/services/payrollBonusService.ts
+++ b/backend/src/services/payrollBonusService.ts
@@ -1,0 +1,337 @@
+import { pool } from '../config/database';
+import logger from '../utils/logger';
+
+export interface PayrollRun {
+  id: number;
+  organization_id: number;
+  batch_id: string;
+  status: 'draft' | 'pending' | 'processing' | 'completed' | 'failed';
+  period_start: Date;
+  period_end: Date;
+  total_base_amount: string;
+  total_bonus_amount: string;
+  total_amount: string;
+  asset_code: string;
+  created_at: Date;
+  updated_at: Date;
+  processed_at?: Date;
+}
+
+export interface PayrollItem {
+  id: number;
+  payroll_run_id: number;
+  employee_id: number;
+  item_type: 'base' | 'bonus';
+  amount: string;
+  description?: string;
+  tx_hash?: string;
+  status: 'pending' | 'completed' | 'failed';
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface PayrollItemWithEmployee extends PayrollItem {
+  employee_first_name?: string;
+  employee_last_name?: string;
+  employee_email?: string;
+  employee_wallet_address?: string;
+}
+
+export interface CreateBonusItemInput {
+  payroll_run_id: number;
+  employee_id: number;
+  amount: string;
+  description?: string;
+}
+
+export interface PayrollRunSummary {
+  payroll_run: PayrollRun;
+  items: PayrollItemWithEmployee[];
+  summary: {
+    total_employees: number;
+    total_base_items: number;
+    total_bonus_items: number;
+    total_base_amount: string;
+    total_bonus_amount: string;
+    total_amount: string;
+    by_status: {
+      pending: number;
+      completed: number;
+      failed: number;
+    };
+  };
+}
+
+function generateBatchId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 8);
+  return `PAYROLL-${timestamp}-${random}`.toUpperCase();
+}
+
+export class PayrollBonusService {
+  static async createPayrollRun(
+    organizationId: number,
+    periodStart: Date,
+    periodEnd: Date,
+    assetCode: string = 'XLM'
+  ): Promise<PayrollRun> {
+    const batchId = generateBatchId();
+    const result = await pool.query(
+      `INSERT INTO payroll_runs (organization_id, batch_id, period_start, period_end, asset_code)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [organizationId, batchId, periodStart, periodEnd, assetCode]
+    );
+    return result.rows[0];
+  }
+
+  static async getPayrollRunById(id: number): Promise<PayrollRun | null> {
+    const result = await pool.query(
+      'SELECT * FROM payroll_runs WHERE id = $1',
+      [id]
+    );
+    return result.rows[0] || null;
+  }
+
+  static async getPayrollRunByBatchId(batchId: string): Promise<PayrollRun | null> {
+    const result = await pool.query(
+      'SELECT * FROM payroll_runs WHERE batch_id = $1',
+      [batchId]
+    );
+    return result.rows[0] || null;
+  }
+
+  static async listPayrollRuns(
+    organizationId: number,
+    page: number = 1,
+    limit: number = 20
+  ): Promise<{ data: PayrollRun[]; total: number }> {
+    const offset = (page - 1) * limit;
+    const countResult = await pool.query(
+      'SELECT COUNT(*) FROM payroll_runs WHERE organization_id = $1',
+      [organizationId]
+    );
+    const total = parseInt(countResult.rows[0].count, 10);
+
+    const dataResult = await pool.query(
+      `SELECT * FROM payroll_runs 
+       WHERE organization_id = $1 
+       ORDER BY created_at DESC 
+       LIMIT $2 OFFSET $3`,
+      [organizationId, limit, offset]
+    );
+
+    return { data: dataResult.rows, total };
+  }
+
+  static async addBaseSalaryItem(
+    payrollRunId: number,
+    employeeId: number,
+    amount: string
+  ): Promise<PayrollItem> {
+    const result = await pool.query(
+      `INSERT INTO payroll_items (payroll_run_id, employee_id, item_type, amount)
+       VALUES ($1, $2, 'base', $3)
+       RETURNING *`,
+      [payrollRunId, employeeId, amount]
+    );
+
+    await this.updatePayrollRunTotals(payrollRunId);
+
+    return result.rows[0];
+  }
+
+  static async addBonusItem(input: CreateBonusItemInput): Promise<PayrollItem> {
+    const result = await pool.query(
+      `INSERT INTO payroll_items (payroll_run_id, employee_id, item_type, amount, description)
+       VALUES ($1, $2, 'bonus', $3, $4)
+       RETURNING *`,
+      [input.payroll_run_id, input.employee_id, input.amount, input.description || null]
+    );
+
+    await this.updatePayrollRunTotals(input.payroll_run_id);
+
+    return result.rows[0];
+  }
+
+  static async addBatchBonusItems(
+    payrollRunId: number,
+    items: Array<{ employee_id: number; amount: string; description?: string }>
+  ): Promise<PayrollItem[]> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const insertedItems: PayrollItem[] = [];
+
+      for (const item of items) {
+        const result = await client.query(
+          `INSERT INTO payroll_items (payroll_run_id, employee_id, item_type, amount, description)
+           VALUES ($1, $2, 'bonus', $3, $4)
+           RETURNING *`,
+          [payrollRunId, item.employee_id, item.amount, item.description || null]
+        );
+        insertedItems.push(result.rows[0]);
+      }
+
+      await client.query('COMMIT');
+      await this.updatePayrollRunTotals(payrollRunId);
+
+      return insertedItems;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  static async getPayrollItems(
+    payrollRunId: number,
+    itemType?: 'base' | 'bonus'
+  ): Promise<PayrollItemWithEmployee[]> {
+    let query = `
+      SELECT pi.*, e.first_name as employee_first_name, e.last_name as employee_last_name,
+             e.email as employee_email, e.wallet_address as employee_wallet_address
+      FROM payroll_items pi
+      JOIN employees e ON pi.employee_id = e.id
+      WHERE pi.payroll_run_id = $1
+    `;
+    const params: (number | string)[] = [payrollRunId];
+
+    if (itemType) {
+      query += ' AND pi.item_type = $2';
+      params.push(itemType);
+    }
+
+    query += ' ORDER BY pi.created_at ASC';
+
+    const result = await pool.query(query, params);
+    return result.rows;
+  }
+
+  static async getPayrollRunSummary(payrollRunId: number): Promise<PayrollRunSummary | null> {
+    const payrollRun = await this.getPayrollRunById(payrollRunId);
+    if (!payrollRun) return null;
+
+    const items = await this.getPayrollItems(payrollRunId);
+
+    const uniqueEmployees = new Set(items.map(item => item.employee_id));
+    const baseItems = items.filter(item => item.item_type === 'base');
+    const bonusItems = items.filter(item => item.item_type === 'bonus');
+
+    const summary = {
+      total_employees: uniqueEmployees.size,
+      total_base_items: baseItems.length,
+      total_bonus_items: bonusItems.length,
+      total_base_amount: baseItems.reduce((sum, item) => sum + parseFloat(item.amount), 0).toFixed(7),
+      total_bonus_amount: bonusItems.reduce((sum, item) => sum + parseFloat(item.amount), 0).toFixed(7),
+      total_amount: items.reduce((sum, item) => sum + parseFloat(item.amount), 0).toFixed(7),
+      by_status: {
+        pending: items.filter(item => item.status === 'pending').length,
+        completed: items.filter(item => item.status === 'completed').length,
+        failed: items.filter(item => item.status === 'failed').length,
+      },
+    };
+
+    return {
+      payroll_run: payrollRun,
+      items,
+      summary,
+    };
+  }
+
+  static async updatePayrollRunTotals(payrollRunId: number): Promise<void> {
+    const result = await pool.query(
+      `SELECT 
+        COALESCE(SUM(CASE WHEN item_type = 'base' THEN amount ELSE 0 END), 0) as total_base,
+        COALESCE(SUM(CASE WHEN item_type = 'bonus' THEN amount ELSE 0 END), 0) as total_bonus,
+        COALESCE(SUM(amount), 0) as total
+       FROM payroll_items 
+       WHERE payroll_run_id = $1`,
+      [payrollRunId]
+    );
+
+    const { total_base, total_bonus, total } = result.rows[0];
+
+    await pool.query(
+      `UPDATE payroll_runs 
+       SET total_base_amount = $1, total_bonus_amount = $2, total_amount = $3 
+       WHERE id = $4`,
+      [total_base, total_bonus, total, payrollRunId]
+    );
+  }
+
+  static async updatePayrollRunStatus(
+    payrollRunId: number,
+    status: PayrollRun['status']
+  ): Promise<PayrollRun | null> {
+    const processedAt = status === 'completed' ? new Date() : null;
+    const result = await pool.query(
+      `UPDATE payroll_runs 
+       SET status = $1, processed_at = $2 
+       WHERE id = $3 
+       RETURNING *`,
+      [status, processedAt, payrollRunId]
+    );
+    return result.rows[0] || null;
+  }
+
+  static async updateItemStatus(
+    itemId: number,
+    status: PayrollItem['status'],
+    txHash?: string
+  ): Promise<PayrollItem | null> {
+    const result = await pool.query(
+      `UPDATE payroll_items 
+       SET status = $1, tx_hash = COALESCE($2, tx_hash) 
+       WHERE id = $3 
+       RETURNING *`,
+      [status, txHash || null, itemId]
+    );
+    return result.rows[0] || null;
+  }
+
+  static async deletePayrollItem(itemId: number): Promise<boolean> {
+    const item = await pool.query('SELECT payroll_run_id FROM payroll_items WHERE id = $1', [itemId]);
+    if (item.rows.length === 0) return false;
+
+    const payrollRunId = item.rows[0].payroll_run_id;
+
+    await pool.query('DELETE FROM payroll_items WHERE id = $1', [itemId]);
+    await this.updatePayrollRunTotals(payrollRunId);
+
+    return true;
+  }
+
+  static async getOrganizationBonusHistory(
+    organizationId: number,
+    page: number = 1,
+    limit: number = 20
+  ): Promise<{ data: PayrollItemWithEmployee[]; total: number }> {
+    const offset = (page - 1) * limit;
+
+    const countResult = await pool.query(
+      `SELECT COUNT(*) FROM payroll_items pi
+       JOIN payroll_runs pr ON pi.payroll_run_id = pr.id
+       WHERE pr.organization_id = $1 AND pi.item_type = 'bonus'`,
+      [organizationId]
+    );
+    const total = parseInt(countResult.rows[0].count, 10);
+
+    const dataResult = await pool.query(
+      `SELECT pi.*, e.first_name as employee_first_name, e.last_name as employee_last_name,
+              e.email as employee_email, e.wallet_address as employee_wallet_address,
+              pr.batch_id, pr.period_start, pr.period_end
+       FROM payroll_items pi
+       JOIN payroll_runs pr ON pi.payroll_run_id = pr.id
+       JOIN employees e ON pi.employee_id = e.id
+       WHERE pr.organization_id = $1 AND pi.item_type = 'bonus'
+       ORDER BY pi.created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [organizationId, limit, offset]
+    );
+
+    return { data: dataResult.rows, total };
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,12 +13,9 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "moduleResolution": "node",
     "types": ["node", "jest", "cors", "morgan"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
-    "moduleResolution": "node"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

This PR implements support for one-time performance bonuses separate from recurring base salary in payroll runs.

### Changes

- **Database**: Added `payroll_runs` and `payroll_items` tables to track payroll batches and individual items (base vs bonus)
- **API**: New endpoints for creating payroll runs and adding bonus items
- **Service**: `PayrollBonusService` for managing payroll runs and bonus items
- **Indexing**: Updated payroll indexing to distinguish between base and bonus items with `itemType` field
- **Reports**: Added `byItemType` breakdown in payroll aggregations showing base vs bonus totals

### API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/payroll-bonus/runs` | Create a new payroll run |
| GET | `/api/payroll-bonus/runs` | List payroll runs |
| GET | `/api/payroll-bonus/runs/:id` | Get payroll run with summary |
| PATCH | `/api/payroll-bonus/runs/:id/status` | Update payroll run status |
| POST | `/api/payroll-bonus/items/bonus` | Add a single bonus item |
| POST | `/api/payroll-bonus/items/bonus/batch` | Add multiple bonus items |
| GET | `/api/payroll-bonus/runs/:payrollRunId/items` | Get payroll items for a run |
| DELETE | `/api/payroll-bonus/items/:itemId` | Delete a payroll item |
| GET | `/api/payroll-bonus/bonuses/history` | Get bonus history |

### Acceptance Criteria

- [x] API supports adding one-time bonus items to a payroll run
- [x] Audit logs and receipts distinguish between base and bonus
- [x] Payroll engine correctly aggregates totals with base/bonus breakdown

Closes #53