### PR TITLE
[WEB3] Frontend: Integrate Freighter for withdraw Action #202

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ PUBLIC_STELLAR_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
 PUBLIC_STELLAR_RPC_URL="http://localhost:8000/rpc"
 # The Stellar Horizon URL. this is local
 PUBLIC_STELLAR_HORIZON_URL="http://localhost:8000"
+PUBLIC_STREAM_CONTRACT_ID=""
 
 # PUBLIC_STELLAR_NETWORK="TESTNET"
 # PUBLIC_STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"

--- a/frontend/src/lib/wallet.ts
+++ b/frontend/src/lib/wallet.ts
@@ -1,0 +1,86 @@
+import {
+  Address,
+  BASE_FEE,
+  Contract,
+  Networks,
+  SorobanRpc,
+  TransactionBuilder,
+  nativeToScVal,
+} from '@stellar/stellar-sdk';
+
+const DEFAULT_RPC_URL = 'https://soroban-testnet.stellar.org';
+const DEFAULT_NETWORK = Networks.TESTNET;
+const POLL_INTERVAL_MS = 1200;
+const MAX_ATTEMPTS = 20;
+
+export interface WithdrawRequest {
+  contractId: string;
+  claimantAddress: string;
+  streamId: string;
+  signTransaction: (xdr: string) => Promise<string>;
+  rpcUrl?: string;
+  networkPassphrase?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function submitWithdrawTransaction({
+  contractId,
+  claimantAddress,
+  streamId,
+  signTransaction,
+  rpcUrl = import.meta.env.PUBLIC_STELLAR_RPC_URL || DEFAULT_RPC_URL,
+  networkPassphrase = import.meta.env.PUBLIC_STELLAR_NETWORK === 'mainnet'
+    ? Networks.PUBLIC
+    : DEFAULT_NETWORK,
+}: WithdrawRequest): Promise<{ hash: string }> {
+  if (!contractId) {
+    throw new Error('Missing Soroban stream contract id.');
+  }
+
+  const server = new SorobanRpc.Server(rpcUrl, { allowHttp: rpcUrl.startsWith('http://') });
+  const source = await server.getAccount(claimantAddress);
+  const contract = new Contract(contractId);
+
+  const tx = new TransactionBuilder(source, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(
+      contract.call(
+        'withdraw',
+        new Address(claimantAddress).toScVal(),
+        nativeToScVal(streamId, { type: 'string' })
+      )
+    )
+    .setTimeout(60)
+    .build();
+
+  const simulation = await server.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(simulation)) {
+    throw new Error(simulation.error || 'Failed to simulate withdraw transaction.');
+  }
+
+  const prepared = SorobanRpc.assembleTransaction(tx, simulation).build();
+  const signedXdr = await signTransaction(prepared.toXDR());
+  const sendResult = await server.sendTransaction(TransactionBuilder.fromXDR(signedXdr, networkPassphrase));
+
+  if (sendResult.status === SorobanRpc.Api.SendTransactionStatus.ERROR) {
+    throw new Error('Withdraw transaction submission failed.');
+  }
+
+  for (let i = 0; i < MAX_ATTEMPTS; i += 1) {
+    const txStatus = await server.getTransaction(sendResult.hash);
+    if (txStatus.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+      return { hash: sendResult.hash };
+    }
+    if (txStatus.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+      throw new Error('Withdraw transaction failed on-chain.');
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new Error('Timed out waiting for withdraw confirmation.');
+}

--- a/frontend/src/pages/PayrollScheduler.tsx
+++ b/frontend/src/pages/PayrollScheduler.tsx
@@ -5,7 +5,10 @@ import { useTransactionSimulation } from '../hooks/useTransactionSimulation';
 import { TransactionSimulationPanel } from '../components/TransactionSimulationPanel';
 import { useNotification } from '../hooks/useNotification';
 import { useSocket } from '../hooks/useSocket';
+import { useWallet } from '../hooks/useWallet';
+import { useWalletSigning } from '../hooks/useWalletSigning';
 import { createClaimableBalanceTransaction, generateWallet } from '../services/stellar';
+import { submitWithdrawTransaction } from '../lib/wallet';
 import { useTranslation } from 'react-i18next';
 import { Card, Heading, Text, Button, Input, Select } from '@stellar/design-system';
 import { SchedulingWizard } from '../components/SchedulingWizard';
@@ -53,9 +56,12 @@ const initialFormState: PayrollFormState = {
 export default function PayrollScheduler() {
   const { t } = useTranslation();
   const { notifySuccess, notifyError } = useNotification();
+  const { address } = useWallet();
+  const { sign, isReady: walletReady } = useWalletSigning();
   const { socket, subscribeToTransaction, unsubscribeFromTransaction } = useSocket();
   const [formData, setFormData] = useState<PayrollFormState>(initialFormState);
   const [isBroadcasting, setIsBroadcasting] = useState(false);
+  const [withdrawingClaimId, setWithdrawingClaimId] = useState<string | null>(null);
   const [isWizardOpen, setIsWizardOpen] = useState(false);
   const [activeSchedule, setActiveSchedule] = useState<{
     frequency: string;
@@ -233,6 +239,44 @@ export default function PayrollScheduler() {
     const updatedClaims = pendingClaims.filter((c) => c.id !== id);
     setPendingClaims(updatedClaims);
     localStorage.setItem('pending-claims', JSON.stringify(updatedClaims));
+  };
+
+  const handleWithdrawClaim = async (claim: PendingClaim) => {
+    if (!walletReady || !address) {
+      notifyError('Wallet not connected', 'Connect Freighter to sign withdraw transactions.');
+      return;
+    }
+
+    const contractId = import.meta.env.PUBLIC_STREAM_CONTRACT_ID as string | undefined;
+    if (!contractId) {
+      notifyError('Missing contract config', 'PUBLIC_STREAM_CONTRACT_ID is not configured.');
+      return;
+    }
+
+    setWithdrawingClaimId(claim.id);
+    try {
+      const result = await submitWithdrawTransaction({
+        contractId,
+        claimantAddress: address,
+        streamId: claim.id,
+        signTransaction: sign,
+      });
+
+      const updated = pendingClaims.map((row) =>
+        row.id === claim.id ? { ...row, status: 'Withdrawn' } : row
+      );
+      setPendingClaims(updated);
+      localStorage.setItem('pending-claims', JSON.stringify(updated));
+
+      notifySuccess('Withdraw successful', `Transaction hash: ${result.hash.slice(0, 10)}...`);
+    } catch (error) {
+      notifyError(
+        'Withdraw failed',
+        error instanceof Error ? error.message : 'Unable to complete withdraw.'
+      );
+    } finally {
+      setWithdrawingClaimId(null);
+    }
   };
 
   return (
@@ -487,6 +531,15 @@ export default function PayrollScheduler() {
                         To: {claim.claimantPublicKey}
                       </Text>
                     </div>
+                    <button
+                      onClick={() => {
+                        void handleWithdrawClaim(claim);
+                      }}
+                      disabled={withdrawingClaimId === claim.id}
+                      className="mr-3 text-success hover:text-success/80 text-sm font-medium disabled:opacity-50"
+                    >
+                      {withdrawingClaimId === claim.id ? 'Withdrawing...' : 'Withdraw'}
+                    </button>
                     <button
                       onClick={() => handleRemoveClaim(claim.id)}
                       className="text-danger hover:text-danger/80 text-sm font-medium"


### PR DESCRIPTION
## Description
Integrate wallet-signed Soroban withdraw flow in the frontend so users can trigger withdraw actions through Freighter-compatible signing and receive clear success/error feedback.

Closes #202

## Changes proposed

### What were you told to do?
I was asked to:
- implement withdraw transaction builder logic in frontend wallet layer,
- connect the Withdraw button to signature flow,
- add success/error UI notifications and submission states.

### What did I do?

#### Added Soroban withdraw wallet helper
Created `frontend/src/lib/wallet.ts` with:
- `submitWithdrawTransaction(...)` that builds Soroban `withdraw` invocation,
- RPC simulation precheck,
- wallet signing callback integration,
- submission + confirmation polling,
- typed success return `{ hash }` and explicit error handling.

#### Wired Withdraw action in UI
Updated `frontend/src/pages/PayrollScheduler.tsx`:
- added wallet integration via `useWallet` and `useWalletSigning`,
- mapped claim-row `Withdraw` button to transaction signing flow,
- added in-flight state (`withdrawingClaimId`) to prevent duplicate submit,
- updated local claim status to `Withdrawn` on success.

#### Added user-facing notifications and config support
- Added success and failure notifications around withdraw lifecycle.
- Added `PUBLIC_STREAM_CONTRACT_ID` to `.env.example` for contract configuration.

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Attempted validation:
```text
cd frontend && npm run lint -- src/pages/PayrollScheduler.tsx src/lib/wallet.ts
```
Lint could not run due missing frontend lint dependency resolution in this environment (`eslint-plugin-react-dom` not found).
