### PR TITLE
 secure JWT secrets via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,11 @@ STELLAR_SECRET_KEY=your_issuer_secret_key
 ANCHOR_API_KEY=your_anchor_service_key
 
 # JWT
-JWT_SECRET=your_jwt_secret
+JWT_SECRET=<generate-a-random-32+-char-secret>
+JWT_REFRESH_SECRET=<generate-a-different-random-32+-char-secret>
 ```
+
+Rotate the JWT secrets in your platform environment whenever credentials are exposed or on your normal key-rotation schedule, then restart/redeploy the backend.
 
 ### Development
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,10 +30,12 @@ FRONTEND_URL=http://localhost:5173
 # -----------------------------------------------------------------------------
 # Authentication and session security (required)
 # -----------------------------------------------------------------------------
-# JWT signing secret used for short-lived access tokens.
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# Rotate by replacing the value in your platform environment settings, then redeploying.
+# JWT signing secret used for short-lived access tokens. Must be at least 32 characters.
 JWT_SECRET=replace-with-a-long-random-secret
 
-# JWT signing secret used for refresh tokens.
+# JWT signing secret used for refresh tokens. Must differ from JWT_SECRET and also be rotated.
 JWT_REFRESH_SECRET=replace-with-a-different-long-random-secret
 
 # OAuth provider credentials (required only if social login is enabled)

--- a/backend/README.md
+++ b/backend/README.md
@@ -376,7 +376,11 @@ SDS_RETRY_ATTEMPTS=3
 ENABLE_CACHING=true
 CACHE_TTL=7200000
 LOG_LEVEL=info
+JWT_SECRET=<generate-a-random-32+-char-secret>
+JWT_REFRESH_SECRET=<generate-a-different-random-32+-char-secret>
 ```
+
+Rotate both JWT secrets through your hosting provider's environment variable settings and redeploy the backend so new tokens are issued with the updated keys.
 
 ## Documentation
 

--- a/backend/jest.config.cjs
+++ b/backend/jest.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest/presets/default-esm',
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,5 +1,6 @@
 export default {
   preset: 'ts-jest/presets/default-esm',
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],

--- a/backend/jest.setup.ts
+++ b/backend/jest.setup.ts
@@ -1,0 +1,7 @@
+import crypto from 'crypto';
+
+const generateEphemeralSecret = () => crypto.randomBytes(48).toString('hex');
+
+process.env.NODE_ENV ??= 'test';
+process.env.JWT_SECRET ??= generateEphemeralSecret();
+process.env.JWT_REFRESH_SECRET ??= generateEphemeralSecret();

--- a/backend/src/config/__tests__/env.test.ts
+++ b/backend/src/config/__tests__/env.test.ts
@@ -1,0 +1,50 @@
+import crypto from 'crypto';
+import { parseEnv } from '../env.js';
+
+const generateSecret = () => crypto.randomBytes(48).toString('hex');
+
+const buildEnv = () => ({
+  PORT: '3001',
+  DATABASE_URL: 'postgres://localhost:5432/payd_test',
+  NODE_ENV: 'test' as const,
+  JWT_SECRET: generateSecret(),
+  JWT_REFRESH_SECRET: generateSecret(),
+});
+
+describe('parseEnv', () => {
+  it('accepts strong JWT secrets from environment variables', () => {
+    const env = buildEnv();
+
+    const parsed = parseEnv(env);
+
+    expect(parsed.JWT_SECRET).toBe(env.JWT_SECRET);
+    expect(parsed.JWT_REFRESH_SECRET).toBe(env.JWT_REFRESH_SECRET);
+  });
+
+  it('rejects missing JWT access secrets', () => {
+    const env = buildEnv() as NodeJS.ProcessEnv;
+    delete env.JWT_SECRET;
+
+    expect(() => parseEnv(env)).toThrow(/JWT_SECRET must be set in the environment/);
+  });
+
+  it('rejects placeholder JWT secrets', () => {
+    const env = {
+      ...buildEnv(),
+      JWT_SECRET: 'replace-with-a-long-random-secret',
+    };
+
+    expect(() => parseEnv(env)).toThrow(/JWT_SECRET must be replaced with a strong random value/);
+  });
+
+  it('rejects reused refresh secrets', () => {
+    const sharedSecret = generateSecret();
+    const env = {
+      ...buildEnv(),
+      JWT_SECRET: sharedSecret,
+      JWT_REFRESH_SECRET: sharedSecret,
+    };
+
+    expect(() => parseEnv(env)).toThrow(/JWT_REFRESH_SECRET must be different from JWT_SECRET/);
+  });
+});

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -3,6 +3,28 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+const MIN_JWT_SECRET_LENGTH = 32;
+const disallowedJwtSecretValues = new Set([
+  'dev-jwt-secret',
+  'dev-jwt-refresh-secret',
+  'your_jwt_secret',
+  'replace-with-a-long-random-secret',
+  'replace-with-a-different-long-random-secret',
+]);
+
+const jwtSecretSchema = (name: string) =>
+  z.preprocess(
+    (value) => (typeof value === 'string' ? value.trim() : ''),
+    z
+      .string()
+      .min(1, `${name} must be set in the environment`)
+      .min(MIN_JWT_SECRET_LENGTH, `${name} must be at least ${MIN_JWT_SECRET_LENGTH} characters long`)
+      .refine(
+        (value) => !disallowedJwtSecretValues.has(value),
+        `${name} must be replaced with a strong random value`
+      )
+  );
+
 const envSchema = z.object({
   PORT: z.string().default('3000'),
   DATABASE_URL: z.string().default('postgres://localhost:5432/payd_test'),
@@ -19,8 +41,8 @@ const envSchema = z.object({
   RATE_LIMIT_API_MAX: z.string().default('100'),
   RATE_LIMIT_DATA_WINDOW_MS: z.string().default('60000'),
   RATE_LIMIT_DATA_MAX: z.string().default('200'),
-  JWT_SECRET: z.string().default('dev-jwt-secret'),
-  JWT_REFRESH_SECRET: z.string().default('dev-jwt-refresh-secret'),
+  JWT_SECRET: jwtSecretSchema('JWT_SECRET'),
+  JWT_REFRESH_SECRET: jwtSecretSchema('JWT_REFRESH_SECRET'),
   // Email notification configuration
   EMAIL_PROVIDER: z.enum(['resend', 'sendgrid']).default('resend'),
   EMAIL_FROM_ADDRESS: z.string().default('noreply@payd.example.com'),
@@ -33,9 +55,14 @@ const envSchema = z.object({
   STELLAR_MAX_RETRIES: z.string().default('3'),
   STELLAR_RETRY_DELAY_MS: z.string().default('1000'),
   STELLAR_RETRY_DELAY_MAX_MS: z.string().default('10000'),
+}).refine((env) => env.JWT_SECRET !== env.JWT_REFRESH_SECRET, {
+  message: 'JWT_REFRESH_SECRET must be different from JWT_SECRET',
+  path: ['JWT_REFRESH_SECRET'],
 });
 
-export const config = envSchema.parse(process.env);
+export const parseEnv = (env: NodeJS.ProcessEnv = process.env) => envSchema.parse(env);
+
+export const config = parseEnv(process.env);
 
 export const getThrottlingConfig = () => ({
   tpm: parseInt(config.THROTTLING_TPM, 10),

--- a/docs/DEPLOYMENT_GUIDE_VERCEL_RENDER.md
+++ b/docs/DEPLOYMENT_GUIDE_VERCEL_RENDER.md
@@ -38,11 +38,14 @@ Create production environment values before deployment.
 - PORT=10000
 - DATABASE_URL=Render PostgreSQL connection string
 - REDIS_URL=Render Redis connection string
-- JWT_SECRET=long random secret
+- JWT_SECRET=long random secret (32+ chars)
+- JWT_REFRESH_SECRET=different long random secret (32+ chars)
 - STELLAR_NETWORK=testnet or mainnet
 - STELLAR_HORIZON_URL=network horizon endpoint
 - STELLAR_SECRET_KEY=secure issuer/distribution key
 - Optional provider keys (email, webhooks, OAuth)
+
+Rotate JWT secrets by updating the Render environment variables and redeploying all backend services that verify or mint tokens.
 
 ## 4. Deploy Backend on Render
 


### PR DESCRIPTION
Closes #367 

## Summary
- remove hardcoded JWT access and refresh secret fallbacks from backend env parsing
- require strong, non-placeholder JWT secrets from environment variables and ensure refresh secret differs from the access secret
- add a Jest setup file that injects fresh test-only JWT secrets per run, plus unit coverage for the new validation rules
- update backend and deployment docs to explain secret generation and rotation through platform environment settings

## Root Cause
The backend accepted hardcoded JWT defaults in `backend/src/config/env.ts`, which allowed deployments to start with committed fallback secrets instead of platform-managed values.

## Validation
- `npx jest --config jest.config.cjs --runTestsByPath src/config/__tests__/env.test.ts --runInBand`
- `npx eslint src/config/env.ts src/config/__tests__/env.test.ts`
- `npx tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --esModuleInterop true --types jest,node src/config/env.ts src/config/__tests__/env.test.ts jest.setup.ts`

## Repo Baseline Issues
- `npm ci` currently fails because `backend/package-lock.json` is out of sync with `backend/package.json`
- `npm run build` and `npm run lint` currently fail on pre-existing repo-wide TypeScript and ESLint issues outside this change

Refs: https://github.com/Gildado/PayD/issues/367
