### PR TITLE
feat: API Rate Limiting

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import dotenv from 'dotenv';
 
-// ok
 dotenv.config();
 
 const envSchema = z.object({
@@ -13,6 +12,12 @@ const envSchema = z.object({
   THROTTLING_TPM: z.string().default('100'),
   THROTTLING_MAX_QUEUE_SIZE: z.string().default('1000'),
   THROTTLING_REFILL_INTERVAL_MS: z.string().default('1000'),
+  RATE_LIMIT_AUTH_WINDOW_MS: z.string().default('900000'),
+  RATE_LIMIT_AUTH_MAX: z.string().default('10'),
+  RATE_LIMIT_API_WINDOW_MS: z.string().default('60000'),
+  RATE_LIMIT_API_MAX: z.string().default('100'),
+  RATE_LIMIT_DATA_WINDOW_MS: z.string().default('60000'),
+  RATE_LIMIT_DATA_MAX: z.string().default('200'),
 });
 
 export const config = envSchema.parse(process.env);
@@ -21,4 +26,19 @@ export const getThrottlingConfig = () => ({
   tpm: parseInt(config.THROTTLING_TPM, 10),
   maxQueueSize: parseInt(config.THROTTLING_MAX_QUEUE_SIZE, 10),
   refillIntervalMs: parseInt(config.THROTTLING_REFILL_INTERVAL_MS, 10),
+});
+
+export const getRateLimitConfig = () => ({
+  auth: {
+    windowMs: parseInt(config.RATE_LIMIT_AUTH_WINDOW_MS, 10),
+    maxRequests: parseInt(config.RATE_LIMIT_AUTH_MAX, 10),
+  },
+  api: {
+    windowMs: parseInt(config.RATE_LIMIT_API_WINDOW_MS, 10),
+    maxRequests: parseInt(config.RATE_LIMIT_API_MAX, 10),
+  },
+  data: {
+    windowMs: parseInt(config.RATE_LIMIT_DATA_WINDOW_MS, 10),
+    maxRequests: parseInt(config.RATE_LIMIT_DATA_MAX, 10),
+  },
 });

--- a/backend/src/controllers/rateLimitController.ts
+++ b/backend/src/controllers/rateLimitController.ts
@@ -1,0 +1,64 @@
+import { Request, Response } from 'express';
+import { rateLimitService, RateLimitTierName } from '../services/rateLimitService';
+
+export class RateLimitController {
+  static async getStatus(req: Request, res: Response): Promise<void> {
+    const { identifier, tier } = req.query;
+
+    if (!identifier) {
+      res.status(400).json({
+        error: 'Missing required parameter: identifier',
+      });
+      return;
+    }
+
+    const tierName = (tier as RateLimitTierName) || 'api';
+    const tierConfig = rateLimitService.getTierConfig(tierName);
+
+    const result = await rateLimitService.checkRateLimit(
+      identifier as string,
+      tierName
+    );
+
+    res.json({
+      success: true,
+      data: {
+        identifier,
+        tier: tierName,
+        tierConfig: {
+          windowMs: tierConfig.windowMs,
+          maxRequests: tierConfig.maxRequests,
+        },
+        currentStatus: {
+          allowed: result.allowed,
+          limit: result.limit,
+          remaining: result.remaining,
+          resetAt: result.resetAt.toISOString(),
+          retryAfter: result.retryAfter,
+        },
+      },
+    });
+  }
+
+  static async getTiers(_req: Request, res: Response): Promise<void> {
+    const tiers = {
+      auth: rateLimitService.getTierConfig('auth'),
+      api: rateLimitService.getTierConfig('api'),
+      data: rateLimitService.getTierConfig('data'),
+      strict: rateLimitService.getTierConfig('strict'),
+    };
+
+    res.json({
+      success: true,
+      data: {
+        tiers,
+        description: {
+          auth: 'Stricter limits for authentication endpoints',
+          api: 'Standard limits for API operations',
+          data: 'Higher limits for data retrieval endpoints',
+          strict: 'Very strict limits for sensitive operations',
+        },
+      },
+    });
+  }
+}

--- a/backend/src/middlewares/rateLimitMiddleware.ts
+++ b/backend/src/middlewares/rateLimitMiddleware.ts
@@ -1,0 +1,116 @@
+import { Request, Response, NextFunction } from 'express';
+import { rateLimitService, RateLimitTierName } from '../services/rateLimitService';
+import logger from '../utils/logger';
+
+export interface RateLimitOptions {
+  tier?: RateLimitTierName;
+  identifier?: (req: Request) => string;
+  skip?: (req: Request) => boolean;
+  handler?: (req: Request, res: Response) => void;
+}
+
+function defaultIdentifier(req: Request): string {
+  return req.ip || 
+         req.headers['x-forwarded-for']?.toString().split(',')[0].trim() ||
+         req.headers['x-real-ip']?.toString() ||
+         'unknown';
+}
+
+function defaultHandler(_req: Request, res: Response, result: any): void {
+  res.status(429).json({
+    error: 'Too Many Requests',
+    message: 'Rate limit exceeded. Please try again later.',
+    retryAfter: result.retryAfter,
+    limit: result.limit,
+  });
+}
+
+export function rateLimitMiddleware(options: RateLimitOptions = {}) {
+  const {
+    tier = 'api',
+    identifier = defaultIdentifier,
+    skip,
+    handler,
+  } = options;
+
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    if (skip && skip(req)) {
+      return next();
+    }
+
+    const clientIdentifier = identifier(req);
+    const tierConfig = rateLimitService.getTierConfig(tier);
+
+    try {
+      const result = await rateLimitService.checkRateLimit(clientIdentifier, tier);
+
+      res.setHeader('X-RateLimit-Limit', result.limit);
+      res.setHeader('X-RateLimit-Remaining', result.remaining);
+      res.setHeader('X-RateLimit-Reset', Math.ceil(result.resetAt.getTime() / 1000));
+
+      if (!result.allowed) {
+        res.setHeader('Retry-After', result.retryAfter || 60);
+        
+        logger.warn('Rate limit exceeded', {
+          ip: clientIdentifier,
+          tier,
+          path: req.path,
+          method: req.method,
+          limit: result.limit,
+        });
+
+        if (handler) {
+          handler(req, res);
+        } else {
+          defaultHandler(req, res, result);
+        }
+        return;
+      }
+
+      res.on('finish', () => {
+        if (res.statusCode === 429) {
+          logger.info('Rate limit response sent', {
+            ip: clientIdentifier,
+            tier,
+            path: req.path,
+          });
+        }
+      });
+
+      next();
+    } catch (error) {
+      logger.error('Rate limit middleware error', { error });
+      next();
+    }
+  };
+}
+
+export function authRateLimit(options: Omit<RateLimitOptions, 'tier'> = {}) {
+  return rateLimitMiddleware({ ...options, tier: 'auth' });
+}
+
+export function apiRateLimit(options: Omit<RateLimitOptions, 'tier'> = {}) {
+  return rateLimitMiddleware({ ...options, tier: 'api' });
+}
+
+export function dataRateLimit(options: Omit<RateLimitOptions, 'tier'> = {}) {
+  return rateLimitMiddleware({ ...options, tier: 'data' });
+}
+
+export function strictRateLimit(options: Omit<RateLimitOptions, 'tier'> = {}) {
+  return rateLimitMiddleware({ ...options, tier: 'strict' });
+}
+
+export function apiKeyRateLimit(options: Omit<RateLimitOptions, 'identifier'> = {}) {
+  return rateLimitMiddleware({
+    ...options,
+    tier: options.tier || 'api',
+    identifier: (req: Request) => {
+      const apiKey = req.headers['x-api-key']?.toString();
+      if (apiKey) {
+        return `apikey:${apiKey}`;
+      }
+      return defaultIdentifier(req);
+    },
+  });
+}

--- a/backend/src/routes/rateLimitRoutes.ts
+++ b/backend/src/routes/rateLimitRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { RateLimitController } from '../controllers/rateLimitController';
+
+const router = Router();
+
+router.get('/status', RateLimitController.getStatus);
+router.get('/tiers', RateLimitController.getTiers);
+
+export default router;

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { throttlingMiddleware } from '../../middlewares/throttlingMiddleware';
+import { authRateLimit, apiRateLimit, dataRateLimit } from '../../middlewares/rateLimitMiddleware';
 import searchRoutes from '../searchRoutes';
 import employeeRoutes from '../employeeRoutes';
 import paymentRoutes from '../paymentRoutes';
@@ -14,22 +15,24 @@ import trustlineRoutes from '../trustlineRoutes';
 import payrollRoutes from '../payroll.routes';
 import exportRoutes from '../exportRoutes';
 import taxRoutes from '../taxRoutes';
+import rateLimitRoutes from '../rateLimitRoutes';
 
 const router = Router();
 
-router.use('/auth', authRoutes);
-router.use('/search', searchRoutes);
-router.use('/employees', employeeRoutes);
-router.use('/payments', throttlingMiddleware(), paymentRoutes);
-router.use('/assets', assetRoutes);
-router.use('/throttling', throttlingRoutes);
-router.use('/payroll-bonus', payrollBonusRoutes);
-router.use('/payroll/audit', payrollAuditRoutes);
-router.use('/payroll', payrollRoutes);
-router.use('/audit', auditRoutes);
-router.use('/balance', balanceRoutes);
-router.use('/trustline', trustlineRoutes);
-router.use('/exports', exportRoutes);
-router.use('/taxes', taxRoutes);
+router.use('/auth', authRateLimit(), authRoutes);
+router.use('/search', dataRateLimit(), searchRoutes);
+router.use('/employees', dataRateLimit(), employeeRoutes);
+router.use('/payments', apiRateLimit(), throttlingMiddleware(), paymentRoutes);
+router.use('/assets', dataRateLimit(), assetRoutes);
+router.use('/throttling', apiRateLimit(), throttlingRoutes);
+router.use('/payroll-bonus', apiRateLimit(), payrollBonusRoutes);
+router.use('/payroll/audit', dataRateLimit(), payrollAuditRoutes);
+router.use('/payroll', dataRateLimit(), payrollRoutes);
+router.use('/audit', dataRateLimit(), auditRoutes);
+router.use('/balance', dataRateLimit(), balanceRoutes);
+router.use('/trustline', dataRateLimit(), trustlineRoutes);
+router.use('/exports', dataRateLimit(), exportRoutes);
+router.use('/taxes', dataRateLimit(), taxRoutes);
+router.use('/rate-limit', apiRateLimit(), rateLimitRoutes);
 
 export default router;

--- a/backend/src/services/rateLimitService.ts
+++ b/backend/src/services/rateLimitService.ts
@@ -1,0 +1,228 @@
+import Redis from 'ioredis';
+import { config } from '../config/env';
+import logger from '../utils/logger';
+
+export interface RateLimitConfig {
+  windowMs: number;
+  maxRequests: number;
+  keyPrefix: string;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: Date;
+  retryAfter?: number;
+}
+
+export interface RateLimitTier {
+  windowMs: number;
+  maxRequests: number;
+}
+
+const RATE_LIMIT_TIERS = {
+  auth: {
+    windowMs: 15 * 60 * 1000,
+    maxRequests: 10,
+  },
+  api: {
+    windowMs: 60 * 1000,
+    maxRequests: 100,
+  },
+  data: {
+    windowMs: 60 * 1000,
+    maxRequests: 200,
+  },
+  strict: {
+    windowMs: 60 * 1000,
+    maxRequests: 20,
+  },
+} as const;
+
+export type RateLimitTierName = keyof typeof RATE_LIMIT_TIERS;
+
+class RedisClient {
+  private static instance: Redis | null = null;
+
+  static getInstance(): Redis | null {
+    if (!this.instance && config.REDIS_URL) {
+      this.instance = new Redis(config.REDIS_URL, {
+        maxRetriesPerRequest: 3,
+        retryDelayOnFailover: 100,
+        lazyConnect: true,
+      });
+
+      this.instance.on('error', (err) => {
+        logger.error('Redis connection error', { error: err.message });
+      });
+
+      this.instance.on('connect', () => {
+        logger.info('Redis connected for rate limiting');
+      });
+    }
+    return this.instance;
+  }
+
+  static async disconnect(): Promise<void> {
+    if (this.instance) {
+      await this.instance.quit();
+      this.instance = null;
+    }
+  }
+}
+
+export class RateLimitService {
+  private redis: Redis | null;
+  private memoryStore: Map<string, { count: number; resetAt: number }> = new Map();
+  private useMemoryFallback: boolean = false;
+
+  constructor() {
+    this.redis = RedisClient.getInstance();
+    
+    if (!this.redis) {
+      logger.warn('Redis not configured, using in-memory rate limiting (not recommended for production)');
+      this.useMemoryFallback = true;
+    }
+
+    if (this.useMemoryFallback) {
+      setInterval(() => this.cleanupMemoryStore(), 60 * 1000);
+    }
+  }
+
+  async checkRateLimit(
+    identifier: string,
+    tier: RateLimitTierName = 'api'
+  ): Promise<RateLimitResult> {
+    const tierConfig = RATE_LIMIT_TIERS[tier];
+    const key = `ratelimit:${tier}:${identifier}`;
+    const now = Date.now();
+    const windowStart = now - tierConfig.windowMs;
+
+    if (this.useMemoryFallback || !this.redis) {
+      return this.checkMemoryRateLimit(key, tierConfig, now);
+    }
+
+    return this.checkRedisRateLimit(key, tierConfig, now);
+  }
+
+  private async checkRedisRateLimit(
+    key: string,
+    config: RateLimitTier,
+    now: number
+  ): Promise<RateLimitResult> {
+    try {
+      const redis = this.redis!;
+      
+      const results = await redis
+        .multi()
+        .zremrangebyscore(key, '-inf', now - config.windowMs)
+        .zcard(key)
+        .zadd(key, now, `${now}-${Math.random()}`)
+        .pttl(key)
+        .exec();
+
+      if (!results) {
+        return this.checkMemoryRateLimit(key, config, now);
+      }
+
+      const currentCount = results[1]?.[1] as number || 0;
+      const ttl = results[3]?.[1] as number || config.windowMs;
+
+      if (ttl < 0) {
+        await redis.pexpire(key, config.windowMs);
+      }
+
+      const limit = config.maxRequests;
+      const remaining = Math.max(0, limit - currentCount - 1);
+      const resetAt = new Date(now + (ttl > 0 ? ttl : config.windowMs));
+
+      if (currentCount >= limit) {
+        const retryAfter = Math.ceil((ttl > 0 ? ttl : config.windowMs) / 1000);
+        
+        return {
+          allowed: false,
+          limit,
+          remaining: 0,
+          resetAt,
+          retryAfter,
+        };
+      }
+
+      return {
+        allowed: true,
+        limit,
+        remaining,
+        resetAt,
+      };
+    } catch (error) {
+      logger.error('Redis rate limit error, falling back to memory', { error });
+      return this.checkMemoryRateLimit(key, config, now);
+    }
+  }
+
+  private checkMemoryRateLimit(
+    key: string,
+    config: RateLimitTier,
+    now: number
+  ): RateLimitResult {
+    const entry = this.memoryStore.get(key);
+    const resetAt = now + config.windowMs;
+
+    if (!entry || entry.resetAt < now) {
+      this.memoryStore.set(key, { count: 1, resetAt });
+      return {
+        allowed: true,
+        limit: config.maxRequests,
+        remaining: config.maxRequests - 1,
+        resetAt: new Date(resetAt),
+      };
+    }
+
+    if (entry.count >= config.maxRequests) {
+      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+      return {
+        allowed: false,
+        limit: config.maxRequests,
+        remaining: 0,
+        resetAt: new Date(entry.resetAt),
+        retryAfter,
+      };
+    }
+
+    entry.count++;
+    this.memoryStore.set(key, entry);
+
+    return {
+      allowed: true,
+      limit: config.maxRequests,
+      remaining: config.maxRequests - entry.count,
+      resetAt: new Date(entry.resetAt),
+    };
+  }
+
+  private cleanupMemoryStore(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.memoryStore.entries()) {
+      if (entry.resetAt < now) {
+        this.memoryStore.delete(key);
+      }
+    }
+  }
+
+  async resetRateLimit(identifier: string, tier: RateLimitTierName = 'api'): Promise<void> {
+    const key = `ratelimit:${tier}:${identifier}`;
+
+    if (this.redis && !this.useMemoryFallback) {
+      await this.redis.del(key);
+    } else {
+      this.memoryStore.delete(key);
+    }
+  }
+
+  getTierConfig(tier: RateLimitTierName): RateLimitTier {
+    return RATE_LIMIT_TIERS[tier];
+  }
+}
+
+export const rateLimitService = new RateLimitService();


### PR DESCRIPTION
## Summary

This PR implements Redis-backed API rate limiting to protect the API from abuse.

### Changes

- **RateLimitService**: Redis-backed sliding window rate limiting with memory fallback
- **Middleware**: Express middleware with configurable rate limit tiers
- **Headers**: All responses include rate limit headers
- **Different limits**: Stricter limits for auth routes vs data routes

### Rate Limit Tiers

| Tier | Window | Requests | Use Case |
|------|--------|----------|----------|
| `auth` | 15 min | 10 | Login, registration |
| `api` | 1 min | 100 | General API operations |
| `data` | 1 min | 200 | Data retrieval |
| `strict` | 1 min | 20 | Sensitive operations |

### Response Headers

All responses include:
- `X-RateLimit-Limit` - Maximum requests allowed
- `X-RateLimit-Remaining` - Requests remaining
- `X-RateLimit-Reset` - Unix timestamp when limit resets

When exceeded:
- `Retry-After` - Seconds until retry

### Routes Applied

```typescript
router.use('/auth', authRateLimit(), authRoutes);        // 10 req/15min
router.use('/search', dataRateLimit(), searchRoutes);     // 200 req/min
router.use('/employees', dataRateLimit(), employeeRoutes);// 200 req/min
router.use('/payments', apiRateLimit(), paymentRoutes);   // 100 req/min
router.use('/rate-limit', apiRateLimit(), rateLimitRoutes);
```

### Acceptance Criteria

- [x] Redis-backed rate limiter integrated
- [x] 429 Too Many Requests status returned when limits exceeded
- [x] Rate limit headers included in API responses

Closes #58