### PR TITLE
docs(contributing): reinforce filenaming conventions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Run documentation tests
+        run: npm run test:docs
       - uses: actions/cache@v3
         with:
           path: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,16 @@ CREATE TABLE IF NOT EXISTS organizations (
 );
 ```
 
+### File Naming
+
+- **React components**: Use `PascalCase` filenames such as `PayrollScheduler.tsx`
+- **Hooks and TypeScript implementation files**: Use `camelCase` filenames such as `usePayrollData.ts` and `payrollAuditService.ts`
+- **Static assets and path-oriented docs**: Use `kebab-case` filenames such as `payroll-summary-icon.svg`
+- **SQL migrations**: Use `NNN_snake_case.sql` filenames such as `025_add_metadata_to_payroll_items.sql`
+- **Legacy areas**: Preserve the existing directory pattern unless the change is a dedicated rename/refactor
+
+See [docs/FILENAMING_CONVENTIONS.md](docs/FILENAMING_CONVENTIONS.md) for the full naming matrix and migration guidance.
+
 ### Documentation
 
 - **Markdown**: Use clear headings, code blocks, and examples

--- a/tests/filenaming-guide-docs.test.mjs
+++ b/tests/filenaming-guide-docs.test.mjs
@@ -3,10 +3,18 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+const contributing = readFileSync(new URL('../CONTRIBUTING.md', import.meta.url), 'utf8');
 const guide = readFileSync(new URL('../docs/FILENAMING_CONVENTIONS.md', import.meta.url), 'utf8');
 
 test('README links filenaming convention guide', () => {
   assert.match(readme, /FILENAMING_CONVENTIONS\.md/);
+});
+
+test('CONTRIBUTING links the filenaming guide for contributors', () => {
+  assert.match(contributing, /FILENAMING_CONVENTIONS\.md/);
+  assert.match(contributing, /PascalCase/);
+  assert.match(contributing, /camelCase/);
+  assert.match(contributing, /kebab-case/i);
 });
 
 test('filenaming guide documents kebab-case and camelCase usage', () => {


### PR DESCRIPTION
#440 

## Summary
Closes #440.

This PR reinforces the repository’s file-naming guidance by making it easier for contributors to find and follow the existing convention guide, and by adding CI coverage so the docs stay validated over time.

## What Changed
- Added a dedicated **File Naming** section to `CONTRIBUTING.md`
- Linked contributors directly to `docs/FILENAMING_CONVENTIONS.md` for the full naming matrix and migration guidance
- Expanded `tests/filenaming-guide-docs.test.mjs` to verify that contributor docs reference the naming guide and its key casing rules
- Updated `.github/workflows/build.yml` to run the docs test suite in CI

## Checklist
- [x] I linked the relevant issue(s) in the summary.
- [x] I added or updated tests for the change.
- [x] I ran the relevant test suite locally.
- [x] I updated documentation where needed, or explained why it was not needed.
- [x] If this change touches the UI, I verified responsive behavior and accessibility.
- [ ] I included screenshots, logs, or other proof when they help review.

## Testing
```bash
node --test tests/*.test.mjs
