### PR TITLE
feat(#355): add detailed audit log for organization changes

### DIFF
--- a/backend/src/__tests__/orgAuditService.test.ts
+++ b/backend/src/__tests__/orgAuditService.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for OrgAuditService
+ *
+ * Uses a mock pg Pool so no real database connection is required.
+ */
+
+import { OrgAuditService } from '../services/orgAuditService.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePool(queryResult: { rows: unknown[]; rowCount?: number }) {
+  return {
+    query: jest.fn().mockResolvedValue(queryResult),
+  } as unknown as import('pg').Pool;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OrgAuditService', () => {
+  describe('log()', () => {
+    it('inserts a row with the correct parameters', async () => {
+      const mockRow = { id: '1', organization_id: 42, change_type: 'setting_upserted' };
+      const mockPool = makePool({ rows: [mockRow] });
+      const service = new OrgAuditService(mockPool);
+
+      const result = await service.log({
+        organizationId: 42,
+        changeType: 'setting_upserted',
+        configKey: 'payment_settings',
+        oldValue: { currency: 'USD' },
+        newValue: { currency: 'EUR' },
+        actorId: 7,
+        actorEmail: 'admin@example.com',
+        actorIp: '127.0.0.1',
+      });
+
+      expect(mockPool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = (mockPool.query as jest.Mock).mock.calls[0];
+      expect(sql).toContain('INSERT INTO org_audit_log');
+      expect(params[0]).toBe(42);                           // organizationId
+      expect(params[1]).toBe('setting_upserted');           // changeType
+      expect(params[2]).toBe('payment_settings');           // configKey
+      expect(JSON.parse(params[3])).toEqual({ currency: 'USD' }); // oldValue
+      expect(JSON.parse(params[4])).toEqual({ currency: 'EUR' }); // newValue
+      expect(params[5]).toBe(7);                            // actorId
+      expect(params[6]).toBe('admin@example.com');          // actorEmail
+      expect(result).toEqual(mockRow);
+    });
+
+    it('returns null and does not throw when the insert fails', async () => {
+      const mockPool = {
+        query: jest.fn().mockRejectedValue(new Error('DB error')),
+      } as unknown as import('pg').Pool;
+      const service = new OrgAuditService(mockPool);
+
+      const result = await service.log({ organizationId: 1, changeType: 'name_updated' });
+      expect(result).toBeNull();
+    });
+
+    it('stores null config_key when not provided', async () => {
+      const mockPool = makePool({ rows: [{ id: '2' }] });
+      const service = new OrgAuditService(mockPool);
+
+      await service.log({ organizationId: 1, changeType: 'name_updated', newValue: 'Acme' });
+
+      const params = (mockPool.query as jest.Mock).mock.calls[0][1];
+      expect(params[2]).toBeNull(); // configKey
+    });
+  });
+
+  describe('list()', () => {
+    it('returns rows and total count', async () => {
+      const mockRows = [
+        { id: '1', organization_id: 10, change_type: 'setting_upserted', created_at: '2025-01-01' },
+      ];
+      const mockPool = {
+        query: jest
+          .fn()
+          .mockResolvedValueOnce({ rows: mockRows })   // data query
+          .mockResolvedValueOnce({ rows: [{ count: '1' }] }), // count query
+      } as unknown as import('pg').Pool;
+      const service = new OrgAuditService(mockPool);
+
+      const { rows, total } = await service.list(10);
+      expect(rows).toEqual(mockRows);
+      expect(total).toBe(1);
+    });
+
+    it('caps limit at 200', async () => {
+      const mockPool = {
+        query: jest
+          .fn()
+          .mockResolvedValue({ rows: [] }),
+      } as unknown as import('pg').Pool;
+      const service = new OrgAuditService(mockPool);
+
+      await service.list(1, { limit: 9999 });
+      const params = (mockPool.query as jest.Mock).mock.calls[0][1];
+      expect(params[1]).toBe(200);
+    });
+  });
+});

--- a/backend/src/controllers/tenantConfigController.ts
+++ b/backend/src/controllers/tenantConfigController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import tenantConfigService from '../services/tenantConfigService.js';
+import { orgAuditService } from '../services/orgAuditService.js';
 
 const upsertSchema = z.object({
   configKey: z.string().min(1).max(100),
@@ -46,12 +47,29 @@ export class TenantConfigController {
         return res.status(403).json({ error: 'User is not associated with an organization' });
       }
       const { configKey, configValue, description } = upsertSchema.parse(req.body);
+
+      // Capture old value for audit diff
+      const oldValue = await tenantConfigService.getConfig(organizationId, configKey);
+
       const updated = await tenantConfigService.setConfig(
         organizationId,
         configKey,
         configValue,
         description
       );
+
+      // Fire-and-forget audit log (errors must not break the response)
+      void orgAuditService.log({
+        organizationId,
+        changeType: 'setting_upserted',
+        configKey,
+        oldValue: oldValue ?? undefined,
+        newValue: configValue,
+        actorId: req.user?.id,
+        actorEmail: req.user?.email,
+        actorIp: req.ip,
+      });
+
       return res.status(200).json({ success: true, data: updated });
     } catch (error) {
       if (error instanceof z.ZodError) {
@@ -69,8 +87,23 @@ export class TenantConfigController {
         return res.status(403).json({ error: 'User is not associated with an organization' });
       }
       const configKey = req.params.configKey as string;
+
+      // Capture old value for audit diff before deleting
+      const oldValue = await tenantConfigService.getConfig(organizationId, configKey);
+
       const deleted = await tenantConfigService.deleteConfig(organizationId, configKey);
       if (!deleted) return res.status(404).json({ error: 'Configuration not found' });
+
+      void orgAuditService.log({
+        organizationId,
+        changeType: 'setting_deleted',
+        configKey,
+        oldValue: oldValue ?? undefined,
+        actorId: req.user?.id,
+        actorEmail: req.user?.email,
+        actorIp: req.ip,
+      });
+
       return res.status(204).send();
     } catch (error) {
       console.error('delete tenant config error:', error);

--- a/backend/src/db/migrations/027_create_org_audit_log.sql
+++ b/backend/src/db/migrations/027_create_org_audit_log.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- Migration 027: Organization Audit Log
+-- Purpose : Dedicated, append-only table that records every change made to an
+--           organization's name, settings (tenant_configurations), or issuer
+--           account.  Kept separate from the generic audit_logs table so that
+--           compliance queries targeting org-level data stay fast and clear.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS org_audit_log (
+  id              BIGSERIAL PRIMARY KEY,
+
+  -- Which organization was changed
+  organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+  -- What kind of change occurred
+  -- Allowed values: 'name_updated' | 'setting_upserted' | 'setting_deleted'
+  --                 | 'issuer_updated' | 'org_created' | 'org_deleted'
+  change_type     VARCHAR(50) NOT NULL,
+
+  -- The config key that was changed (NULL for name / issuer changes)
+  config_key      VARCHAR(100),
+
+  -- JSON snapshots of the value before and after the change
+  old_value       JSONB,
+  new_value       JSONB,
+
+  -- Who made the change
+  actor_id        INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  actor_email     VARCHAR(255),
+  actor_ip        INET,
+
+  -- When the change happened (immutable)
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Enforce append-only semantics: no UPDATE or DELETE on existing rows
+CREATE RULE org_audit_log_no_update AS ON UPDATE TO org_audit_log DO INSTEAD NOTHING;
+CREATE RULE org_audit_log_no_delete AS ON DELETE TO org_audit_log DO INSTEAD NOTHING;
+
+-- Index for the most common query patterns
+CREATE INDEX IF NOT EXISTS idx_org_audit_log_org       ON org_audit_log (organization_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_org_audit_log_actor     ON org_audit_log (actor_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_org_audit_log_type      ON org_audit_log (change_type, created_at DESC);
+
+COMMENT ON TABLE  org_audit_log IS
+  'Append-only log of every change made to an organization''s name, settings, or issuer account.';
+COMMENT ON COLUMN org_audit_log.change_type IS
+  'Classifies the kind of change: name_updated, setting_upserted, setting_deleted, issuer_updated, org_created, org_deleted.';
+COMMENT ON COLUMN org_audit_log.config_key IS
+  'The tenant_configurations key that was changed; NULL for name/issuer changes.';

--- a/backend/src/routes/orgAuditRoutes.ts
+++ b/backend/src/routes/orgAuditRoutes.ts
@@ -1,0 +1,38 @@
+import { Router, Request, Response } from 'express';
+import authenticateJWT from '../middlewares/auth.js';
+import { authorizeRoles, isolateOrganization } from '../middlewares/rbac.js';
+import { orgAuditService } from '../services/orgAuditService.js';
+
+const router = Router();
+
+router.use(authenticateJWT);
+router.use(authorizeRoles('EMPLOYER'));
+router.use(isolateOrganization);
+
+/**
+ * GET /api/org-audit
+ * Returns paginated organization audit log entries for the authenticated org.
+ *
+ * Query params:
+ *   limit  – max rows per page (default 50, max 200)
+ *   offset – rows to skip (default 0)
+ */
+router.get('/', async (req: Request, res: Response) => {
+  try {
+    const organizationId = req.user?.organizationId;
+    if (!organizationId) {
+      return res.status(403).json({ error: 'User is not associated with an organization' });
+    }
+
+    const limit = Math.min(parseInt(String(req.query.limit ?? '50'), 10) || 50, 200);
+    const offset = Math.max(parseInt(String(req.query.offset ?? '0'), 10) || 0, 0);
+
+    const { rows, total } = await orgAuditService.list(organizationId, { limit, offset });
+    return res.status(200).json({ success: true, data: rows, total, limit, offset });
+  } catch (err) {
+    console.error('org-audit list error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+export default router;

--- a/backend/src/services/orgAuditService.ts
+++ b/backend/src/services/orgAuditService.ts
@@ -1,0 +1,112 @@
+/**
+ * orgAuditService
+ *
+ * Writes append-only records to the org_audit_log table whenever an
+ * organization's name, tenant settings, or issuer account changes.
+ *
+ * All methods are fire-and-forget safe: errors are logged but never
+ * re-thrown so that a logging failure cannot break the main request path.
+ */
+
+import { Pool } from 'pg';
+import { pool } from '../config/database.js';
+
+export type OrgChangeType =
+  | 'name_updated'
+  | 'setting_upserted'
+  | 'setting_deleted'
+  | 'issuer_updated'
+  | 'org_created'
+  | 'org_deleted';
+
+export interface OrgAuditEntry {
+  organizationId: number;
+  changeType: OrgChangeType;
+  configKey?: string;
+  oldValue?: unknown;
+  newValue?: unknown;
+  actorId?: number;
+  actorEmail?: string;
+  actorIp?: string;
+}
+
+export interface OrgAuditRow {
+  id: string;
+  organization_id: number;
+  change_type: string;
+  config_key: string | null;
+  old_value: unknown;
+  new_value: unknown;
+  actor_id: number | null;
+  actor_email: string | null;
+  actor_ip: string | null;
+  created_at: string;
+}
+
+export class OrgAuditService {
+  constructor(private readonly db: Pool = pool) {}
+
+  /**
+   * Append a single entry to the org_audit_log table.
+   * Returns the inserted row, or null if the insert failed.
+   */
+  async log(entry: OrgAuditEntry): Promise<OrgAuditRow | null> {
+    const query = `
+      INSERT INTO org_audit_log
+        (organization_id, change_type, config_key, old_value, new_value,
+         actor_id, actor_email, actor_ip)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8::inet)
+      RETURNING *
+    `;
+
+    try {
+      const result = await this.db.query<OrgAuditRow>(query, [
+        entry.organizationId,
+        entry.changeType,
+        entry.configKey ?? null,
+        entry.oldValue !== undefined ? JSON.stringify(entry.oldValue) : null,
+        entry.newValue !== undefined ? JSON.stringify(entry.newValue) : null,
+        entry.actorId ?? null,
+        entry.actorEmail ?? null,
+        entry.actorIp ?? null,
+      ]);
+      return result.rows[0] ?? null;
+    } catch (err) {
+      console.error('[OrgAuditService] Failed to write audit log entry:', err);
+      return null;
+    }
+  }
+
+  /**
+   * Retrieve paginated audit log entries for an organization.
+   * Results are ordered newest-first.
+   */
+  async list(
+    organizationId: number,
+    options: { limit?: number; offset?: number } = {}
+  ): Promise<{ rows: OrgAuditRow[]; total: number }> {
+    const limit = Math.min(options.limit ?? 50, 200);
+    const offset = options.offset ?? 0;
+
+    const [dataResult, countResult] = await Promise.all([
+      this.db.query<OrgAuditRow>(
+        `SELECT * FROM org_audit_log
+         WHERE organization_id = $1
+         ORDER BY created_at DESC
+         LIMIT $2 OFFSET $3`,
+        [organizationId, limit, offset]
+      ),
+      this.db.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM org_audit_log WHERE organization_id = $1`,
+        [organizationId]
+      ),
+    ]);
+
+    return {
+      rows: dataResult.rows,
+      total: parseInt(countResult.rows[0]?.count ?? '0', 10),
+    };
+  }
+}
+
+export const orgAuditService = new OrgAuditService();

--- a/frontend/src/components/EmployeeList.tsx
+++ b/frontend/src/components/EmployeeList.tsx
@@ -20,6 +20,7 @@ interface Employee {
 
 interface EmployeeListProps {
   employees: Employee[];
+  isLoading?: boolean;
   onEmployeeClick?: (employee: Employee) => void;
   onAddEmployee: (employee: Employee) => void;
   onEditEmployee?: (employee: Employee) => void;
@@ -27,8 +28,49 @@ interface EmployeeListProps {
   onUpdateEmployeeImage?: (id: string, imageUrl: string) => void;
 }
 
+const SKELETON_ROW_COUNT = 5;
+
+const EmployeeSkeletonRow: React.FC = () => (
+  <tr className="animate-pulse border-b border-gray-200/20">
+    {/* Name column */}
+    <td className="p-6">
+      <div className="flex items-center gap-3">
+        <div className="w-8 h-8 rounded-full bg-gray-300/30 shrink-0" />
+        <div className="flex flex-col gap-1.5 flex-1 min-w-0">
+          <div className="h-2.5 rounded bg-gray-300/30 w-3/4" />
+          <div className="h-2 rounded bg-gray-300/20 w-1/2" />
+        </div>
+      </div>
+    </td>
+    {/* Role */}
+    <td className="p-6">
+      <div className="h-2.5 rounded bg-gray-300/30 w-2/3" />
+    </td>
+    {/* Wallet */}
+    <td className="p-6">
+      <div className="h-2.5 rounded bg-gray-300/20 w-3/4 font-mono" />
+    </td>
+    {/* Salary */}
+    <td className="p-6">
+      <div className="h-2.5 rounded bg-gray-300/30 w-1/2" />
+    </td>
+    {/* Status */}
+    <td className="p-6">
+      <div className="h-5 rounded-full bg-gray-300/20 w-16" />
+    </td>
+    {/* Actions */}
+    <td className="p-6">
+      <div className="flex gap-2">
+        <div className="w-5 h-5 rounded bg-gray-300/20" />
+        <div className="w-5 h-5 rounded bg-gray-300/20" />
+      </div>
+    </td>
+  </tr>
+);
+
 export const EmployeeList: React.FC<EmployeeListProps> = ({
   employees,
+  isLoading = false,
   onAddEmployee,
   onEditEmployee,
   onRemoveEmployee,
@@ -212,7 +254,11 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200">
-          {sortedEmployees.length === 0 ? (
+          {isLoading ? (
+            Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+              <EmployeeSkeletonRow key={i} />
+            ))
+          ) : sortedEmployees.length === 0 ? (
             <tr>
               <td colSpan={6} className="p-6 text-center text-gray-500">
                 {debouncedSearch ? `No employees match "${debouncedSearch}"` : 'No employees found'}

--- a/frontend/src/components/FeeEstimationPanel.tsx
+++ b/frontend/src/components/FeeEstimationPanel.tsx
@@ -12,6 +12,7 @@ import { useFeeEstimation } from '../hooks/useFeeEstimation';
 import type { BatchBudgetEstimate } from '../services/feeEstimation';
 import styles from './FeeEstimationPanel.module.css';
 import { useTranslation } from 'react-i18next';
+import { InfoTooltip } from './InfoTooltip';
 
 // ---------------------------------------------------------------------------
 // Sub‑components
@@ -141,7 +142,13 @@ export const FeeEstimationPanel: React.FC = () => {
               </div>
 
               <div className={styles.statRow}>
-                <span className={styles.statLabel}>{t('feeEstimation.lastLedger')}</span>
+                <span className={styles.statLabel}>
+                  {t('feeEstimation.lastLedger')}
+                  <InfoTooltip
+                    label="What is a Ledger Sequence?"
+                    content="The Ledger Sequence (or ledger number) identifies the latest confirmed block on the Stellar network. Each ledger closes roughly every 5 seconds and bundles a set of transactions. Higher numbers mean a more recent ledger."
+                  />
+                </span>
                 <span className={styles.statValue}>
                   #{feeRecommendation.lastLedger.toLocaleString()}
                 </span>

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -1,0 +1,68 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Info } from 'lucide-react';
+
+interface InfoTooltipProps {
+  /** The explanation text shown in the tooltip. */
+  content: string;
+  /** Optional accessible label for the trigger button. Defaults to "More information". */
+  label?: string;
+}
+
+/**
+ * A small ⓘ button that shows a descriptive tooltip when focused or hovered.
+ * Keyboard-accessible and screen-reader friendly.
+ */
+export const InfoTooltip: React.FC<InfoTooltipProps> = ({
+  content,
+  label = 'More information',
+}) => {
+  const [visible, setVisible] = useState(false);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Close tooltip on outside click
+  useEffect(() => {
+    if (!visible) return;
+    const handleClick = (e: MouseEvent) => {
+      if (
+        tooltipRef.current &&
+        !tooltipRef.current.contains(e.target as Node) &&
+        !triggerRef.current?.contains(e.target as Node)
+      ) {
+        setVisible(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [visible]);
+
+  return (
+    <span className="relative inline-flex items-center">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={label}
+        aria-expanded={visible}
+        aria-haspopup="true"
+        onClick={() => setVisible((v) => !v)}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        className="ml-1 rounded-full text-(--muted) hover:text-(--accent) focus:outline-none focus:ring-2 focus:ring-(--accent) transition"
+      >
+        <Info className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+
+      {visible && (
+        <div
+          ref={tooltipRef}
+          role="tooltip"
+          className="absolute left-5 top-0 z-50 w-64 rounded-lg border border-(--border-hi) bg-(--surface) p-3 text-xs text-(--text) shadow-lg"
+        >
+          {content}
+        </div>
+      )}
+    </span>
+  );
+};

--- a/frontend/src/components/__tests__/EmployeeList.test.tsx
+++ b/frontend/src/components/__tests__/EmployeeList.test.tsx
@@ -40,4 +40,24 @@ describe('EmployeeList', () => {
     expect(email).toHaveAttribute('title', employee.email);
     expect(email.className).toContain('truncate');
   });
+
+  test('renders skeleton rows and hides employee data while loading', () => {
+    render(<EmployeeList employees={[employee]} isLoading onAddEmployee={vi.fn()} />);
+
+    // Employee data must not be visible during loading
+    expect(screen.queryByLabelText(`Employee name: ${employee.name}`)).toBeNull();
+    expect(screen.queryByLabelText(`Employee email: ${employee.email}`)).toBeNull();
+
+    // Skeleton rows are rendered with pulse animation
+    const rows = document.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(5);
+    rows.forEach((row) => {
+      expect(row.className).toContain('animate-pulse');
+    });
+  });
+
+  test('renders empty state message when not loading and no employees exist', () => {
+    render(<EmployeeList employees={[]} isLoading={false} onAddEmployee={vi.fn()} />);
+    expect(screen.getByText('No employees found')).toBeTruthy();
+  });
 });

--- a/frontend/src/components/__tests__/InfoTooltip.test.tsx
+++ b/frontend/src/components/__tests__/InfoTooltip.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { InfoTooltip } from '../InfoTooltip';
+
+describe('InfoTooltip', () => {
+  test('does not show tooltip content initially', () => {
+    render(<InfoTooltip content="Test explanation" />);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  test('shows tooltip content on mouse enter', () => {
+    render(<InfoTooltip content="ORGUSD is the org asset" label="What is ORGUSD?" />);
+    const button = screen.getByRole('button', { name: 'What is ORGUSD?' });
+    fireEvent.mouseEnter(button);
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+    expect(screen.getByText('ORGUSD is the org asset')).toBeTruthy();
+  });
+
+  test('hides tooltip content on mouse leave', () => {
+    render(<InfoTooltip content="ORGUSD is the org asset" label="What is ORGUSD?" />);
+    const button = screen.getByRole('button', { name: 'What is ORGUSD?' });
+    fireEvent.mouseEnter(button);
+    fireEvent.mouseLeave(button);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  test('shows tooltip on focus and hides on blur', () => {
+    render(<InfoTooltip content="Ledger explanation" label="What is a Ledger?" />);
+    const button = screen.getByRole('button', { name: 'What is a Ledger?' });
+    fireEvent.focus(button);
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+    fireEvent.blur(button);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  test('uses default label when none provided', () => {
+    render(<InfoTooltip content="Some info" />);
+    expect(screen.getByRole('button', { name: 'More information' })).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -13,6 +13,7 @@ import { useNotification } from '../hooks/useNotification';
 import { useWallet } from '../hooks/useWallet';
 import ContractUpgradeTab from '../components/ContractUpgradeTab';
 import MultisigDetector from '../components/MultisigDetector';
+import { InfoTooltip } from '../components/InfoTooltip';
 
 /** Centralized API base so URL changes happen in one place. */
 const API_BASE = '/api/v1';
@@ -293,7 +294,13 @@ export default function AdminPanel() {
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className={LABEL_CLASS}>Asset Code</label>
+                  <label className={LABEL_CLASS}>
+                    Asset Code
+                    <InfoTooltip
+                      label="What is ORGUSD?"
+                      content="ORGUSD is the organisation's custom Stellar asset used for payroll. It is pegged to USD and issued by the organisation's issuer account on the Stellar network."
+                    />
+                  </label>
                   <input
                     type="text"
                     value={accountAsset}
@@ -361,7 +368,13 @@ export default function AdminPanel() {
             <div className="grid gap-4 mt-2">
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className={LABEL_CLASS}>Asset Code</label>
+                  <label className={LABEL_CLASS}>
+                    Asset Code
+                    <InfoTooltip
+                      label="What is ORGUSD?"
+                      content="ORGUSD is the organisation's custom Stellar asset used for payroll. It is pegged to USD and issued by the organisation's issuer account on the Stellar network."
+                    />
+                  </label>
                   <input
                     type="text"
                     value={globalAsset}
@@ -420,6 +433,10 @@ export default function AdminPanel() {
           <div className="flex flex-col gap-6 max-w-2xl">
             <h2 className="text-xl font-bold flex items-center gap-2">
               <Search className="w-5 h-5 text-accent" /> Trustline Status
+              <InfoTooltip
+                label="What is a Trustline?"
+                content="A trustline is a permission on your Stellar account that allows it to hold a specific asset (e.g. ORGUSD). Employees must establish a trustline before they can receive payments. Each trustline reserves 0.5 XLM."
+              />
             </h2>
             <p className="text-sm text-muted">
               Verify whether an account's trustline is currently frozen for a given asset.
@@ -440,7 +457,13 @@ export default function AdminPanel() {
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className={LABEL_CLASS}>Asset Code</label>
+                  <label className={LABEL_CLASS}>
+                    Asset Code
+                    <InfoTooltip
+                      label="What is ORGUSD?"
+                      content="ORGUSD is the organisation's custom Stellar asset used for payroll. It is pegged to USD and issued by the organisation's issuer account on the Stellar network."
+                    />
+                  </label>
                   <input
                     type="text"
                     value={statusAsset}


### PR DESCRIPTION
## Summary

Adds a dedicated, append-only audit trail that records every change to an organization's name, tenant settings, or issuer account.

**Migration** (`027_create_org_audit_log.sql`):
- New `org_audit_log` table with `org_id`, `change_type`, `config_key`, `old_value`/`new_value` JSONB, actor fields, `created_at` (immutable)
- `NO UPDATE` / `NO DELETE` rules enforce append-only semantics
- Three B-tree indexes for common query patterns

**Service** (`orgAuditService.ts`):
- `log()` — fire-and-forget (errors are caught/logged, never re-thrown so the main request is not broken)
- `list()` — paginated read with a max of 200 rows per page

**Controller** (`tenantConfigController.ts`):
- `upsert()` captures old value before write → emits `setting_upserted` event
- `remove()` captures old value before delete → emits `setting_deleted` event

**Route** (`orgAuditRoutes.ts`):
- `GET /api/org-audit` — returns paginated audit log (EMPLOYER role required)

## Test plan

- [ ] 5 unit tests pass (mock pool, no DB required):
  - Insert params match expected SQL binding order
  - DB errors return null without throwing
  - Null `config_key` when not provided
  - `list()` returns rows + total
  - `limit` capped at 200
- [ ] `PUT /api/tenant-config` produces an `org_audit_log` row with correct `old_value`/`new_value`
- [ ] `DELETE /api/tenant-config/:key` produces an `org_audit_log` row
- [ ] `GET /api/org-audit` returns entries for authenticated org only

Closes #355