### PR TITLE
feat: dockerize backend service with docker compose

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+dist
+.env
+coverage
+.git
+*.md

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+
+RUN npm run build
+
+FROM node:20-alpine AS production
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm ci --only=production
+
+COPY --from=builder /usr/src/app/dist ./dist
+
+EXPOSE 3001
+
+CMD ["node", "dist/index.js"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3001"
+    environment:
+      - PORT=3001
+      - NODE_ENV=development
+      - DATABASE_URL=postgresql://${DB_USER:-payd_user}:${DB_PASSWORD:-payd_password}@postgres:5432/${DB_NAME:-payd_db}
+      - REDIS_URL=redis://redis:6379
+      - DB_HOST=postgres
+      - DB_PORT=5432
+      - DB_USER=${DB_USER:-payd_user}
+      - DB_PASSWORD=${DB_PASSWORD:-payd_password}
+      - DB_NAME=${DB_NAME:-payd_db}
+      - STELLAR_NETWORK_PASSPHRASE=${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network \; September 2015}
+      - STELLAR_HORIZON_URL=${STELLAR_HORIZON_URL:-https://horizon-testnet.stellar.org}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - payd_network
+
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      - POSTGRES_USER=${DB_USER:-payd_user}
+      - POSTGRES_PASSWORD=${DB_PASSWORD:-payd_password}
+      - POSTGRES_DB=${DB_NAME:-payd_db}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-payd_user} -d ${DB_NAME:-payd_db}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - payd_network
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - payd_network
+
+volumes:
+  postgres_data:
+  redis_data:
+
+networks:
+  payd_network:
+    driver: bridge


### PR DESCRIPTION
## Description
This PR addresses the requirement to Dockerize the backend service with Docker Compose.

### Changes Made
- Created an optimized multi-stage `Dockerfile` for the Node.js API (builder and production stages to reduce image size).
- Added a `.dockerignore` file to prevent unnecessary files from inflating the build context.
- Created `docker-compose.yml` defining three services:
  - **api**: Runs the Node API and injects environment variables for DB and Redis connections.
  - **postgres**: Uses official PostgreSQL image with a persistent volume and a `pg_isready` healthcheck.
  - **redis**: Uses official Redis image with a persistent volume and a `redis-cli ping` healthcheck.

Closes #24