### PR TITLE
feat(frontend): bulk payment status tracker

### DIFF
--- a/frontend/src/components/BulkPaymentStatusTracker.tsx
+++ b/frontend/src/components/BulkPaymentStatusTracker.tsx
@@ -5,10 +5,12 @@ import { useWallet } from '../hooks/useWallet';
 import { useWalletSigning } from '../hooks/useWalletSigning';
 import { contractService } from '../services/contracts';
 import {
+  fetchPayrollRunOnChainState,
   fetchPayrollRuns,
   fetchPayrollRunSummary,
   getTxExplorerUrl,
-  retryFailedBatch,
+  retryFailedPayment,
+  type OnChainBatchState,
   type PayrollRecipientStatus,
   type PayrollRunRecord,
   type PayrollRunSummary,
@@ -19,6 +21,7 @@ interface BulkPaymentStatusTrackerProps {
 }
 
 type ConfirmationMap = Record<string, number>;
+type OnChainStateMap = Record<number, OnChainBatchState>;
 
 function toRecipientStatus(
   status: PayrollRecipientStatus['status']
@@ -74,15 +77,16 @@ function normalizeConfirmationPayload(payload: unknown): {
 export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTrackerProps) {
   const [runs, setRuns] = useState<PayrollRunRecord[]>([]);
   const [summaries, setSummaries] = useState<Record<number, PayrollRunSummary>>({});
+  const [onChainStates, setOnChainStates] = useState<OnChainStateMap>({});
   const [expandedRunId, setExpandedRunId] = useState<number | null>(null);
   const [confirmations, setConfirmations] = useState<ConfirmationMap>({});
   const [isLoading, setIsLoading] = useState(false);
-  const [isRetryingBatchId, setIsRetryingBatchId] = useState<string | null>(null);
+  const [isRetryingKey, setIsRetryingKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const { notifyError, notifySuccess } = useNotification();
   const { socket } = useSocket();
-  const { requireWallet } = useWallet();
+  const { address, requireWallet } = useWallet();
   const { sign } = useWalletSigning();
 
   const loadRuns = useCallback(async () => {
@@ -104,21 +108,41 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
     void loadRuns();
   }, [loadRuns]);
 
-  const loadSummary = useCallback(
-    async (runId: number) => {
-      if (summaries[runId]) return;
+  const loadOnChainState = useCallback(
+    async (run: PayrollRunRecord, summary?: PayrollRunSummary) => {
+      if (onChainStates[run.id]) return;
+
+      const readSource =
+        address || (import.meta.env.VITE_SOROBAN_READ_SOURCE as string | undefined) || null;
+      if (!readSource) return;
+
       try {
-        const summary = await fetchPayrollRunSummary(runId);
-        setSummaries((prev) => ({ ...prev, [runId]: summary }));
-      } catch (summaryError) {
+        await contractService.initialize();
+        const contractId =
+          contractService.getContractId('bulk_payment', 'testnet') ||
+          (import.meta.env.VITE_BULK_PAYMENT_CONTRACT_ID as string | undefined);
+
+        if (!contractId) {
+          throw new Error('Bulk payment contract ID is unavailable.');
+        }
+
+        const onChainState = await fetchPayrollRunOnChainState({
+          contractId,
+          batchId: run.batch_id,
+          recipientCount: summary?.items.length ?? 0,
+          sourceAddress: readSource,
+        });
+
+        setOnChainStates((prev) => ({ ...prev, [run.id]: onChainState }));
+      } catch (onChainError) {
         const message =
-          summaryError instanceof Error
-            ? summaryError.message
-            : 'Failed to load per-recipient status';
-        notifyError('Failed to load batch details', message);
+          onChainError instanceof Error
+            ? onChainError.message
+            : 'Unable to load on-chain batch state';
+        notifyError('Bulk on-chain read failed', message);
       }
     },
-    [notifyError, summaries]
+    [address, notifyError, onChainStates]
   );
 
   useEffect(() => {
@@ -155,20 +179,26 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
       return;
     }
     setExpandedRunId(runId);
-    await loadSummary(runId);
+    const run = runs.find((entry) => entry.id === runId);
+    if (!run) return;
+    const summary =
+      summaries[runId] ||
+      (await fetchPayrollRunSummary(runId).then((payload) => {
+        setSummaries((prev) => ({ ...prev, [runId]: payload }));
+        return payload;
+      }));
+    await loadOnChainState(run, summary);
   };
 
-  const handleRetry = async (run: PayrollRunRecord) => {
+  const handleRetry = async (run: PayrollRunRecord, paymentIndex: number) => {
     const walletAddress = await requireWallet();
     if (!walletAddress) {
       return;
     }
 
-    const summary = summaries[run.id];
-    const hasFailedRecipients = summary?.items.some((item) => item.status === 'failed');
-    if (!hasFailedRecipients) return;
+    const retryKey = `${run.batch_id}:${paymentIndex}`;
 
-    setIsRetryingBatchId(run.batch_id);
+    setIsRetryingKey(retryKey);
     try {
       await contractService.initialize();
       const contractId =
@@ -179,41 +209,46 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
         throw new Error('Bulk payment contract ID is unavailable.');
       }
 
-      const { txHash } = await retryFailedBatch({
+      const { txHash } = await retryFailedPayment({
         contractId,
         batchId: run.batch_id,
+        paymentIndex,
         sourceAddress: walletAddress,
         signTransaction: sign,
       });
 
       notifySuccess('Retry submitted', `Batch ${run.batch_id} was re-invoked. TX: ${txHash}`);
-      await loadSummary(run.id);
+      const refreshedSummary = await fetchPayrollRunSummary(run.id);
+      setSummaries((prev) => ({ ...prev, [run.id]: refreshedSummary }));
+      await loadOnChainState(run, refreshedSummary);
     } catch (retryError) {
       const message = retryError instanceof Error ? retryError.message : 'Retry failed';
       notifyError('Retry failed', message);
     } finally {
-      setIsRetryingBatchId(null);
+      setIsRetryingKey(null);
     }
   };
 
   const rows = useMemo(() => {
     return runs.map((run) => {
       const summary = summaries[run.id];
-      const employeeCount = summary?.summary.total_employees ?? 0;
+      const onChainState = onChainStates[run.id];
+      const employeeCount = summary?.summary.total_employees ?? summary?.items.length ?? 0;
       const txHash = findRunTxHash(summary);
-      const confirmationCount = confirmations[run.batch_id] ?? 0;
+      const confirmationCount = confirmations[run.batch_id] ?? onChainState?.successCount ?? 0;
       const hasFailedRecipients = summary?.items.some((item) => item.status === 'failed') ?? false;
 
       return {
         run,
         summary,
+        onChainState,
         employeeCount,
         txHash,
         confirmationCount,
         hasFailedRecipients,
       };
     });
-  }, [confirmations, runs, summaries]);
+  }, [confirmations, onChainStates, runs, summaries]);
 
   return (
     <div className="card glass noise mt-8">
@@ -254,6 +289,7 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
                 ({
                   run,
                   summary,
+                  onChainState,
                   employeeCount,
                   txHash,
                   confirmationCount,
@@ -263,17 +299,18 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
                     key={run.id}
                     run={run}
                     summary={summary}
+                    onChainState={onChainState}
                     employeeCount={employeeCount}
                     txHash={txHash}
                     confirmationCount={confirmationCount}
                     expanded={expandedRunId === run.id}
-                    retrying={isRetryingBatchId === run.batch_id}
+                    retryingKey={isRetryingKey}
                     hasFailedRecipients={hasFailedRecipients}
                     onToggleExpand={() => {
                       void handleToggleExpand(run.id);
                     }}
-                    onRetry={() => {
-                      void handleRetry(run);
+                    onRetry={(paymentIndex) => {
+                      void handleRetry(run, paymentIndex);
                     }}
                   />
                 )
@@ -289,24 +326,26 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
 interface FragmentRowProps {
   run: PayrollRunRecord;
   summary?: PayrollRunSummary;
+  onChainState?: OnChainBatchState;
   employeeCount: number;
   txHash: string | null;
   confirmationCount: number;
   expanded: boolean;
-  retrying: boolean;
+  retryingKey: string | null;
   hasFailedRecipients: boolean;
   onToggleExpand: () => void;
-  onRetry: () => void;
+  onRetry: (paymentIndex: number) => void;
 }
 
 function FragmentRow({
   run,
   summary,
+  onChainState,
   employeeCount,
   txHash,
   confirmationCount,
   expanded,
-  retrying,
+  retryingKey,
   hasFailedRecipients,
   onToggleExpand,
   onRetry,
@@ -315,7 +354,16 @@ function FragmentRow({
     <>
       <tr className="border-b border-hi/40">
         <td className="py-3 pr-4 font-mono">{run.batch_id}</td>
-        <td className="py-3 pr-4 capitalize">{run.status}</td>
+        <td className="py-3 pr-4 capitalize">
+          <div className="flex flex-col">
+            <span>{run.status}</span>
+            {onChainState?.status ? (
+              <span className="text-[11px] uppercase tracking-wide text-muted">
+                On-chain: {onChainState.status}
+              </span>
+            ) : null}
+          </div>
+        </td>
         <td className="py-3 pr-4">{employeeCount}</td>
         <td className="py-3 pr-4">
           {run.total_amount} {run.asset_code}
@@ -345,14 +393,7 @@ function FragmentRow({
               {expanded ? 'Hide' : 'Details'}
             </button>
             {hasFailedRecipients ? (
-              <button
-                type="button"
-                onClick={onRetry}
-                disabled={retrying}
-                className="text-danger hover:text-danger/80 disabled:opacity-60"
-              >
-                {retrying ? 'Retrying...' : 'Retry Failed'}
-              </button>
+              <span className="text-xs text-danger">Retry available below</span>
             ) : null}
           </div>
         </td>
@@ -363,19 +404,63 @@ function FragmentRow({
             {!summary ? (
               <p className="text-sm text-muted">Loading recipient statuses...</p>
             ) : (
-              <div className="space-y-2">
-                {summary.items.map((recipient) => (
-                  <div
-                    key={recipient.id}
-                    className="flex items-center justify-between rounded-md border border-hi/30 px-3 py-2 text-xs"
-                  >
-                    <span>{getEmployeeName(recipient)}</span>
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-4 rounded-md border border-hi/30 px-3 py-2 text-xs text-muted">
+                  <span>Recipients: {summary.items.length}</span>
+                  <span>Confirmed on-chain: {onChainState?.successCount ?? 0}</span>
+                  <span>Failed on-chain: {onChainState?.failCount ?? 0}</span>
+                  {onChainState?.totalSent ? (
                     <span>
-                      {recipient.amount} {run.asset_code}
+                      Total settled: {onChainState.totalSent} {run.asset_code}
                     </span>
-                    <span className="capitalize">{toRecipientStatus(recipient.status)}</span>
-                  </div>
-                ))}
+                  ) : null}
+                </div>
+                {summary.items.map((recipient, index) => {
+                  const onChainRecipient = onChainState?.items[index];
+                  const status =
+                    onChainRecipient?.status && onChainRecipient.status !== 'unknown'
+                      ? onChainRecipient.status
+                      : toRecipientStatus(recipient.status);
+                  const retryId = `${run.batch_id}:${index}`;
+
+                  return (
+                    <div
+                      key={recipient.id}
+                      className="grid gap-2 rounded-md border border-hi/30 px-3 py-3 text-xs md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_auto]"
+                    >
+                      <div className="min-w-0">
+                        <p className="font-semibold text-text">{getEmployeeName(recipient)}</p>
+                        {onChainRecipient?.recipient ? (
+                          <p className="truncate font-mono text-[11px] text-muted">
+                            {onChainRecipient.recipient}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div>
+                        <p className="text-muted">Amount</p>
+                        <p>
+                          {recipient.amount} {run.asset_code}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-muted">Status</p>
+                        <p className="capitalize">{status}</p>
+                      </div>
+                      <div className="flex items-center justify-end">
+                        {status === 'failed' ? (
+                          <button
+                            type="button"
+                            onClick={() => onRetry(index)}
+                            disabled={retryingKey === retryId}
+                            className="text-danger hover:text-danger/80 disabled:opacity-60"
+                          >
+                            {retryingKey === retryId ? 'Retrying...' : 'Retry'}
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             )}
           </td>

--- a/frontend/src/services/bulkPaymentStatus.ts
+++ b/frontend/src/services/bulkPaymentStatus.ts
@@ -5,6 +5,8 @@ import {
   rpc,
   TransactionBuilder,
   nativeToScVal,
+  scValToNative,
+  xdr,
 } from '@stellar/stellar-sdk';
 import { simulateTransaction } from './transactionSimulation';
 
@@ -43,6 +45,22 @@ export interface PayrollRunSummary {
   };
 }
 
+export interface OnChainPaymentStatus {
+  index: number;
+  recipient: string | null;
+  amount: string | null;
+  status: 'pending' | 'confirmed' | 'failed' | 'refunded' | 'unknown';
+}
+
+export interface OnChainBatchState {
+  batchId: number;
+  status: string | null;
+  successCount: number;
+  failCount: number;
+  totalSent: string | null;
+  items: OnChainPaymentStatus[];
+}
+
 interface PayrollRunsListResponse {
   success: boolean;
   data: {
@@ -58,9 +76,18 @@ interface PayrollRunSummaryResponse {
 
 export interface RetryInvocationOptions {
   contractId: string;
-  batchId: string;
+  batchId: string | number;
+  paymentIndex?: number;
   sourceAddress: string;
   signTransaction: (xdr: string) => Promise<string>;
+  rpcUrl?: string;
+}
+
+export interface OnChainBatchStateOptions {
+  contractId: string;
+  batchId: string | number;
+  recipientCount: number;
+  sourceAddress: string;
   rpcUrl?: string;
 }
 
@@ -77,6 +104,200 @@ function payrollAuthHeaders(): Record<string, string> {
   if (typeof localStorage === 'undefined') return {};
   const token = localStorage.getItem('payd_auth_token');
   return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function getReadMethodName(key: 'batch' | 'payment' | 'retry'): string {
+  if (key === 'batch') {
+    return (
+      (import.meta.env.VITE_BULK_PAYMENT_GET_BATCH_METHOD as string | undefined) || 'get_batch'
+    );
+  }
+
+  if (key === 'payment') {
+    return (
+      (import.meta.env.VITE_BULK_PAYMENT_GET_PAYMENT_METHOD as string | undefined) ||
+      'get_payment_entry'
+    );
+  }
+
+  return (
+    (import.meta.env.VITE_BULK_PAYMENT_RETRY_METHOD as string | undefined) || 'retry_failed_batch'
+  );
+}
+
+function toBatchIdValue(batchId: string | number): string | number {
+  if (typeof batchId === 'number') return batchId;
+
+  const trimmed = batchId.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10);
+  }
+
+  const numericTail = trimmed.match(/(\d+)$/);
+  if (numericTail) {
+    return Number.parseInt(numericTail[1], 10);
+  }
+
+  return trimmed;
+}
+
+function parseNumeric(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function safeString(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return null;
+}
+
+function parseStatusValue(value: unknown): OnChainPaymentStatus['status'] {
+  if (typeof value === 'number') {
+    if (value === 0) return 'pending';
+    if (value === 1) return 'confirmed';
+    if (value === 2) return 'failed';
+    if (value === 3) return 'refunded';
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.toLowerCase();
+    if (['pending', '0'].includes(normalized)) return 'pending';
+    if (['sent', 'confirmed', 'completed', '1'].includes(normalized)) return 'confirmed';
+    if (['failed', '2'].includes(normalized)) return 'failed';
+    if (['refunded', '3'].includes(normalized)) return 'refunded';
+  }
+
+  return 'unknown';
+}
+
+function parseBatchState(nativeValue: unknown, batchId: number): Omit<OnChainBatchState, 'items'> {
+  if (Array.isArray(nativeValue)) {
+    const values = nativeValue as unknown[];
+    const totalSent = values[2];
+    const successCount = values[3];
+    const failCount = values[4];
+    const status = values[5];
+    return {
+      batchId,
+      totalSent: safeString(totalSent),
+      successCount: parseNumeric(successCount),
+      failCount: parseNumeric(failCount),
+      status: safeString(status),
+    };
+  }
+
+  if (nativeValue && typeof nativeValue === 'object') {
+    const record = nativeValue as Record<string, unknown>;
+    return {
+      batchId,
+      totalSent: safeString(record.total_sent),
+      successCount: parseNumeric(record.success_count),
+      failCount: parseNumeric(record.fail_count),
+      status: safeString(record.status),
+    };
+  }
+
+  return {
+    batchId,
+    totalSent: null,
+    successCount: 0,
+    failCount: 0,
+    status: null,
+  };
+}
+
+function parsePaymentState(index: number, nativeValue: unknown): OnChainPaymentStatus {
+  if (Array.isArray(nativeValue)) {
+    const values = nativeValue as unknown[];
+    const recipient = values[0];
+    const amount = values[1];
+    const status = values[3];
+    return {
+      index,
+      recipient: safeString(recipient),
+      amount: safeString(amount),
+      status: parseStatusValue(status),
+    };
+  }
+
+  if (nativeValue && typeof nativeValue === 'object') {
+    const record = nativeValue as Record<string, unknown>;
+    return {
+      index,
+      recipient: safeString(record.recipient),
+      amount: safeString(record.amount),
+      status: parseStatusValue(record.status),
+    };
+  }
+
+  return {
+    index,
+    recipient: null,
+    amount: null,
+    status: 'unknown',
+  };
+}
+
+async function simulateReadContract<T>(
+  contractId: string,
+  sourceAddress: string,
+  method: string,
+  args: Array<string | number>,
+  rpcUrl?: string
+): Promise<T> {
+  const normalizedRpcUrl = normalizeBaseUrl(rpcUrl || DEFAULT_RPC_URL);
+  const server = new rpc.Server(normalizedRpcUrl, {
+    allowHttp: normalizedRpcUrl.startsWith('http://'),
+  });
+  const account = await server.getAccount(sourceAddress);
+  const contract = new Contract(contractId);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(),
+  })
+    .addOperation(contract.call(method, ...args.map((arg) => nativeToScVal(arg))))
+    .setTimeout(60)
+    .build();
+
+  const rpcResponse = await fetch(normalizedRpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'simulateTransaction',
+      params: { transaction: tx.toXDR() },
+    }),
+  });
+
+  if (!rpcResponse.ok) {
+    throw new Error(`Failed to read bulk payment state (${rpcResponse.status})`);
+  }
+
+  const payload = (await rpcResponse.json()) as {
+    result?: { retval?: string };
+    error?: { message?: string };
+  };
+
+  if (payload.error?.message) {
+    throw new Error(payload.error.message);
+  }
+
+  if (!payload.result?.retval) {
+    throw new Error(`Contract method "${method}" returned no value.`);
+  }
+
+  const retval = xdr.ScVal.fromXDR(payload.result.retval, 'base64');
+  return scValToNative(retval) as T;
 }
 
 /** organizationId is ignored; runs are scoped by the signed-in employer JWT. */
@@ -118,19 +339,69 @@ export function getTxExplorerUrl(
   return `https://stellar.expert/explorer/${network}/tx/${txHash}`;
 }
 
-export async function retryFailedBatch(
+export async function fetchPayrollRunOnChainState(
+  options: OnChainBatchStateOptions
+): Promise<OnChainBatchState> {
+  const parsedBatchId = toBatchIdValue(options.batchId);
+  if (typeof parsedBatchId !== 'number') {
+    throw new Error('This batch ID cannot be mapped to an on-chain batch number.');
+  }
+
+  const batchNative = await simulateReadContract<unknown>(
+    options.contractId,
+    options.sourceAddress,
+    getReadMethodName('batch'),
+    [parsedBatchId],
+    options.rpcUrl
+  );
+
+  const items = await Promise.all(
+    Array.from({ length: options.recipientCount }, async (_, index) => {
+      try {
+        const paymentNative = await simulateReadContract<unknown>(
+          options.contractId,
+          options.sourceAddress,
+          getReadMethodName('payment'),
+          [parsedBatchId, index],
+          options.rpcUrl
+        );
+        return parsePaymentState(index, paymentNative);
+      } catch {
+        return {
+          index,
+          recipient: null,
+          amount: null,
+          status: 'unknown',
+        } satisfies OnChainPaymentStatus;
+      }
+    })
+  );
+
+  return {
+    ...parseBatchState(batchNative, parsedBatchId),
+    items,
+  };
+}
+
+export async function retryFailedPayment(
   options: RetryInvocationOptions
 ): Promise<{ txHash: string }> {
   const rpcUrl = normalizeBaseUrl(options.rpcUrl || DEFAULT_RPC_URL);
   const server = new rpc.Server(rpcUrl, { allowHttp: rpcUrl.startsWith('http://') });
   const account = await server.getAccount(options.sourceAddress);
   const contract = new Contract(options.contractId);
+  const methodName = getReadMethodName('retry');
+  const parsedBatchId = toBatchIdValue(options.batchId);
+  const args =
+    options.paymentIndex != null && methodName !== 'retry_failed_batch'
+      ? [nativeToScVal(parsedBatchId), nativeToScVal(options.paymentIndex)]
+      : [nativeToScVal(parsedBatchId)];
 
   const tx = new TransactionBuilder(account, {
     fee: BASE_FEE,
     networkPassphrase: getNetworkPassphrase(),
   })
-    .addOperation(contract.call('retry_failed_batch', nativeToScVal(options.batchId)))
+    .addOperation(contract.call(methodName, ...args))
     .setTimeout(60)
     .build();
 


### PR DESCRIPTION
## Description
Builds a bulk payment status tracker for payroll batch runs so employers can inspect per-recipient outcomes, monitor on-chain confirmations, and retry failed entries from the UI.

Closes #247

## Changes proposed

### What were you told to do?
Build a status tracker for bulk payroll runs that queries both the backend audit log and on-chain confirmation state from the bulk payment contract. Each batch row should show employee count, total amount, per-recipient status, explorer links, live confirmation updates via the socket provider, and a retry action for failed rows.

### What did I do?
#### Batch Status And On-Chain Reads
- extended the bulk payment service to read batch and per-payment state from Soroban using simulated contract reads
- normalized batch IDs and contract method handling so the UI can work with either env-configured method names or repo defaults
- merged socket confirmation updates with on-chain batch success counts for a clearer confirmation column

#### Tracker UI And Retry Flow
- expanded each payroll batch row into a richer recipient breakdown with status, recipient address, settled totals, and failure counts
- moved retry actions to the failed recipient level and wired them to signed contract re-invocation requests
- preserved explorer links for transaction hashes and kept the tracker embedded in the payroll scheduler flow

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated frontend build with `npm run build`.
Validated touched files with `npx eslint src/services/bulkPaymentStatus.ts src/components/BulkPaymentStatusTracker.tsx`.
Note: direct push to upstream was not permitted for this GitHub account, so the branch was pushed to the fork and the PR targets `Gildado/PayD:main`.