### PR TITLE
[FEAT] Soroban: Implement cancel_stream Logic #199

### DIFF
--- a/contracts/vesting_escrow/src/lib.rs
+++ b/contracts/vesting_escrow/src/lib.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
 #[contracttype]
 #[derive(Clone)]
 pub struct VestingConfig {
+    pub funder: Address,
     pub beneficiary: Address,
     pub token: Address,
     pub start_time: u64,
@@ -51,6 +52,7 @@ impl VestingContract {
         }
 
         let config = VestingConfig {
+            funder: funder.clone(),
             beneficiary: beneficiary.clone(),
             token: token.clone(),
             start_time,
@@ -117,6 +119,41 @@ impl VestingContract {
             let client = token::Client::new(&e, &config.token);
             client.transfer(&e.current_contract_address(), &config.clawback_admin, &unvested);
         }
+    }
+
+    pub fn cancel_stream(e: Env, sender: Address) {
+        let mut config: VestingConfig = e.storage().instance().get(&DataKey::Config).expect("Not initialized");
+
+        sender.require_auth();
+        if sender != config.funder {
+            panic!("Only sender can cancel stream");
+        }
+
+        if !config.is_active {
+            panic!("Stream already inactive");
+        }
+
+        let vested = Self::calc_vested(&e, &config);
+        let claimable = vested - config.claimed_amount;
+
+        let client = token::Client::new(&e, &config.token);
+
+        // Settle recipient for final claimable amount at cancellation time.
+        if claimable > 0 {
+            config.claimed_amount += claimable;
+            client.transfer(&e.current_contract_address(), &config.beneficiary, &claimable);
+        }
+
+        // Refund all remaining deposited tokens back to the sender.
+        let remaining = config.total_amount - config.claimed_amount;
+        if remaining > 0 {
+            client.transfer(&e.current_contract_address(), &sender, &remaining);
+        }
+
+        // Freeze future vesting and mark stream inactive.
+        config.total_amount = config.claimed_amount;
+        config.is_active = false;
+        e.storage().instance().set(&DataKey::Config, &config);
     }
 
     pub fn get_vested_amount(e: Env) -> i128 {

--- a/contracts/vesting_escrow/src/test.rs
+++ b/contracts/vesting_escrow/src/test.rs
@@ -45,6 +45,7 @@ fn test_vesting_flow() {
     let config = client.get_config();
     assert_eq!(config.total_amount, amount);
     assert_eq!(config.is_active, true);
+    assert_eq!(config.funder, funder);
     
     // Check contract balance
     assert_eq!(token_client.balance(&contract_id), 10000);
@@ -111,4 +112,82 @@ fn test_vesting_flow() {
     client.claim();
     assert_eq!(token_client.balance(&beneficiary), 2000 + 3000);
     assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_cancel_stream_pays_recipient_and_refunds_sender() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let funder = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let clawback_admin = Address::generate(&e);
+    let contract_id = e.register(VestingContract, ());
+    let client = VestingContractClient::new(&e, &contract_id);
+
+    let token_admin = Address::generate(&e);
+    let token_contract = e.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_client = token::Client::new(&e, &token_contract);
+    let token_admin_client = token::StellarAssetClient::new(&e, &token_contract);
+
+    token_admin_client.mint(&funder, &10_000);
+
+    let start_time = e.ledger().timestamp();
+    client.initialize(
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &100,
+        &1_000,
+        &10_000,
+        &clawback_admin,
+    );
+
+    // 40% vested at this point => 4,000 claimable
+    e.ledger().set_timestamp(start_time + 400);
+    client.cancel_stream(&funder);
+
+    // Beneficiary receives claimable portion and sender is refunded the rest.
+    assert_eq!(token_client.balance(&beneficiary), 4_000);
+    assert_eq!(token_client.balance(&funder), 6_000);
+    assert_eq!(token_client.balance(&contract_id), 0);
+
+    let config = client.get_config();
+    assert_eq!(config.is_active, false);
+    assert_eq!(config.claimed_amount, 4_000);
+    assert_eq!(config.total_amount, 4_000);
+}
+
+#[test]
+#[should_panic(expected = "Only sender can cancel stream")]
+fn test_cancel_stream_rejects_non_sender() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let funder = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let non_sender = Address::generate(&e);
+    let clawback_admin = Address::generate(&e);
+    let contract_id = e.register(VestingContract, ());
+    let client = VestingContractClient::new(&e, &contract_id);
+
+    let token_admin = Address::generate(&e);
+    let token_contract = e.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_admin_client = token::StellarAssetClient::new(&e, &token_contract);
+    token_admin_client.mint(&funder, &1_000);
+
+    let start_time = e.ledger().timestamp();
+    client.initialize(
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &0,
+        &1_000,
+        &1_000,
+        &clawback_admin,
+    );
+
+    client.cancel_stream(&non_sender);
 }


### PR DESCRIPTION
## Description
Implement sender-driven stream cancellation logic in the Soroban vesting/escrow flow so unused funds are refunded and recipient claimable value is settled at cancel time.

Closes #199

## Changes proposed

### What were you told to do?
I was asked to implement `cancel_stream` logic that:
- verifies caller is the stream sender,
- pays final claimable amount to recipient,
- refunds remaining deposited amount to sender,
- marks stream inactive.

### What did I do?

#### Added sender-aware cancellation support in contract state
Updated `contracts/vesting_escrow/src/lib.rs`:
- Added `funder` to `VestingConfig` so sender identity is persisted in contract state.
- Persisted `funder` during `initialize`.

#### Implemented `cancel_stream` settlement flow
Added `cancel_stream(e: Env, sender: Address)` in `contracts/vesting_escrow/src/lib.rs` to:
- Require sender auth and enforce `sender == config.funder`.
- Calculate current vested amount and final claimable amount (`vested - claimed_amount`).
- Transfer final claimable amount to beneficiary.
- Refund all remaining deposited tokens to sender.
- Mark stream inactive and cap `total_amount` to already-claimed amount.

#### Added coverage tests for cancellation behavior
Updated `contracts/vesting_escrow/src/test.rs`:
- `test_cancel_stream_pays_recipient_and_refunds_sender`
- `test_cancel_stream_rejects_non_sender`
- Existing vesting flow test now also verifies `funder` is stored.

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Attempted to validate with:
```text
cargo test (contracts/vesting_escrow)
```
Could not execute tests in this repo layout without workspace changes because `contracts/vesting_escrow` is not included in root workspace members.
