### PR TITLE
feat(backend): add ORGUSD preflight balance check Before Payroll execution

### DIFF
--- a/backend/src/workers/payrollWorker.ts
+++ b/backend/src/workers/payrollWorker.ts
@@ -5,6 +5,8 @@ import { PayrollJobData } from '../services/payrollQueueService.js';
 import { StellarService } from '../services/stellarService.js';
 import { PayrollAuditService } from '../services/payrollAuditService.js';
 import { emitBulkUpdate } from '../services/socketService.js';
+import { BalanceService } from '../services/balanceService.js';
+import { webhookNotificationService } from '../services/webhookNotificationService.js';
 import taxService from '../services/taxService.js';
 import logger from '../utils/logger.js';
 import { Keypair, Asset, Operation, TransactionBuilder } from '@stellar/stellar-sdk';
@@ -43,6 +45,59 @@ export const payrollWorker = new Worker<PayrollJobData>(
             const assetCode = payroll_run.asset_code;
             // In a real app, you'd get the issuer from the DB or config based on organization
             const assetIssuer = process.env.ORGUSD_ISSUER_PUBLIC;
+
+            // 2a. Preflight balance check before execution for ORGUSD payroll runs.
+            if (assetCode === 'ORGUSD') {
+                if (!assetIssuer) {
+                    throw new Error('ORGUSD_ISSUER_PUBLIC not configured on server');
+                }
+
+                const preflightPayments = items.map((item) => ({
+                    employeeId: String(item.employee_id),
+                    employeeName:
+                        `${item.employee_first_name ?? ''} ${item.employee_last_name ?? ''}`.trim() ||
+                        item.employee_email ||
+                        `Employee #${item.employee_id}`,
+                    walletAddress: item.employee_wallet_address || 'N/A',
+                    amount: item.amount,
+                }));
+
+                const preflightResult = await BalanceService.preflightCheck(
+                    distributionKeypair.publicKey(),
+                    assetIssuer,
+                    preflightPayments
+                );
+
+                if (!preflightResult.sufficient) {
+                    const shortfallReport = {
+                        payrollRunId,
+                        batchId,
+                        organizationId: payroll_run.organization_id,
+                        generatedAt: new Date().toISOString(),
+                        ...preflightResult,
+                    };
+
+                    await webhookNotificationService.dispatch(
+                        'balance.low',
+                        {
+                            message: 'Payroll aborted due to insufficient ORGUSD distribution balance.',
+                            shortfallReport,
+                        },
+                        payroll_run.organization_id
+                    );
+
+                    emitBulkUpdate(batchId, 'failed', {
+                        error: 'Insufficient ORGUSD balance. Payroll aborted before execution.',
+                        shortfallReport,
+                    });
+
+                    throw new Error(
+                        `Insufficient ORGUSD balance for payroll run ${payrollRunId}. ` +
+                            `Required: ${preflightResult.totalRequired}, Available: ${preflightResult.availableBalance}, ` +
+                            `Shortfall: ${preflightResult.shortfall}`
+                    );
+                }
+            }
 
             const asset = assetCode === 'XLM'
                 ? Asset.native()


### PR DESCRIPTION
This pull request introduces a preflight balance check for ORGUSD payroll runs in the `payrollWorker` to prevent payroll execution when the distribution wallet has insufficient funds. It also adds notification and reporting mechanisms for low balance situations. The most important changes are:

**Payroll Execution Safeguards:**

* Added a preflight balance check using `BalanceService.preflightCheck` before executing ORGUSD payroll runs to ensure the distribution wallet has sufficient funds. If the balance is insufficient, the payroll run is aborted before any transactions are attempted.
* If the preflight check fails, a detailed shortfall report is generated, and the payroll run is marked as failed with an appropriate error message and report.

**Notifications and Reporting:**

* Integrated `webhookNotificationService` to dispatch a `balance.low` webhook notification, including the shortfall report, to alert the organization of insufficient funds.

**Dependency Updates:**

* Imported `BalanceService` and `webhookNotificationService` into `payrollWorker.ts` to support the new balance check and notification features.


### Acceptance Criteria
- [x] Preflight balance check implemented before payroll execution  
- [x] Payroll aborts if balance is insufficient  
- [x] Shortfall report generated and sent to the employer  


closes #193 