### PR TITLE
feat(frontend): implement wallet selection modal and persistent walleet status

### DIFF
--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -15,11 +15,13 @@ import {
 } from 'lucide-react';
 import { Avatar } from './Avatar';
 import { AvatarUpload } from './AvatarUpload';
+import { useWallet } from '../hooks/useWallet';
 
 const AppNav: React.FC = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isProfileEditorOpen, setIsProfileEditorOpen] = useState(false);
   const [userImageUrl, setUserImageUrl] = useState<string | undefined>(undefined);
+  const { address, walletName, isConnecting } = useWallet();
 
   useEffect(() => {
     const savedImage = localStorage.getItem('payd:user-avatar');
@@ -212,6 +214,18 @@ const AppNav: React.FC = () => {
 
         {/* User profile */}
         <div className="ml-auto flex items-center gap-2">
+          <div className="hidden xl:flex flex-col items-end rounded-lg border border-(--border-hi) bg-(--surface) px-3 py-1.5">
+            <span className="text-[9px] uppercase tracking-wider text-(--muted)">
+              {isConnecting
+                ? 'Connecting wallet'
+                : walletName
+                  ? `${walletName} connected`
+                  : 'Wallet'}
+            </span>
+            <span className="text-[11px] font-mono text-(--accent)">
+              {address ? `${address.slice(0, 6)}...${address.slice(-4)}` : 'Not connected'}
+            </span>
+          </div>
           <button
             type="button"
             className="p-1 rounded-lg flex items-center gap-2 cursor-pointer border border-(--border-hi) bg-(--surface) hover:bg-(--surface-hi) transition"

--- a/frontend/src/providers/WalletProvider.tsx
+++ b/frontend/src/providers/WalletProvider.tsx
@@ -3,14 +3,24 @@ import {
   StellarWalletsKit,
   WalletNetwork,
   FreighterModule,
+  FREIGHTER_ID,
   xBullModule,
   LobstrModule,
+  LOBSTR_ID,
 } from '@creit.tech/stellar-wallets-kit';
 import { useTranslation } from 'react-i18next';
 import { useNotification } from '../hooks/useNotification';
 import { WalletContext } from '../hooks/useWallet';
 
 const LAST_WALLET_STORAGE_KEY = 'payd:last_wallet_name';
+const SUPPORTED_MODAL_WALLETS = [FREIGHTER_ID, LOBSTR_ID] as const;
+
+type SelectableWallet = {
+  id: string;
+  name: string;
+  icon?: string;
+  isAvailable: boolean;
+};
 
 function hasAnyWalletExtension(): boolean {
   if (typeof window === 'undefined') return true;
@@ -30,6 +40,8 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [isConnecting, setIsConnecting] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const [walletExtensionAvailable, setWalletExtensionAvailable] = useState(true);
+  const [walletModalOpen, setWalletModalOpen] = useState(false);
+  const [walletOptions, setWalletOptions] = useState<SelectableWallet[]>([]);
   const kitRef = useRef<StellarWalletsKit | null>(null);
   const { t } = useTranslation();
   const { notifyWalletEvent } = useNotification();
@@ -54,6 +66,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       setIsConnecting(true);
 
       try {
+        newKit.setWallet(lastWalletName);
         const account = await newKit.getAddress();
         if (account?.address) {
           setAddress(account.address);
@@ -73,53 +86,62 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     void attemptSilentReconnect();
   }, [notifyWalletEvent]);
 
-  const connect = async (): Promise<string | null> => {
+  const loadWalletOptions = async (): Promise<SelectableWallet[]> => {
+    const kit = kitRef.current;
+    if (!kit) return [];
+    const supported = await kit.getSupportedWallets();
+    const options = supported
+      .filter((wallet) =>
+        SUPPORTED_MODAL_WALLETS.includes(wallet.id as (typeof SUPPORTED_MODAL_WALLETS)[number])
+      )
+      .map((wallet) => ({
+        id: wallet.id,
+        name: wallet.name,
+        icon: wallet.icon,
+        isAvailable: wallet.isAvailable,
+      }));
+    setWalletOptions(options);
+    setWalletExtensionAvailable(options.some((wallet) => wallet.isAvailable));
+    return options;
+  };
+
+  const connectWithWallet = async (selectedWalletId: string): Promise<string | null> => {
     const kit = kitRef.current;
     if (!kit) return null;
 
     setIsConnecting(true);
     try {
-      const selectedAddress = await new Promise<string | null>((resolve) => {
-        void kit.openModal({
-          modalTitle: t('wallet.modalTitle'),
-          onWalletSelected: (option) => {
-            void (async () => {
-              try {
-                const { address } = await kit.getAddress();
-                setAddress(address);
-                setWalletName(option.id);
-                localStorage.setItem(LAST_WALLET_STORAGE_KEY, option.id);
-                notifyWalletEvent(
-                  'connected',
-                  `${address.slice(0, 6)}...${address.slice(-4)} via ${option.id}`
-                );
-                resolve(address);
-              } catch (error) {
-                notifyWalletEvent(
-                  'connection_failed',
-                  error instanceof Error ? error.message : 'Please try again.'
-                );
-                resolve(null);
-              }
-            })();
-          },
-          onClosed: () => {
-            setIsConnecting(false);
-            resolve(null);
-          },
-        });
-      });
-
-      return selectedAddress;
+      kit.setWallet(selectedWalletId);
+      const { address } = await kit.getAddress();
+      setAddress(address);
+      setWalletName(selectedWalletId);
+      localStorage.setItem(LAST_WALLET_STORAGE_KEY, selectedWalletId);
+      notifyWalletEvent(
+        'connected',
+        `${address.slice(0, 6)}...${address.slice(-4)} via ${selectedWalletId}`
+      );
+      return address;
     } catch (error) {
       console.error('Failed to connect wallet:', error);
       notifyWalletEvent(
         'connection_failed',
         error instanceof Error ? error.message : 'Please try again.'
       );
+      return null;
+    } finally {
       setIsConnecting(false);
+      setWalletModalOpen(false);
+    }
+  };
+
+  const connect = async (): Promise<string | null> => {
+    const options = await loadWalletOptions();
+    if (options.length === 0) {
+      notifyWalletEvent('connection_failed', 'No supported wallet providers were found.');
       return null;
     }
+    setWalletModalOpen(true);
+    return null;
   };
 
   const requireWallet = async (): Promise<string | null> => {
@@ -129,6 +151,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   };
 
   const disconnect = () => {
+    const kit = kitRef.current;
+    if (kit) {
+      void kit.disconnect();
+    }
     setAddress(null);
     setWalletName(null);
     localStorage.removeItem(LAST_WALLET_STORAGE_KEY);
@@ -147,6 +173,47 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       {!walletExtensionAvailable && (
         <div className="sticky top-0 z-50 w-full border-b border-amber-600/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-300">
           Wallet extension not detected. Install Freighter, xBull, or Lobstr to sign transactions.
+        </div>
+      )}
+
+      {walletModalOpen && (
+        <div className="fixed inset-0 z-[80] grid place-items-center bg-black/70 px-4">
+          <div className="w-full max-w-md rounded-2xl border border-hi bg-surface p-6 shadow-2xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-lg font-black">{t('wallet.modalTitle') || 'Select a wallet'}</h3>
+              <button
+                onClick={() => setWalletModalOpen(false)}
+                className="rounded-lg border border-hi px-2 py-1 text-xs text-muted hover:text-text"
+              >
+                Close
+              </button>
+            </div>
+            <div className="space-y-2">
+              {walletOptions.map((wallet) => (
+                <button
+                  key={wallet.id}
+                  onClick={() => void connectWithWallet(wallet.id)}
+                  disabled={!wallet.isAvailable || isConnecting}
+                  className="flex w-full items-center justify-between rounded-xl border border-hi bg-black/20 px-4 py-3 text-left transition hover:bg-black/30 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <div className="flex items-center gap-3">
+                    {wallet.icon ? (
+                      <img src={wallet.icon} alt={wallet.name} className="h-6 w-6 rounded" />
+                    ) : (
+                      <div className="h-6 w-6 rounded bg-white/10" />
+                    )}
+                    <div>
+                      <p className="text-sm font-bold">{wallet.name}</p>
+                      <p className="text-[11px] text-muted">
+                        {wallet.isAvailable ? 'Detected on this device' : 'Not available'}
+                      </p>
+                    </div>
+                  </div>
+                  {isConnecting && <span className="text-xs text-muted">Connecting…</span>}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## What changed
Implemented a first-class wallet connection UX for supported wallets:
Added an in-app wallet selection modal in WalletProvider.
Detects wallet availability from Stellar Wallets Kit and limits choices to:
Freighter
LOBSTR
Updated connection lifecycle behavior:
connect() now loads wallet options and opens the selection modal.
Selecting a wallet sets wallet provider in kit and requests address.
disconnect() clears session state and calls wallet kit disconnect.
Improved session persistence:
Persist selected wallet ID in local storage (payd:last_wallet_name).
On reload, provider restores prior wallet selection and attempts silent reconnect.
Added wallet status visibility in navigation:
AppNav now shows connection state, selected wallet name, and truncated address (or not-connected state).
## Files changed
frontend/src/providers/WalletProvider.tsx
frontend/src/components/AppNav.tsx
Why
This fulfills the wallet UX requirements with a consistent product-level modal and robust connect/disconnect/session restore behavior, instead of relying solely on kit default modal handling.
Acceptance criteria mapping
Wallet selection modal implemented
✅ Added modal with explicit wallet choices and availability status.
Connection lifecycle hooks functional
✅ Connect/disconnect logic implemented and wired through existing wallet context.
Displays connected wallet address or status in UI
✅ Nav shows connected wallet name/address and connecting/not-connected states.
Persists wallet connection session across reloads
✅ Last selected wallet is stored and used to restore session on app init.
Validation
Local frontend checks run:
npm run lint (warnings only, no errors)
npx prettier . --check (pass after formatting)
npm run build (pass)
Edited files lint-clean via targeted checks.

closes #27 