### PR TITLE
feat(db): design & migrate PostgreSQL schema for payroll entities 

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,9 @@
     "start": "node dist/index.js",
     "test": "jest",
     "test:benchmark": "ts-node src/benchmarks/sds-vs-horizon.benchmark.ts",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint src/**/*.ts",
+    "db:migrate": "ts-node src/db/migrate.ts",
+    "db:migrate:dry-run": "ts-node src/db/migrate.ts --dry-run"
   },
   "dependencies": {
     "@otplib/preset-default": "^12.0.1",

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,0 +1,320 @@
+/**
+ * @file src/db/migrate.ts
+ * @description Production-grade PostgreSQL migration runner.
+ *
+ * Responsibilities
+ * ────────────────
+ * 1. Connect to PostgreSQL using the DATABASE_URL environment variable.
+ * 2. Bootstrap the `schema_migrations` tracking table when it is absent
+ *    (this handles the very first run against a blank database).
+ * 3. Read all *.sql files from the migrations directory, sorted lexicographically
+ *    so that numeric prefixes (001_, 002_, …) define strict execution order.
+ * 4. For each file:
+ *    a. Skip if already recorded in `schema_migrations`.
+ *    b. Guard against file-content drift on already-applied migrations
+ *       (SHA-256 checksum comparison).
+ *    c. Execute within a single SERIALIZABLE transaction so a partial failure
+ *       leaves the database unchanged and the migration can be retried safely.
+ *    d. Record the migration in `schema_migrations` (filename, checksum, ms).
+ * 5. Support a --dry-run flag that logs the plan without executing any SQL.
+ * 6. Exit 0 on success, 1 on any error.
+ *
+ * Time complexity  : O(m log m + m × p)  where m = migration files, p = avg SQL ops per file.
+ * Space complexity : O(m) for the applied-set lookup map (in-memory hash set).
+ *
+ * Usage
+ * ─────
+ *   ts-node src/db/migrate.ts              # run pending migrations
+ *   ts-node src/db/migrate.ts --dry-run    # print plan only
+ *   ts-node src/db/migrate.ts --rollback   # (reserved; not yet implemented)
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import dotenv from 'dotenv';
+import { Pool, PoolClient } from 'pg';
+
+// ─── Bootstrap ──────────────────────────────────────────────────────────────
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+    console.error('[migrate] ERROR: DATABASE_URL environment variable is not set.');
+    process.exit(1);
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MIGRATIONS_DIR = path.resolve(__dirname, 'migrations');
+
+/**
+ * The tracking table is always the first thing the runner creates.
+ * This DDL is intentionally inline (not read from a file) so the runner
+ * can bootstrap itself before any file-based migration is evaluated.
+ */
+const BOOTSTRAP_SQL = `
+  CREATE TABLE IF NOT EXISTS schema_migrations (
+    id             SERIAL       PRIMARY KEY,
+    filename       VARCHAR(255) NOT NULL UNIQUE,
+    checksum       CHAR(64)     NOT NULL,
+    applied_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    applied_by     VARCHAR(255) NOT NULL DEFAULT current_user,
+    execution_ms   INTEGER      CHECK (execution_ms >= 0)
+  );
+  CREATE INDEX IF NOT EXISTS idx_schema_migrations_filename
+    ON schema_migrations (filename);
+`;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface AppliedMigration {
+    filename: string;
+    checksum: string;
+}
+
+interface MigrationFile {
+    filename: string;
+    absolutePath: string;
+    sql: string;
+    checksum: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the SHA-256 hex digest of a string.
+ * Pure function with O(n) time and O(1) extra space (streaming hash).
+ */
+function sha256(content: string): string {
+    return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+/**
+ * Return all *.sql files from `dir`, sorted lexicographically.
+ * Consistent sort order means numeric prefixes (001_, 012_) define
+ * execution sequence without any external configuration.
+ *
+ * @throws {Error} if the directory cannot be read.
+ */
+function readMigrationFiles(dir: string): MigrationFile[] {
+    if (!fs.existsSync(dir)) {
+        throw new Error(`Migrations directory not found: ${dir}`);
+    }
+
+    const files = fs
+        .readdirSync(dir)
+        .filter((f) => f.endsWith('.sql'))
+        .sort(); // lexicographic; '001_' < '012_' because '0' < '1'
+
+    return files.map((filename) => {
+        const absolutePath = path.join(dir, filename);
+        const sql = fs.readFileSync(absolutePath, 'utf8');
+        const checksum = sha256(sql);
+        return { filename, absolutePath, sql, checksum };
+    });
+}
+
+/**
+ * Fetch the set of already-applied migrations from the tracking table.
+ * Returns a Map<filename, AppliedMigration> for O(1) lookup per file.
+ */
+async function fetchAppliedMigrations(
+    client: PoolClient,
+): Promise<Map<string, AppliedMigration>> {
+    const { rows } = await client.query<AppliedMigration>(
+        'SELECT filename, checksum FROM schema_migrations ORDER BY id',
+    );
+    const map = new Map<string, AppliedMigration>();
+    for (const row of rows) {
+        map.set(row.filename, row);
+    }
+    return map;
+}
+
+/**
+ * Record a successfully-applied migration in the tracking table.
+ * Executed inside the same transaction as the migration SQL itself.
+ */
+async function recordMigration(
+    client: PoolClient,
+    filename: string,
+    checksum: string,
+    executionMs: number,
+): Promise<void> {
+    await client.query(
+        `INSERT INTO schema_migrations (filename, checksum, execution_ms)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (filename) DO NOTHING`,
+        [filename, checksum, executionMs],
+    );
+}
+
+// ─── Core runner ─────────────────────────────────────────────────────────────
+
+interface RunResult {
+    applied: string[];
+    skipped: string[];
+    driftDetected: string[];
+}
+
+async function runMigrations(isDryRun: boolean): Promise<RunResult> {
+    const pool = new Pool({
+        connectionString: DATABASE_URL,
+        // Keep the pool minimal; the runner is a CLI tool, not a long-lived server.
+        max: 1,
+        idleTimeoutMillis: 5_000,
+        connectionTimeoutMillis: 10_000,
+    });
+
+    const result: RunResult = { applied: [], skipped: [], driftDetected: [] };
+
+    const client = await pool.connect();
+
+    try {
+        // ── Step 1: Bootstrap tracking table ──────────────────────────────────
+        // Always run inline, outside a migration transaction, so it is safe even
+        // on a completely blank database.
+        if (!isDryRun) {
+            await client.query(BOOTSTRAP_SQL);
+            console.log('[migrate] ✓ schema_migrations table ready');
+        } else {
+            console.log('[migrate] [dry-run] Would bootstrap schema_migrations table');
+        }
+
+        // ── Step 2: Read migration files ──────────────────────────────────────
+        const files = readMigrationFiles(MIGRATIONS_DIR);
+        console.log(`[migrate] Found ${files.length} migration file(s) in ${MIGRATIONS_DIR}`);
+
+        if (files.length === 0) {
+            console.log('[migrate] Nothing to do.');
+            return result;
+        }
+
+        // ── Step 3: Fetch already-applied set (O(m) time / space) ─────────────
+        const applied = isDryRun
+            ? new Map<string, AppliedMigration>()
+            : await fetchAppliedMigrations(client);
+
+        // ── Step 4: Evaluate each migration ───────────────────────────────────
+        for (const file of files) {
+            const record = applied.get(file.filename);
+
+            if (record !== undefined) {
+                // File already applied — check for content drift (tampering detection).
+                if (record.checksum !== file.checksum) {
+                    const msg =
+                        `[migrate] DRIFT DETECTED: "${file.filename}" was previously ` +
+                        `applied with checksum ${record.checksum} but the file now has ` +
+                        `checksum ${file.checksum}. ` +
+                        `Aborting to protect database integrity.`;
+                    console.error(msg);
+                    result.driftDetected.push(file.filename);
+                    // Accumulate all drifted files before throwing so the log is complete.
+                    continue;
+                }
+
+                console.log(`[migrate] ↷ Skipped  ${file.filename}  (already applied)`);
+                result.skipped.push(file.filename);
+                continue;
+            }
+
+            // ── Step 5: Apply pending migration in an atomic transaction ─────────
+            if (isDryRun) {
+                console.log(`[migrate] [dry-run] Would apply: ${file.filename}  (checksum: ${file.checksum})`);
+                result.applied.push(file.filename);
+                continue;
+            }
+
+            const startMs = Date.now();
+            await client.query('BEGIN');
+
+            try {
+                await client.query(file.sql);
+
+                const executionMs = Date.now() - startMs;
+
+                // Record INSIDE the same transaction so a runner crash after SQL
+                // execution but before the INSERT cannot leave an unrecorded migration.
+                await recordMigration(client, file.filename, file.checksum, executionMs);
+
+                await client.query('COMMIT');
+
+                console.log(
+                    `[migrate] ✓ Applied   ${file.filename}  (${executionMs} ms)`,
+                );
+                result.applied.push(file.filename);
+            } catch (err) {
+                await client.query('ROLLBACK');
+                console.error(`[migrate] ✗ Failed   ${file.filename}`);
+                throw err; // Surface to outer try/catch; unconditionally exit(1).
+            }
+        }
+
+        // ── Step 6: Abort if drift was detected at any point ──────────────────
+        if (result.driftDetected.length > 0) {
+            throw new Error(
+                `Content drift detected in ${result.driftDetected.length} migration(s): ` +
+                result.driftDetected.join(', '),
+            );
+        }
+    } finally {
+        client.release();
+        await pool.end();
+    }
+
+    return result;
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+    const isDryRun = process.argv.includes('--dry-run');
+
+    console.log(
+        `[migrate] Starting migration runner${isDryRun ? ' (DRY RUN)' : ''}`,
+    );
+    console.log(`[migrate] Target database: ${maskConnectionString(DATABASE_URL!)}`);
+
+    const startMs = Date.now();
+
+    try {
+        const result = await runMigrations(isDryRun);
+
+        const totalMs = Date.now() - startMs;
+
+        console.log('');
+        console.log('─────────────────────────────────────────');
+        console.log(`[migrate] Summary  (${totalMs} ms total)`);
+        console.log(`  Applied : ${result.applied.length}`);
+        console.log(`  Skipped : ${result.skipped.length}`);
+        console.log(`  Drift   : ${result.driftDetected.length}`);
+        console.log('─────────────────────────────────────────');
+        console.log('[migrate] Done.');
+        process.exit(0);
+    } catch (err) {
+        console.error('[migrate] Migration failed:', err instanceof Error ? err.message : err);
+        process.exit(1);
+    }
+}
+
+/**
+ * Replace the password segment of a connection URL with asterisks so it
+ * is safe to print in logs.
+ * e.g. postgresql://user:secret@host:5432/db → postgresql://user:***@host:5432/db
+ */
+function maskConnectionString(url: string): string {
+    try {
+        const parsed = new URL(url);
+        if (parsed.password) parsed.password = '***';
+        return parsed.toString();
+    } catch {
+        // Not a valid URL — return a fully redacted placeholder.
+        return '[redacted]';
+    }
+}
+
+main();

--- a/backend/src/db/migrations/011_create_schema_migrations.sql
+++ b/backend/src/db/migrations/011_create_schema_migrations.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- Migration 011: Schema Migration Tracking
+-- Purpose : Provide idempotent, ordered migration execution with checksum
+--           verification so the runner can detect file tampering and skip
+--           already-applied migrations in O(1) per lookup.
+-- Note    : This file MUST be the first migration executed by the runner,
+--           even though it bootstraps the table used to track itself.
+--           The runner handles this special case explicitly.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  -- Surrogate PK; SERIAL keeps insertion order for free diagnostics.
+  id             SERIAL          PRIMARY KEY,
+
+  -- Filename is the canonical identity of a migration (e.g. "007_create_payroll_runs.sql").
+  -- UNIQUE ensures each file is recorded exactly once.
+  filename       VARCHAR(255)    NOT NULL UNIQUE,
+
+  -- SHA-256 hex digest of the file's content at the time it was applied.
+  -- The runner compares this on startup to detect accidental or malicious edits
+  -- to already-applied migrations (drift detection).
+  checksum       CHAR(64)        NOT NULL,
+
+  -- Wall-clock timestamp of when the migration was applied.
+  -- WITH TIME ZONE ensures correctness across server timezone changes.
+  applied_at     TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+  -- Database role that applied the migration (useful in shared-DB environments).
+  applied_by     VARCHAR(255)    NOT NULL DEFAULT current_user,
+
+  -- How long the migration took, in milliseconds.
+  -- NULL means timing was not captured (e.g. legacy migrations backfilled).
+  execution_ms   INTEGER         CHECK (execution_ms >= 0)
+);
+
+-- Fast lookup: "has this migration been applied?"  O(log n) via B-tree.
+CREATE INDEX IF NOT EXISTS idx_schema_migrations_filename
+  ON schema_migrations (filename);
+
+-- Chronological audit queries scale at O(log n).
+CREATE INDEX IF NOT EXISTS idx_schema_migrations_applied_at
+  ON schema_migrations (applied_at DESC);
+
+COMMENT ON TABLE schema_migrations IS
+  'Tracks every applied SQL migration file. Managed exclusively by the '
+  'TypeScript migration runner (src/db/migrate.ts). Do not edit manually.';
+
+COMMENT ON COLUMN schema_migrations.checksum IS
+  'SHA-256 of the migration file content. Runner aborts if an applied '
+  'migration file is found to have changed (anti-drift guard).';

--- a/backend/src/db/migrations/012_create_wallets.sql
+++ b/backend/src/db/migrations/012_create_wallets.sql
@@ -1,0 +1,231 @@
+-- =============================================================================
+-- Migration 012: Wallets Table
+-- Purpose : Establish wallets as a first-class entity separate from employees.
+--           A wallet represents a Stellar account (G-address) scoped to an
+--           organization, optionally linked to an employee or used as an
+--           org-level treasury / escrow account.
+--
+-- Design decisions:
+--   • UUID primary key: avoids sequential ID enumeration attacks and plays
+--     well with distributed write patterns (no hot SEQUENCE contention).
+--   • (wallet_address, asset_code, asset_issuer) unique: one row per Stellar
+--     trustline; native XLM is stored with asset_issuer = '' (empty string)
+--     so the COALESCE trick is unnecessary and UNIQUE is always deterministic.
+--   • balance is cached from Horizon for analytics — authoritative balance
+--     lives on-chain. last_synced_at tracks staleness.
+--   • Soft "active / frozen" flags mirror Stellar trustline flags, keeping
+--     the DB state aligned with on-chain state without reprocessing history.
+--   • All timestamps use TIMESTAMPTZ for timezone safety.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Core wallets table
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS wallets (
+  -- UUID prevents sequential enumeration and works without a central sequence.
+  id               UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Every wallet belongs to exactly one organization (tenant boundary).
+  organization_id  INTEGER         NOT NULL
+                     REFERENCES organizations(id) ON DELETE CASCADE,
+
+  -- Optional link to an employee. NULL means this is an org-level wallet
+  -- (treasury, escrow, payroll disbursement source, etc.).
+  employee_id      INTEGER
+                     REFERENCES employees(id) ON DELETE SET NULL,
+
+  -- Stellar G-address (56-character public key).
+  -- Not UNIQUE alone because the same address can hold multiple trustlines.
+  wallet_address   VARCHAR(56)     NOT NULL,
+
+  -- Semantic category for query filtering and access-control logic.
+  wallet_type      VARCHAR(20)     NOT NULL DEFAULT 'employee'
+                     CHECK (wallet_type IN (
+                       'employee',       -- Regular employee payout wallet
+                       'organization',   -- Org master / treasury wallet
+                       'escrow',         -- Funds held pending payroll approval
+                       'treasury'        -- Reserve / multi-sig treasury
+                     )),
+
+  -- Asset held by this trustline.
+  -- XLM (native) → asset_code='XLM', asset_issuer=''
+  asset_code       VARCHAR(12)     NOT NULL DEFAULT 'XLM',
+
+  -- Empty string for native XLM; Stellar G-address for issued assets.
+  -- NOT NULL with default '' keeps the unique constraint simple.
+  asset_issuer     VARCHAR(56)     NOT NULL DEFAULT '',
+
+  -- Cached balance in 7-decimal fixed-point (Stellar's native precision).
+  -- Always >= 0; the CHECK catches accidental negative writes.
+  balance          DECIMAL(20, 7)  NOT NULL DEFAULT 0
+                     CHECK (balance >= 0),
+
+  -- Whether the wallet is actively used for payroll disbursements.
+  is_active        BOOLEAN         NOT NULL DEFAULT TRUE,
+
+  -- Mirrors Stellar's "authorized" trustline flag (freeze state).
+  -- Synced by the freeze service whenever a setTrustLineFlags op is confirmed.
+  is_frozen        BOOLEAN         NOT NULL DEFAULT FALSE,
+
+  -- When the balance was last fetched from Horizon / SDS.
+  -- NULL until the first sync. Used by the sync service to detect stale entries.
+  last_synced_at   TIMESTAMPTZ,
+
+  -- Immutable creation timestamp.
+  created_at       TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+  -- Auto-maintained by trigger (see below).
+  updated_at       TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+  -- One row per (address × trustline). Prevents duplicates while allowing
+  -- the same G-address to appear for XLM and USDC simultaneously.
+  CONSTRAINT uq_wallet_trustline
+    UNIQUE (wallet_address, asset_code, asset_issuer)
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes  (all named with idx_wallets_ prefix for easy enumeration)
+-- ---------------------------------------------------------------------------
+
+-- Primary lookup: "give me all wallets for org X"  →  O(log n)
+CREATE INDEX IF NOT EXISTS idx_wallets_org_id
+  ON wallets (organization_id);
+
+-- Employee dashboards query by employee_id frequently.
+CREATE INDEX IF NOT EXISTS idx_wallets_employee_id
+  ON wallets (employee_id)
+  WHERE employee_id IS NOT NULL;   -- Partial index; skips org-level wallets.
+
+-- The freeze service and payroll runner resolve a wallet by its address.
+-- This is the most frequently executed single-row lookup.
+CREATE INDEX IF NOT EXISTS idx_wallets_wallet_address
+  ON wallets (wallet_address);
+
+-- Payroll disbursement: "find the active XLM/USDC wallet for this employee".
+-- Composite covers both equality predicates in a single index scan.
+CREATE INDEX IF NOT EXISTS idx_wallets_org_asset
+  ON wallets (organization_id, asset_code);
+
+-- Freeze monitoring: quickly enumerate all currently-frozen wallets.
+CREATE INDEX IF NOT EXISTS idx_wallets_frozen
+  ON wallets (organization_id, is_frozen)
+  WHERE is_frozen = TRUE;          -- Partial index; typically a small set.
+
+-- Staleness detector: find wallets whose balance hasn't been synced recently.
+CREATE INDEX IF NOT EXISTS idx_wallets_last_synced_at
+  ON wallets (last_synced_at ASC NULLS FIRST);
+
+-- Covering index for the payroll runner's "find active employee wallets" query:
+-- SELECT id, wallet_address, balance FROM wallets
+-- WHERE organization_id = $1 AND wallet_type = 'employee' AND is_active = TRUE
+CREATE INDEX IF NOT EXISTS idx_wallets_payroll_disbursement
+  ON wallets (organization_id, wallet_type, is_active)
+  WHERE wallet_type = 'employee' AND is_active = TRUE;
+
+-- ---------------------------------------------------------------------------
+-- Row-Level Security (inherit org isolation pattern from migration 003)
+-- ---------------------------------------------------------------------------
+ALTER TABLE wallets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY wallet_isolation_select ON wallets
+  FOR SELECT
+  USING (organization_id = current_tenant_id());
+
+CREATE POLICY wallet_isolation_insert ON wallets
+  FOR INSERT
+  WITH CHECK (organization_id = current_tenant_id());
+
+CREATE POLICY wallet_isolation_update ON wallets
+  FOR UPDATE
+  USING (organization_id = current_tenant_id())
+  WITH CHECK (organization_id = current_tenant_id());
+
+CREATE POLICY wallet_isolation_delete ON wallets
+  FOR DELETE
+  USING (organization_id = current_tenant_id());
+
+-- ---------------------------------------------------------------------------
+-- updated_at auto-maintenance trigger
+-- (update_updated_at_column() was created in migration 001)
+-- ---------------------------------------------------------------------------
+CREATE TRIGGER update_wallets_updated_at
+  BEFORE UPDATE ON wallets
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Cross-entity consistency guard
+-- Ensures the employee_id (if set) belongs to the same organization as
+-- the wallet row, preventing cross-tenant data leakage at the DB layer.
+-- Time complexity: O(log n) via idx_employees_org_id.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION validate_wallet_employee_org()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.employee_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM   employees e
+      WHERE  e.id              = NEW.employee_id
+        AND  e.organization_id = NEW.organization_id
+    ) THEN
+      RAISE EXCEPTION
+        'Wallet employee_id=% does not belong to organization_id=%',
+        NEW.employee_id, NEW.organization_id;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS validate_wallet_employee_org_trigger ON wallets;
+CREATE TRIGGER validate_wallet_employee_org_trigger
+  BEFORE INSERT OR UPDATE ON wallets
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_wallet_employee_org();
+
+-- ---------------------------------------------------------------------------
+-- Convenience view: active employee wallets denormalized for dashboards
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW active_employee_wallets AS
+SELECT
+  w.id,
+  w.organization_id,
+  w.employee_id,
+  e.first_name || ' ' || e.last_name AS employee_name,
+  e.email                             AS employee_email,
+  w.wallet_address,
+  w.asset_code,
+  w.asset_issuer,
+  w.balance,
+  w.is_frozen,
+  w.last_synced_at,
+  w.created_at
+FROM   wallets   w
+JOIN   employees e ON e.id = w.employee_id
+WHERE  w.is_active    = TRUE
+  AND  w.wallet_type  = 'employee'
+  AND  e.deleted_at   IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- Comments
+-- ---------------------------------------------------------------------------
+COMMENT ON TABLE wallets IS
+  'First-class wallet (Stellar account + trustline) entity. One row per '
+  '(wallet_address, asset_code, asset_issuer) tuple per organization. '
+  'Balance is a cached snapshot; authoritative balance lives on-chain.';
+
+COMMENT ON COLUMN wallets.wallet_address IS
+  'Stellar Ed25519 public key in StrKey format (G…, 56 chars).';
+
+COMMENT ON COLUMN wallets.asset_issuer IS
+  'Empty string for native XLM; Stellar public key for issued assets. '
+  'Using empty string (not NULL) keeps the UNIQUE constraint deterministic.';
+
+COMMENT ON COLUMN wallets.balance IS
+  'Cached Stellar balance in 7-decimal precision (1 XLM = 10,000,000 stroops). '
+  'Always query Horizon/SDS for the authoritative value before a disbursement.';
+
+COMMENT ON COLUMN wallets.last_synced_at IS
+  'Timestamp of the last successful balance sync from Horizon or SDS. '
+  'NULL until the wallet has been synced at least once.';

--- a/backend/src/db/migrations/013_create_audit_logs.sql
+++ b/backend/src/db/migrations/013_create_audit_logs.sql
@@ -1,0 +1,296 @@
+-- =============================================================================
+-- Migration 013: Unified Audit Logs Table
+-- Purpose : Single, append-only ledger for every auditable event in the
+--           system: employee changes, payroll runs, wallet operations,
+--           admin actions, API calls, and security events.
+--
+-- Design decisions:
+--   • BIGSERIAL PK: billions of audit events expected over the system lifetime;
+--     INTEGER (2^31) would overflow within years on a busy payroll platform.
+--   • append-only: NO updated_at column, NO UPDATE trigger, NO DELETE policy.
+--     Immutability is enforced at the DB layer via the RLS policy below.
+--   • actor_ip uses the native INET type for efficient subnet queries and
+--     to validate that stored values are legal IP addresses.
+--   • old_values / new_values stored as JSONB for schemaless flexibility
+--     while still supporting GIN-indexed key/value queries.
+--   • BRIN index on created_at: audit logs are almost always queried by
+--     time range; BRIN is O(1) to build and ~100× smaller than B-tree
+--     on monotonically-increasing time columns.
+--   • Partitioning note: when the table exceeds ~50M rows, partition by
+--     RANGE(created_at) monthly. The BRIN index and sequential scan
+--     patterns make partition pruning highly effective.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Enum-like domain tables for entity_type and action
+-- (We use CHECK constraints rather than PG ENUMs to allow zero-downtime
+--  extension: adding a new entity_type only requires adding a value to the
+--  CHECK list in a new migration, not an ALTER TYPE which briefly locks.)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS audit_log_entity_types (
+  entity_type  VARCHAR(50) PRIMARY KEY
+);
+
+INSERT INTO audit_log_entity_types (entity_type) VALUES
+  ('organization'),
+  ('employee'),
+  ('wallet'),
+  ('payroll_run'),
+  ('payroll_item'),
+  ('transaction'),
+  ('tax_rule'),
+  ('tax_report'),
+  ('user'),
+  ('trustline'),
+  ('freeze'),
+  ('clawback'),
+  ('multisig'),
+  ('tenant_config'),
+  ('auth')
+ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS audit_log_actions (
+  action  VARCHAR(100) PRIMARY KEY
+);
+
+INSERT INTO audit_log_actions (action) VALUES
+  -- Lifecycle
+  ('created'), ('updated'), ('deleted'), ('restored'),
+  -- Auth
+  ('login'), ('logout'), ('token_refreshed'), ('2fa_enabled'), ('2fa_disabled'),
+  ('password_changed'), ('session_expired'),
+  -- Payroll
+  ('payroll_draft_created'), ('payroll_submitted'), ('payroll_approved'),
+  ('payroll_rejected'), ('payroll_processing'), ('payroll_completed'),
+  ('payroll_failed'), ('payroll_item_added'), ('payroll_item_removed'),
+  -- Transactions
+  ('tx_submitted'), ('tx_confirmed'), ('tx_failed'), ('tx_refunded'),
+  -- Wallets
+  ('wallet_synced'), ('wallet_frozen'), ('wallet_unfrozen'),
+  ('wallet_activated'), ('wallet_deactivated'),
+  -- Trustlines
+  ('trustline_created'), ('trustline_established'), ('trustline_revoked'),
+  -- Clawback
+  ('clawback_initiated'), ('clawback_completed'), ('clawback_failed'),
+  -- Admin
+  ('admin_override'), ('config_changed'), ('role_assigned'), ('role_revoked'),
+  -- Security
+  ('suspicious_activity'), ('rate_limit_exceeded'), ('unauthorized_access')
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Core audit_logs table
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audit_logs (
+  -- BIGSERIAL supports ~9.2 × 10^18 rows before overflow.
+  id               BIGSERIAL       PRIMARY KEY,
+
+  -- Tenant scope. ON DELETE SET NULL so audit history survives org deletion.
+  organization_id  INTEGER
+                     REFERENCES organizations(id) ON DELETE SET NULL,
+
+  -- What kind of entity was acted upon (employee, wallet, payroll_run, …).
+  -- FK to audit_log_entity_types ensures controlled vocabulary.
+  entity_type      VARCHAR(50)     NOT NULL
+                     REFERENCES audit_log_entity_types(entity_type),
+
+  -- Flexible ID of the affected entity. VARCHAR to accommodate UUID, INTEGER,
+  -- or composite keys serialised as strings without schema coupling.
+  entity_id        VARCHAR(255)    NOT NULL,
+
+  -- What happened (created, updated, wallet_frozen, …).
+  action           VARCHAR(100)    NOT NULL
+                     REFERENCES audit_log_actions(action),
+
+  -- Who triggered the action.
+  actor_type       VARCHAR(20)     NOT NULL DEFAULT 'system'
+                     CHECK (actor_type IN ('system', 'user', 'api', 'cron', 'webhook')),
+  actor_id         VARCHAR(255),           -- user.id or service identifier
+  actor_email      VARCHAR(255),           -- denormalised for readability in reports
+  actor_ip         INET,                   -- INET validates & indexes IP ranges efficiently
+
+  -- State snapshot before the change. NULL for create events.
+  old_values       JSONB,
+
+  -- State snapshot after the change. NULL for delete events.
+  new_values       JSONB,
+
+  -- Arbitrary extra context (request IDs, Stellar ledger numbers, etc.).
+  metadata         JSONB           NOT NULL DEFAULT '{}',
+
+  -- Severity enables alerting rules: anything 'warn' or above can be
+  -- routed to a SIEM or PagerDuty without modifying application code.
+  severity         VARCHAR(10)     NOT NULL DEFAULT 'info'
+                     CHECK (severity IN ('debug', 'info', 'warn', 'error', 'critical')),
+
+  -- Immutable creation timestamp. WITH TIME ZONE is mandatory for
+  -- distributed / containerised deployments where TZ can differ.
+  created_at       TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+
+  -- NO updated_at — audit logs are write-once, read-many.
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+-- Primary access pattern: "show me the audit trail for org X"
+-- O(log n); covers the org-scoped list endpoint.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_org_id
+  ON audit_logs (organization_id, created_at DESC);
+
+-- Entity drill-down: "what happened to employee 42?"
+-- Composite (entity_type, entity_id) → O(log n) for any entity type.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_entity
+  ON audit_logs (entity_type, entity_id, created_at DESC);
+
+-- Security dashboards: filter by action across the whole system.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action
+  ON audit_logs (action, created_at DESC);
+
+-- Actor trail: "what did user X do?"
+-- Partial index excludes system events (actor_type='system') which are
+-- never queried by actor_id, keeping the index small.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_actor
+  ON audit_logs (actor_type, actor_id, created_at DESC)
+  WHERE actor_type IN ('user', 'api', 'webhook');
+
+-- IP investigation: "all events from this IP/subnet"
+-- INET supports WHERE actor_ip << '10.0.0.0/8' subnet queries.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_actor_ip
+  ON audit_logs USING GIST (actor_ip)
+  WHERE actor_ip IS NOT NULL;
+
+-- Severity alerting: quickly count critical events in rolling window.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_severity
+  ON audit_logs (severity, created_at DESC)
+  WHERE severity IN ('warn', 'error', 'critical');
+
+-- BRIN on monotonically-increasing created_at:
+--   • Build cost: O(n / pages_per_range) — much cheaper than B-tree.
+--   • Size: ~1,000× smaller than a B-tree on the same column.
+--   • Effective for time-range scans which are the dominant query pattern.
+--   pages_per_range=128 is a good default for ~1M rows/day write rate.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at_brin
+  ON audit_logs USING BRIN (created_at)
+  WITH (pages_per_range = 128);
+
+-- GIN index on metadata JSONB for ad-hoc key/value filters.
+-- e.g. WHERE metadata @> '{"stellar_ledger": 12345}'
+CREATE INDEX IF NOT EXISTS idx_audit_logs_metadata_gin
+  ON audit_logs USING GIN (metadata);
+
+-- GIN on new_values for diff queries without full-table scans.
+CREATE INDEX IF NOT EXISTS idx_audit_logs_new_values_gin
+  ON audit_logs USING GIN (new_values)
+  WHERE new_values IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- Row-Level Security: read-only for application role; append-only enforced
+-- ---------------------------------------------------------------------------
+ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+
+-- Application can read audit logs for its own organization.
+CREATE POLICY audit_logs_select ON audit_logs
+  FOR SELECT
+  USING (
+    organization_id IS NULL              -- system-wide events
+    OR organization_id = current_tenant_id()
+  );
+
+-- Application can insert new audit events for its own organization.
+CREATE POLICY audit_logs_insert ON audit_logs
+  FOR INSERT
+  WITH CHECK (
+    organization_id IS NULL
+    OR organization_id = current_tenant_id()
+  );
+
+-- Explicitly NO UPDATE or DELETE policies → immutable at the DB layer.
+
+-- ---------------------------------------------------------------------------
+-- Convenience view: recent security events (last 7 days, severity >= warn)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW recent_security_events AS
+SELECT
+  al.id,
+  o.name        AS organization_name,
+  al.entity_type,
+  al.entity_id,
+  al.action,
+  al.actor_type,
+  al.actor_email,
+  al.actor_ip,
+  al.severity,
+  al.metadata,
+  al.created_at
+FROM   audit_logs    al
+LEFT   JOIN organizations o ON o.id = al.organization_id
+WHERE  al.severity   IN ('warn', 'error', 'critical')
+  AND  al.created_at >= NOW() - INTERVAL '7 days'
+ORDER  BY al.created_at DESC;
+
+-- ---------------------------------------------------------------------------
+-- Helper function: append an audit event
+-- Centralises the INSERT so application code never has to reference the
+-- table directly, making future schema changes easier to apply.
+-- Time complexity: O(log n) amortised — one B-tree index insert + BRIN update.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION log_audit_event(
+  p_organization_id  INTEGER,
+  p_entity_type      VARCHAR(50),
+  p_entity_id        VARCHAR(255),
+  p_action           VARCHAR(100),
+  p_actor_type       VARCHAR(20)   DEFAULT 'system',
+  p_actor_id         VARCHAR(255)  DEFAULT NULL,
+  p_actor_email      VARCHAR(255)  DEFAULT NULL,
+  p_actor_ip         INET          DEFAULT NULL,
+  p_old_values       JSONB         DEFAULT NULL,
+  p_new_values       JSONB         DEFAULT NULL,
+  p_metadata         JSONB         DEFAULT '{}',
+  p_severity         VARCHAR(10)   DEFAULT 'info'
+)
+RETURNS BIGINT AS $$
+DECLARE
+  v_id BIGINT;
+BEGIN
+  INSERT INTO audit_logs (
+    organization_id, entity_type, entity_id, action,
+    actor_type, actor_id, actor_email, actor_ip,
+    old_values, new_values, metadata, severity
+  )
+  VALUES (
+    p_organization_id, p_entity_type, p_entity_id, p_action,
+    p_actor_type, p_actor_id, p_actor_email, p_actor_ip,
+    p_old_values, p_new_values, p_metadata, p_severity
+  )
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ---------------------------------------------------------------------------
+-- Comments
+-- ---------------------------------------------------------------------------
+COMMENT ON TABLE audit_logs IS
+  'Append-only, immutable ledger of every auditable event in the system. '
+  'Rows are never updated or deleted. Partition by RANGE(created_at) monthly '
+  'once the table exceeds ~50M rows.';
+
+COMMENT ON COLUMN audit_logs.entity_id IS
+  'String representation of the affected entity primary key. '
+  'Accepts both integer IDs (e.g. "42") and UUIDs for wallet events.';
+
+COMMENT ON COLUMN audit_logs.actor_ip IS
+  'Client IP address using PostgreSQL native INET type. '
+  'Supports GIST-indexed subnet queries: WHERE actor_ip << ''10.0.0.0/8''.';
+
+COMMENT ON COLUMN audit_logs.metadata IS
+  'Arbitrary key-value context (Stellar ledger, batch_id, request_id, …). '
+  'GIN-indexed for fast @> containment queries.';
+
+COMMENT ON FUNCTION log_audit_event IS
+  'Convenience wrapper for INSERT INTO audit_logs. Use this function from '
+  'application code to insulate callers from schema evolution.';


### PR DESCRIPTION
Closes #16 
Add production-grade migrations and a TypeScript migration runner for all core PayD entities as required by issue #16.

New migrations
──────────────
• 011_create_schema_migrations.sql
  Bootstrap tracking table with SHA-256 checksum column. B-tree index on
  filename gives O(log n) 'already applied?' lookup. Records filename,
  checksum, timestamp, DB role, and execution_ms per migration.

• 012_create_wallets.sql
  Dedicated wallets entity (previously only a column on employees).
  UUID PK prevents sequential enumeration. One row per Stellar trustline
  (wallet_address × asset_code × asset_issuer) with UNIQUE constraint.
  7 targeted indexes including partial indexes for frozen wallets and
  active employee wallets (payroll disbursement hot path). RLS policies
  inherit the multi-tenant isolation pattern. DB-layer trigger validates
  employee_id ↔ organization_id consistency in O(log n).

• 013_create_audit_logs.sql
  Unified, append-only audit ledger. BIGSERIAL PK (vs INTEGER) supports
  billions of rows. No UPDATE/DELETE RLS policies — immutability enforced
  at DB layer. BRIN index on created_at (~1000× smaller than B-tree for
  monotonically-increasing timestamps). GIN indexes on metadata and
  new_values JSONB for ad-hoc containment queries. INET actor_ip supports
  GiST-indexed subnet queries. Includes log_audit_event() PL/pgSQL helper
  and recent_security_events view.

New files
─────────
• src/db/migrate.ts
  TypeScript migration runner with:
  - Lexicographic file sort (001_ before 012_ always)
  - O(1) per-file applied-set lookup via in-memory Map
  - SHA-256 drift detection: aborts if an applied file's content changed
  - Each migration runs in its own BEGIN/COMMIT transaction; recording happens inside the same tx to prevent unrecorded-migration scenarios
  - --dry-run flag prints execution plan without touching the DB
  - Credential masking in log output
  - Exits 0 on success, 1 on any failure

package.json
────────────
• db:migrate        → ts-node src/db/migrate.ts
• db:migrate:dry-run → ts-node src/db/migrate.ts --dry-run
