### PR TITLE
docs(readme): enhance project badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # PayD: Stellar-Based Cross-Border Payroll Platform!
 
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Stellar](https://img.shields.io/badge/Powered%20by-Stellar-7B68EE)](https://www.stellar.org/)
+[![Build Status](https://github.com/Gildado/PayD/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/Gildado/PayD/actions/workflows/build.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
+[![Stellar Compatible](https://img.shields.io/badge/Stellar-Compatible-08B5E5?style=flat-square&logo=stellar)](https://www.stellar.org/)
 
 ## License
 

--- a/tests/license-docs.test.mjs
+++ b/tests/license-docs.test.mjs
@@ -6,7 +6,7 @@ const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
 const license = readFileSync(new URL("../LICENSE", import.meta.url), "utf8");
 
 test("README highlights the MIT license", () => {
-  assert.match(readme, /\[!\[License\][^\]]*\]\(LICENSE\)/i);
+  assert.match(readme, /\[!\[License(?:: MIT)?\][^\]]*\]\(LICENSE\)/i);
   assert.match(readme, /##\s+License/i);
   assert.match(readme, /\[MIT License\]\(LICENSE\)/i);
 });

--- a/tests/readme-badges.test.mjs
+++ b/tests/readme-badges.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+
+test("README exposes build, license, and Stellar badges near the top", () => {
+  const readmeHeader = readme.split("\n").slice(0, 8).join("\n");
+
+  assert.match(
+    readmeHeader,
+    /\[!\[Build Status\]\(https:\/\/github\.com\/Gildado\/PayD\/actions\/workflows\/build\.yml\/badge\.svg\?branch=main\)\]\(https:\/\/github\.com\/Gildado\/PayD\/actions\/workflows\/build\.yml\)/,
+  );
+  assert.match(
+    readmeHeader,
+    /\[!\[License: MIT\]\(https:\/\/img\.shields\.io\/badge\/License-MIT-blue\.svg\?style=flat-square\)\]\(LICENSE\)/,
+  );
+  assert.match(
+    readmeHeader,
+    /\[!\[Stellar Compatible\]\(https:\/\/img\.shields\.io\/badge\/Stellar-Compatible-08B5E5\?style=flat-square&logo=stellar\)\]\(https:\/\/www\.stellar\.org\/\)/,
+  );
+});


### PR DESCRIPTION
#479 

## Summary
Closes #479.

This PR improves the project badge section at the top of the README by adding a build status badge and standardizing the existing badges for license and Stellar compatibility.

## What Changed
- Added a GitHub Actions build status badge to the top of `README.md`
- Updated the license badge to a clearer, more consistent format
- Replaced the generic Stellar badge with a clearer Stellar compatibility badge
- Added a dedicated docs test to verify the README keeps the required badges near the top
- Updated the existing license docs test to accept the improved license badge text

## Checklist
- [x] I linked the relevant issue(s) in the summary.
- [x] I added or updated tests for the change.
- [x] I ran the relevant test suite locally.
- [x] I updated documentation where needed, or explained why it was not needed.
- [x] If this change touches the UI, I verified responsive behavior and accessibility.
- [ ] I included screenshots, logs, or other proof when they help review.

## Testing
```bash
node --test tests/license-docs.test.mjs tests/readme-badges.test.mjs
