### PR TITLE
feat: network switcher, breadcrumbs, version badge, and table row hover effects

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -5,6 +5,13 @@ import AppNav from './AppNav';
 import { LanguageSelector } from './LanguageSelector';
 import { ThemeToggle } from './ThemeToggle';
 import { useTranslation } from 'react-i18next';
+import { Breadcrumb } from './Breadcrumb';
+import { NetworkSwitcher } from './NetworkSwitcher';
+import { useNetworkStore } from '../stores/networkStore';
+
+const APP_VERSION =
+  (import.meta.env.PUBLIC_APP_VERSION as string | undefined)?.trim() ?? '0.0.1';
+const APP_ENV = import.meta.env.MODE;
 
 // ── Page Wrapper ───────────────────────
 const PageWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -15,6 +22,7 @@ const PageWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 const AppLayout: React.FC = () => {
   const location = useLocation();
   useTranslation();
+  const { network } = useNetworkStore();
 
   return (
     <div
@@ -46,6 +54,7 @@ const AppLayout: React.FC = () => {
         <div className="flex items-center gap-6 ml-auto">
           <AppNav />
           <div className="ml-4 flex items-center gap-3">
+            <NetworkSwitcher />
             <LanguageSelector />
             <ThemeToggle />
             <ConnectAccount />
@@ -57,6 +66,7 @@ const AppLayout: React.FC = () => {
       <main className="flex flex-col flex-1 pt-(--header-h)">
         <PageWrapper>
           <div key={location.pathname} className="flex flex-col flex-1 px-6 py-8">
+            <Breadcrumb />
             <Outlet />
           </div>
         </PageWrapper>
@@ -78,9 +88,32 @@ const AppLayout: React.FC = () => {
             Apache License 2.0
           </a>
         </span>
-        <div className="flex items-center gap-1.5">
-          <div className="w-1.5 h-1.5 rounded-full bg-(--accent) shadow-[0_0_6px_var(--accent)]" />
-          STELLAR NETWORK · MAINNET
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className="px-1.5 py-0.5 rounded border text-[10px] uppercase tracking-widest"
+            style={{ borderColor: 'var(--border-hi)' }}
+            aria-label={`App version ${APP_VERSION}`}
+          >
+            v{APP_VERSION}
+          </span>
+          <span
+            className={`px-1.5 py-0.5 rounded border text-[10px] uppercase tracking-widest ${
+              APP_ENV === 'production'
+                ? 'border-green-500/40 text-green-500'
+                : 'border-yellow-500/40 text-yellow-500'
+            }`}
+            aria-label={`Environment: ${APP_ENV}`}
+          >
+            {APP_ENV === 'production' ? 'production' : APP_ENV === 'staging' ? 'staging' : 'dev'}
+          </span>
+          <div className="flex items-center gap-1.5" aria-label={`Connected to Stellar ${network}`}>
+            <div
+              className={`w-1.5 h-1.5 rounded-full shadow-[0_0_6px_var(--accent)] ${
+                network === 'TESTNET' ? 'bg-yellow-500' : 'bg-(--accent)'
+              }`}
+            />
+            STELLAR · {network}
+          </div>
         </div>
       </footer>
     </div>

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { ChevronRight } from 'lucide-react';
+
+const ROUTE_LABELS: Record<string, string> = {
+  employer: 'Employer',
+  payroll: 'Payroll',
+  employee: 'Employees',
+  analytics: 'Analytics',
+  reports: 'Reports',
+  'bulk-upload': 'Bulk Upload',
+  'cross-asset-payment': 'Cross-Asset Payment',
+  transactions: 'Transactions',
+  'revenue-split': 'Revenue Split',
+  settings: 'Settings',
+  help: 'Help Center',
+  debug: 'Debugger',
+  admin: 'Admin',
+  portal: 'Employee Portal',
+  rewards: 'Rewards',
+};
+
+const EXCLUDED_PREFIXES = ['/login', '/auth-callback'];
+
+interface Crumb {
+  label: string;
+  href: string;
+}
+
+export function buildCrumbs(pathname: string): Crumb[] {
+  const segments = pathname.split('/').filter(Boolean);
+  const crumbs: Crumb[] = [{ label: 'Home', href: '/' }];
+
+  let accumulated = '';
+  for (const segment of segments) {
+    accumulated += `/${segment}`;
+    const label =
+      ROUTE_LABELS[segment] ?? segment.charAt(0).toUpperCase() + segment.slice(1);
+    crumbs.push({ label, href: accumulated });
+  }
+
+  return crumbs;
+}
+
+export const Breadcrumb: React.FC = () => {
+  const { pathname } = useLocation();
+
+  if (EXCLUDED_PREFIXES.some((p) => pathname.startsWith(p))) return null;
+
+  const crumbs = buildCrumbs(pathname);
+
+  if (crumbs.length <= 1) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex items-center gap-1 text-xs"
+      style={{ color: 'var(--muted)' }}
+    >
+      {crumbs.map((crumb, i) => {
+        const isLast = i === crumbs.length - 1;
+        return (
+          <React.Fragment key={crumb.href}>
+            {i > 0 && (
+              <ChevronRight className="h-3 w-3 shrink-0 opacity-50" aria-hidden />
+            )}
+            {isLast ? (
+              <span
+                className="font-medium"
+                style={{ color: 'var(--text)' }}
+                aria-current="page"
+              >
+                {crumb.label}
+              </span>
+            ) : (
+              <Link
+                to={crumb.href}
+                className="transition-colors hover:underline"
+                style={{ color: 'var(--muted)' }}
+              >
+                {crumb.label}
+              </Link>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </nav>
+  );
+};

--- a/frontend/src/components/EmployeeList.tsx
+++ b/frontend/src/components/EmployeeList.tsx
@@ -197,7 +197,10 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
             </tr>
           ) : (
             sortedEmployees.map((employee) => (
-              <tr key={employee.id} className="cursor-pointer transition">
+              <tr
+                key={employee.id}
+                className="cursor-pointer transition-colors hover:bg-white/5"
+              >
                 <td className="p-6">
                   <div className="flex items-center gap-3">
                     <Avatar

--- a/frontend/src/components/EmployerLayout.tsx
+++ b/frontend/src/components/EmployerLayout.tsx
@@ -19,6 +19,8 @@ import { LanguageSelector } from './LanguageSelector';
 import { ThemeToggle } from './ThemeToggle';
 import ErrorBoundary from './ErrorBoundary';
 import ErrorFallback from './ErrorFallback';
+import { Breadcrumb } from './Breadcrumb';
+import { NetworkSwitcher } from './NetworkSwitcher';
 import { useNativeXlmBalance } from '../hooks/useNativeXlmBalance';
 import { useWallet } from '../hooks/useWallet';
 
@@ -156,9 +158,7 @@ const EmployerLayout: React.FC = () => {
               <Heading as="h1" size="md" weight="bold" addlClassName="truncate tracking-tight">
                 {ORG_NAME}
               </Heading>
-              <Text as="p" size="xs" addlClassName="text-[var(--muted)] truncate">
-                Employer dashboard
-              </Text>
+              <Breadcrumb />
             </div>
           </div>
 
@@ -179,6 +179,7 @@ const EmployerLayout: React.FC = () => {
                 {!address ? 'Connect wallet' : balanceLoading ? '…' : formatXlm(xlmBalance ?? null)}
               </span>
             </div>
+            <NetworkSwitcher />
             <LanguageSelector />
             <ThemeToggle />
             <ConnectAccount />

--- a/frontend/src/components/NetworkSwitcher.tsx
+++ b/frontend/src/components/NetworkSwitcher.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useNetworkStore, type StellarNetwork } from '../stores/networkStore';
+
+export const NetworkSwitcher: React.FC = () => {
+  const { network, setNetwork } = useNetworkStore();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setNetwork(e.target.value as StellarNetwork);
+  };
+
+  const isTestnet = network === 'TESTNET';
+
+  return (
+    <div role="group" aria-label="Stellar network selector">
+      <select
+        value={network}
+        onChange={handleChange}
+        aria-label="Select Stellar network"
+        title="Switch Stellar network"
+        className={[
+          'text-[10px] font-mono font-bold uppercase tracking-widest',
+          'px-2 py-1 rounded border bg-transparent cursor-pointer',
+          'focus:outline-none transition-colors',
+          isTestnet
+            ? 'border-yellow-500/50 text-yellow-500 hover:border-yellow-400'
+            : 'border-(--accent)/50 text-(--accent) hover:border-(--accent)',
+        ].join(' ')}
+      >
+        <option value="TESTNET" className="bg-(--bg) text-(--text)">
+          Testnet
+        </option>
+        <option value="MAINNET" className="bg-(--bg) text-(--text)">
+          Mainnet
+        </option>
+      </select>
+    </div>
+  );
+};

--- a/frontend/src/components/__tests__/AppLayoutFooter.test.tsx
+++ b/frontend/src/components/__tests__/AppLayoutFooter.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import AppLayout from '../AppLayout';
+
+// Stub out all heavy dependencies so we can test just the footer markup
+vi.mock('../ConnectAccount', () => ({ default: () => <div>Connect</div> }));
+vi.mock('./AppNav', () => ({ default: () => null }));
+vi.mock('../AppNav', () => ({ default: () => null }));
+vi.mock('../LanguageSelector', () => ({ LanguageSelector: () => null }));
+vi.mock('../ThemeToggle', () => ({ ThemeToggle: () => null }));
+vi.mock('../NetworkSwitcher', () => ({ NetworkSwitcher: () => null }));
+vi.mock('../Breadcrumb', () => ({ Breadcrumb: () => null }));
+vi.mock('../../stores/networkStore', () => ({
+  useNetworkStore: () => ({ network: 'MAINNET', setNetwork: vi.fn() }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}));
+
+describe('AppLayout footer', () => {
+  test('renders a version badge starting with "v"', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AppLayout />
+      </MemoryRouter>
+    );
+
+    // The version badge text matches /^v\d+\.\d+\.\d+/ (e.g. "v0.0.1")
+    const badge = screen.getByLabelText(/app version/i);
+    expect(badge.textContent).toMatch(/^v\d/);
+  });
+
+  test('renders an environment badge', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AppLayout />
+      </MemoryRouter>
+    );
+
+    const envBadge = screen.getByLabelText(/environment/i);
+    expect(envBadge).toBeInTheDocument();
+    // In test mode, MODE is 'test' which resolves to 'dev' label
+    expect(envBadge.textContent).toBeTruthy();
+  });
+
+  test('renders Stellar network indicator with current network', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AppLayout />
+      </MemoryRouter>
+    );
+
+    const networkIndicator = screen.getByLabelText(/connected to stellar/i);
+    expect(networkIndicator).toBeInTheDocument();
+    expect(networkIndicator.textContent).toContain('MAINNET');
+  });
+
+  test('renders the Apache License link', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AppLayout />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: /apache license/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/Breadcrumb.test.tsx
+++ b/frontend/src/components/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { Breadcrumb, buildCrumbs } from '../Breadcrumb';
+
+// ── pure-function unit tests (no DOM needed) ──────────────────────────────
+
+describe('buildCrumbs', () => {
+  test('returns only Home for root path', () => {
+    const crumbs = buildCrumbs('/');
+    expect(crumbs).toHaveLength(1);
+    expect(crumbs[0]).toEqual({ label: 'Home', href: '/' });
+  });
+
+  test('builds two crumbs for a single-segment path', () => {
+    const crumbs = buildCrumbs('/settings');
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[1]).toEqual({ label: 'Settings', href: '/settings' });
+  });
+
+  test('builds three crumbs for nested employer route', () => {
+    const crumbs = buildCrumbs('/employer/payroll');
+    expect(crumbs).toHaveLength(3);
+    expect(crumbs[1]).toEqual({ label: 'Employer', href: '/employer' });
+    expect(crumbs[2]).toEqual({ label: 'Payroll', href: '/employer/payroll' });
+  });
+
+  test('uses slug as label for unknown segments', () => {
+    const crumbs = buildCrumbs('/unknown-page');
+    expect(crumbs[1].label).toBe('Unknown-page');
+  });
+
+  test('maps all known route labels correctly', () => {
+    const cases: Array<[string, string]> = [
+      ['/employer/employee', 'Employees'],
+      ['/employer/analytics', 'Analytics'],
+      ['/employer/bulk-upload', 'Bulk Upload'],
+      ['/employer/cross-asset-payment', 'Cross-Asset Payment'],
+      ['/employer/transactions', 'Transactions'],
+      ['/employer/revenue-split', 'Revenue Split'],
+      ['/employer/reports', 'Reports'],
+      ['/help', 'Help Center'],
+    ];
+    for (const [path, label] of cases) {
+      const crumbs = buildCrumbs(path);
+      expect(crumbs[crumbs.length - 1].label).toBe(label);
+    }
+  });
+});
+
+// ── component rendering tests ─────────────────────────────────────────────
+
+describe('Breadcrumb component', () => {
+  test('renders nothing on root path', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <Breadcrumb />
+      </MemoryRouter>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders nothing on excluded login path', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/login']}>
+        <Breadcrumb />
+      </MemoryRouter>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders breadcrumb nav for /settings', () => {
+    render(
+      <MemoryRouter initialEntries={['/settings']}>
+        <Breadcrumb />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('navigation', { name: /breadcrumb/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  test('current page segment has aria-current="page"', () => {
+    render(
+      <MemoryRouter initialEntries={['/settings']}>
+        <Breadcrumb />
+      </MemoryRouter>
+    );
+    const current = screen.getByText('Settings');
+    expect(current).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('renders correct links for /employer/payroll', () => {
+    render(
+      <MemoryRouter initialEntries={['/employer/payroll']}>
+        <Breadcrumb />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /home/i })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: /employer/i })).toHaveAttribute(
+      'href',
+      '/employer'
+    );
+    expect(screen.getByText('Payroll')).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/frontend/src/components/__tests__/EmployeeListHover.test.tsx
+++ b/frontend/src/components/__tests__/EmployeeListHover.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { EmployeeList } from '../EmployeeList';
+
+vi.mock('../Avatar', () => ({
+  Avatar: ({ name }: { name: string }) => <div data-testid="avatar">{name}</div>,
+}));
+vi.mock('../AvatarUpload', () => ({ AvatarUpload: () => null }));
+vi.mock('../CSVUploader', () => ({ CSVUploader: () => null }));
+vi.mock('../EmployeeRemovalConfirmModal', () => ({
+  EmployeeRemovalConfirmModal: () => null,
+}));
+
+const employee = {
+  id: 'emp-hover-1',
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  position: 'Engineer',
+  wallet: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE',
+  salary: 5000,
+  status: 'Active' as const,
+};
+
+describe('EmployeeList row hover effects', () => {
+  test('data rows include hover background class', () => {
+    const { container } = render(
+      <EmployeeList employees={[employee]} onAddEmployee={vi.fn()} />
+    );
+
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows.length).toBeGreaterThan(0);
+
+    rows.forEach((row) => {
+      expect(row.className).toContain('hover:bg-white/5');
+    });
+  });
+
+  test('data rows include transition class for smooth hover animation', () => {
+    const { container } = render(
+      <EmployeeList employees={[employee]} onAddEmployee={vi.fn()} />
+    );
+
+    const rows = container.querySelectorAll('tbody tr');
+    rows.forEach((row) => {
+      expect(row.className).toMatch(/transition/);
+    });
+  });
+});

--- a/frontend/src/components/__tests__/NetworkSwitcher.test.tsx
+++ b/frontend/src/components/__tests__/NetworkSwitcher.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { NetworkSwitcher } from '../NetworkSwitcher';
+
+// Use a closure variable so we can change the mocked network between tests
+// without hitting Zustand's persist middleware (which requires localStorage).
+const mockSetNetwork = vi.fn();
+let mockedNetwork: 'MAINNET' | 'TESTNET' = 'MAINNET';
+
+vi.mock('../../stores/networkStore', () => ({
+  useNetworkStore: () => ({
+    get network() {
+      return mockedNetwork;
+    },
+    setNetwork: mockSetNetwork,
+  }),
+}));
+
+describe('NetworkSwitcher', () => {
+  beforeEach(() => {
+    mockSetNetwork.mockClear();
+    mockedNetwork = 'MAINNET';
+  });
+
+  test('renders a select element with an accessible label', () => {
+    render(<NetworkSwitcher />);
+    expect(
+      screen.getByRole('combobox', { name: /select stellar network/i })
+    ).toBeInTheDocument();
+  });
+
+  test('shows MAINNET as the default selected option', () => {
+    render(<NetworkSwitcher />);
+    const select = screen.getByRole<HTMLSelectElement>('combobox', {
+      name: /select stellar network/i,
+    });
+    expect(select.value).toBe('MAINNET');
+  });
+
+  test('shows both Testnet and Mainnet options', () => {
+    render(<NetworkSwitcher />);
+    expect(screen.getByRole('option', { name: /testnet/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /mainnet/i })).toBeInTheDocument();
+  });
+
+  test('calls setNetwork with TESTNET when user switches to Testnet', async () => {
+    const user = userEvent.setup();
+    render(<NetworkSwitcher />);
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: /select stellar network/i }),
+      'TESTNET'
+    );
+    expect(mockSetNetwork).toHaveBeenCalledOnce();
+    expect(mockSetNetwork).toHaveBeenCalledWith('TESTNET');
+  });
+
+  test('reflects TESTNET selection when store returns TESTNET', () => {
+    mockedNetwork = 'TESTNET';
+    render(<NetworkSwitcher />);
+    const select = screen.getByRole<HTMLSelectElement>('combobox', {
+      name: /select stellar network/i,
+    });
+    expect(select.value).toBe('TESTNET');
+  });
+
+  test('wraps select in a group with an accessible label', () => {
+    render(<NetworkSwitcher />);
+    expect(
+      screen.getByRole('group', { name: /stellar network selector/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/stores/networkStore.ts
+++ b/frontend/src/stores/networkStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type StellarNetwork = 'TESTNET' | 'MAINNET';
+
+function getDefaultNetwork(): StellarNetwork {
+  const env = (import.meta.env.PUBLIC_STELLAR_NETWORK as string | undefined)
+    ?.toUpperCase()
+    ?.trim();
+  return env === 'TESTNET' ? 'TESTNET' : 'MAINNET';
+}
+
+interface NetworkState {
+  network: StellarNetwork;
+  setNetwork: (network: StellarNetwork) => void;
+}
+
+export const useNetworkStore = create<NetworkState>()(
+  persist(
+    (set) => ({
+      network: getDefaultNetwork(),
+      setNetwork: (network) => set({ network }),
+    }),
+    { name: 'payd-network' }
+  )
+);


### PR DESCRIPTION
## Summary

This PR resolves four frontend UI enhancement issues:

- **Network Switcher (#387)** — A `NetworkSwitcher` component (select dropdown) lets developers toggle between Testnet and Mainnet directly from the header in both `AppLayout` and `EmployerLayout`. Network preference is persisted via a Zustand store (`payd-network` localStorage key) and defaults to the `PUBLIC_STELLAR_NETWORK` env var. The footer's network indicator (dot + label) is now dynamic and reflects the active selection.

- **Breadcrumbs (#370)** — A `Breadcrumb` component uses `useLocation` to build a `Home > Section > Page` trail for all nested routes. It is excluded from `/login` and `/auth-callback`. Integrated into `AppLayout`'s main content area and `EmployerLayout`'s top-bar (replacing the static "Employer dashboard" subtitle).

- **Version Badge in Footer (#396)** — The footer in `AppLayout` now displays a version badge (`PUBLIC_APP_VERSION` env var, fallback `0.0.1`) and a colour-coded environment badge (`import.meta.env.MODE` → `production` / `staging` / `dev`). Both badges have `aria-label` attributes for accessibility.

- **Table Row Hover Effects (#372)** — Employee table rows in `EmployeeList` now have `hover:bg-white/5` and `transition-colors` for clear row tracking on hover.

## New files

| File | Purpose |
|---|---|
| `src/components/Breadcrumb.tsx` | Breadcrumb nav component |
| `src/components/NetworkSwitcher.tsx` | Network toggle UI component |
| `src/stores/networkStore.ts` | Zustand persist store for network preference |
| `src/components/__tests__/Breadcrumb.test.tsx` | 10 tests (pure-function + render) |
| `src/components/__tests__/NetworkSwitcher.test.tsx` | 6 tests |
| `src/components/__tests__/AppLayoutFooter.test.tsx` | 4 tests (version badge, env badge, network indicator) |
| `src/components/__tests__/EmployeeListHover.test.tsx` | 2 tests |

**22 new passing tests added. No regressions introduced.**

## Test plan

- [ ] Run `npm test` in `frontend/` — all new tests pass, pre-existing suite unchanged
- [ ] Visit `/employer/payroll` — breadcrumb shows `Home > Employer > Payroll`
- [ ] Visit `/settings` — breadcrumb shows `Home > Settings`
- [ ] Switch network in header dropdown — footer dot and label update accordingly
- [ ] Hover over employee table rows — subtle background highlight appears
- [ ] Footer shows version badge (`v0.0.1`) and environment badge (`dev` in development)

closes #387
closes #396
closes #372
closes #370