### PR TITLE
fix: improve autosave recovery for payroll and employee forms

### DIFF
--- a/frontend/src/hooks/useAutosave.ts
+++ b/frontend/src/hooks/useAutosave.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 /**
  * Custom hook for autosaving form data to localStorage with debouncing.
@@ -11,6 +11,7 @@ import { useState, useEffect, useCallback } from 'react';
 export function useAutosave<T>(key: string, data: T, delay: number = 1000) {
   const [saving, setSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
+  const isFirstSaveCycle = useRef(true);
 
   // Load initial data from local storage if available
   // This helper is intended to be used by the component to initialize its state
@@ -29,8 +30,12 @@ export function useAutosave<T>(key: string, data: T, delay: number = 1000) {
   }, [key]);
 
   useEffect(() => {
-    // Don't save if data is empty/initial (optional check, depends on use case)
-    // For now, we save everything to ensure state sync.
+    // Skip the first cycle so existing draft state can be restored
+    // by the screen without being overwritten by initial defaults.
+    if (isFirstSaveCycle.current) {
+      isFirstSaveCycle.current = false;
+      return;
+    }
 
     setSaving(true);
 

--- a/frontend/src/pages/EmployeeEntry.tsx
+++ b/frontend/src/pages/EmployeeEntry.tsx
@@ -80,7 +80,7 @@ export default function EmployeeEntry() {
     walletAddress?: string;
     employeeName?: string;
   } | null>(null);
-  const { notifySuccess } = useNotification();
+  const { notifySuccess, notify } = useNotification();
   const { saving, lastSaved, loadSavedData } = useAutosave<EmployeeFormState>(
     'employee-entry-draft',
     formData
@@ -91,8 +91,9 @@ export default function EmployeeEntry() {
     const saved = loadSavedData();
     if (saved) {
       setFormData(saved);
+      notify('Recovered unsaved employee draft');
     }
-  }, [loadSavedData]);
+  }, [loadSavedData, notify]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;

--- a/frontend/src/pages/PayrollScheduler.tsx
+++ b/frontend/src/pages/PayrollScheduler.tsx
@@ -56,7 +56,7 @@ const initialFormState: PayrollFormState = {
 
 export default function PayrollScheduler() {
   const { t } = useTranslation();
-  const { notifySuccess } = useNotification();
+  const { notifySuccess, notify } = useNotification();
   const { socket, subscribeToTransaction, unsubscribeFromTransaction } = useSocket();
   const [formData, setFormData] = useState<PayrollFormState>(initialFormState);
   const [isBroadcasting, setIsBroadcasting] = useState(false);
@@ -98,8 +98,9 @@ export default function PayrollScheduler() {
     const saved = loadSavedData();
     if (saved) {
       setFormData(saved);
+      notify('Recovered unsaved payroll draft');
     }
-  }, [loadSavedData]);
+  }, [loadSavedData, notify]);
 
   const handleScheduleComplete = (config: { frequency: string; timeOfDay: string }) => {
     setActiveSchedule(config);


### PR DESCRIPTION
## Summary
- prevent first autosave cycle from overwriting an existing draft before hydration completes
- show a user-facing recovery notice when `PayrollScheduler` or `EmployeeEntry` restores saved draft data
- keep debounced autosave indicator behavior unchanged while making reload recovery more reliable

## Test plan
- [x] Open Payroll Scheduler, type into fields, reload page, confirm draft is restored
- [x] Open Employee Entry form, type into fields, reload page, confirm draft is restored
- [x] Verify recovery notification appears after draft restoration
- [x] Verify autosave indicator still updates after edits

Closes #244
