### PR TITLE
feat: API Versioning Strategy

### DIFF
--- a/backend/docs/API_VERSIONING.md
+++ b/backend/docs/API_VERSIONING.md
@@ -1,0 +1,156 @@
+# API Versioning Strategy
+
+## Overview
+
+PayD API uses URL-based versioning to ensure backward compatibility as the platform evolves. All API endpoints are versioned using a version prefix in the URL path.
+
+## Current Version
+
+- **Current Version:** `v1`
+- **Supported Versions:** `v1`
+- **Base URL:** `/api/v1/`
+
+## Version Format
+
+API versions follow the format `v{major}` where `{major}` is an incrementing integer:
+
+```
+/api/v1/employees
+/api/v2/employees (future)
+```
+
+## Making Requests
+
+### Versioned Endpoints (Recommended)
+
+```bash
+# Recommended: Use explicit version
+GET /api/v1/employees
+POST /api/v1/payroll-bonus/runs
+GET /api/v1/payroll/audit
+```
+
+### Legacy Endpoints (Deprecated)
+
+Legacy endpoints without version prefix are still supported but deprecated:
+
+```bash
+# Deprecated: Will be sunset
+GET /api/employees
+POST /api/payroll-bonus/runs
+```
+
+## Response Headers
+
+All API responses include version-related headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-API-Version` | The API version handling the request |
+| `X-API-Current-Version` | The latest stable API version |
+| `X-API-Supported-Versions` | Comma-separated list of supported versions |
+
+### Deprecation Headers
+
+When using deprecated endpoints or versions, additional headers are included:
+
+| Header | Description |
+|--------|-------------|
+| `Deprecation` | `true` if the endpoint/version is deprecated |
+| `Sunset` | Date when the endpoint will be removed (RFC 1123 format) |
+| `X-API-Deprecation-Message` | Human-readable deprecation notice |
+| `Link` | Link to the successor version endpoint |
+
+### Example Response Headers
+
+**Current Version:**
+```
+X-API-Version: v1
+X-API-Current-Version: v1
+X-API-Supported-Versions: v1
+```
+
+**Deprecated/Legacy Endpoint:**
+```
+X-API-Version: v1
+X-API-Current-Version: v1
+X-API-Supported-Versions: v1
+Deprecation: true
+Sunset: Sat, 01 Jan 2027 00:00:00 GMT
+X-API-Deprecation-Message: Legacy API routes are deprecated. Please use /api/v1/ instead.
+Link: </api/v1/employees>; rel="successor-version"
+```
+
+## Version Lifecycle
+
+1. **Active** - Current version, fully supported
+2. **Deprecated** - Still functional but marked for removal
+3. **Sunset** - No longer available
+
+## Deprecation Policy
+
+- Minimum 6 months notice before removing a version
+- Deprecation headers included in all responses
+- Migration guide provided for breaking changes
+- Legacy routes will sunset on **January 1, 2027**
+
+## Adding New Versions
+
+When creating a new API version:
+
+1. Create a new directory: `src/routes/v2/`
+2. Copy and modify routes as needed
+3. Update `apiVersionMiddleware.ts` with new version config
+4. Update this documentation
+5. Add deprecation headers to previous version if needed
+
+## Breaking vs Non-Breaking Changes
+
+### Breaking Changes (Require New Version)
+- Removing endpoints
+- Changing required parameters
+- Changing response structure
+- Changing authentication requirements
+
+### Non-Breaking Changes (No New Version Needed)
+- Adding new endpoints
+- Adding optional parameters
+- Adding new response fields
+- Bug fixes
+
+## Migration Guide
+
+### From Legacy to v1
+
+Replace all `/api/` prefixes with `/api/v1/`:
+
+```diff
+- GET /api/employees
++ GET /api/v1/employees
+
+- POST /api/payroll-bonus/runs
++ POST /api/v1/payroll-bonus/runs
+
+- GET /api/payroll/audit
++ GET /api/v1/payroll/audit
+```
+
+## API Root Endpoint
+
+Get API information at the root endpoint:
+
+```bash
+GET /api
+```
+
+Response:
+```json
+{
+  "name": "PayD API",
+  "currentVersion": "v1",
+  "supportedVersions": ["v1"],
+  "endpoints": {
+    "v1": "/api/v1"
+  }
+}
+```

--- a/backend/src/middlewares/apiVersionMiddleware.ts
+++ b/backend/src/middlewares/apiVersionMiddleware.ts
@@ -1,0 +1,115 @@
+import { Request, Response, NextFunction } from 'express';
+import logger from '../utils/logger';
+
+export type ApiVersion = 'v1';
+
+export interface VersionConfig {
+  version: ApiVersion;
+  deprecated: boolean;
+  sunset?: string;
+  deprecationMessage?: string;
+}
+
+const VERSION_CONFIGS: Record<ApiVersion, VersionConfig> = {
+  v1: {
+    version: 'v1',
+    deprecated: false,
+  },
+};
+
+const CURRENT_VERSION: ApiVersion = 'v1';
+const SUPPORTED_VERSIONS: ApiVersion[] = ['v1'];
+const LEGACY_ROUTES_DEPRECATED = true;
+const LEGACY_ROUTES_SUNSET = 'Sat, 01 Jan 2027 00:00:00 GMT';
+
+export function extractApiVersion(path: string): ApiVersion | null {
+  const versionMatch = path.match(/^\/api\/(v\d+)\//);
+  if (versionMatch && SUPPORTED_VERSIONS.includes(versionMatch[1] as ApiVersion)) {
+    return versionMatch[1] as ApiVersion;
+  }
+  return null;
+}
+
+function isLegacyRoute(path: string): boolean {
+  return path.startsWith('/api/') && !path.match(/^\/api\/v\d+\//);
+}
+
+export function apiVersionMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const version = extractApiVersion(req.path);
+
+  res.setHeader('X-API-Version', version || CURRENT_VERSION);
+  res.setHeader('X-API-Supported-Versions', SUPPORTED_VERSIONS.join(', '));
+  res.setHeader('X-API-Current-Version', CURRENT_VERSION);
+
+  if (version) {
+    const config = VERSION_CONFIGS[version];
+
+    if (config.deprecated) {
+      res.setHeader('Deprecation', 'true');
+      
+      if (config.sunset) {
+        res.setHeader('Sunset', config.sunset);
+      }
+
+      if (config.deprecationMessage) {
+        res.setHeader('X-API-Deprecation-Message', config.deprecationMessage);
+      }
+
+      res.setHeader('Link', `</api/${CURRENT_VERSION}>; rel="successor-version"`);
+
+      logger.warn(`Deprecated API version ${version} accessed`, {
+        path: req.path,
+        method: req.method,
+        ip: req.ip,
+      });
+    }
+  } else if (isLegacyRoute(req.path)) {
+    res.setHeader('Deprecation', 'true');
+    res.setHeader('Sunset', LEGACY_ROUTES_SUNSET);
+    res.setHeader('X-API-Deprecation-Message', 
+      `Legacy API routes are deprecated. Please use /api/${CURRENT_VERSION}/ instead.`);
+    res.setHeader('Link', `</api/${CURRENT_VERSION}${req.path.replace('/api', '')}>; rel="successor-version"`);
+
+    logger.warn('Legacy API route accessed', {
+      path: req.path,
+      method: req.method,
+      ip: req.ip,
+    });
+  }
+
+  req.apiVersion = version || CURRENT_VERSION;
+
+  next();
+}
+
+export function requireApiVersion(minVersion: ApiVersion) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const version = req.apiVersion || CURRENT_VERSION;
+    const versionNum = parseInt(version.replace('v', ''), 10);
+    const minVersionNum = parseInt(minVersion.replace('v', ''), 10);
+
+    if (versionNum < minVersionNum) {
+      res.status(400).json({
+        error: 'Unsupported API version',
+        message: `This endpoint requires API version ${minVersion} or higher`,
+        currentVersion: version,
+        minimumVersion: minVersion,
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+export function versionedRouter(version: ApiVersion, router: express.Router) {
+  return router;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      apiVersion?: ApiVersion;
+    }
+  }
+}

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import { throttlingMiddleware } from '../../middlewares/throttlingMiddleware';
+import searchRoutes from '../searchRoutes';
+import employeeRoutes from '../employeeRoutes';
+import paymentRoutes from '../paymentRoutes';
+import authRoutes from '../authRoutes';
+import assetRoutes from '../assetRoutes';
+import throttlingRoutes from '../throttlingRoutes';
+import payrollBonusRoutes from '../payrollBonusRoutes';
+import payrollAuditRoutes from '../payrollAuditRoutes';
+import auditRoutes from '../auditRoutes';
+import balanceRoutes from '../balanceRoutes';
+import trustlineRoutes from '../trustlineRoutes';
+import payrollRoutes from '../payroll.routes';
+
+const router = Router();
+
+router.use('/auth', authRoutes);
+router.use('/search', searchRoutes);
+router.use('/employees', employeeRoutes);
+router.use('/payments', throttlingMiddleware(), paymentRoutes);
+router.use('/assets', assetRoutes);
+router.use('/throttling', throttlingRoutes);
+router.use('/payroll-bonus', payrollBonusRoutes);
+router.use('/payroll/audit', payrollAuditRoutes);
+router.use('/payroll', payrollRoutes);
+router.use('/audit', auditRoutes);
+router.use('/balance', balanceRoutes);
+router.use('/trustline', trustlineRoutes);
+
+export default router;


### PR DESCRIPTION
## Summary

This PR implements a URL-based API versioning strategy to ensure backward compatibility as the platform evolves.

### Changes

- **Versioning**: Added `/api/v1/` prefix for all API endpoints
- **Middleware**: `apiVersionMiddleware` handles version extraction and deprecation headers
- **Routes**: Created `routes/v1/` aggregator for all v1 routes
- **Backward Compatibility**: Legacy `/api/` routes still work but are deprecated
- **Documentation**: Added `docs/API_VERSIONING.md` with guidelines

### API Endpoints

| Version | Base URL | Status |
|---------|----------|--------|
| v1 | `/api/v1/` | Active |
| Legacy | `/api/` | Deprecated (Sunset: Jan 1, 2027) |

### Response Headers

All responses include version headers:
- `X-API-Version` - Current version handling request
- `X-API-Current-Version` - Latest stable version
- `X-API-Supported-Versions` - All supported versions

Deprecated endpoints include:
- `Deprecation: true`
- `Sunset` - Date of removal
- `X-API-Deprecation-Message` - Migration guidance
- `Link` - Successor version URL

### Example

```bash
# Versioned (recommended)
GET /api/v1/employees

# Legacy (deprecated)
GET /api/employees
```

### Acceptance Criteria

- [x] URL-based versioning implemented across all routes
- [x] Documentation reflects versioning guidelines
- [x] Deprecation headers added for older versions

Closes #56