### PR TITLE
feat(api): complete v1 prefix coverage for system endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -115,6 +115,8 @@ http://localhost:3001/api-docs
 
 # Raw OpenAPI document
 http://localhost:3001/api/openapi.json
+# Versioned OpenAPI endpoint
+http://localhost:3001/api/v1/openapi.json
 ```
 
 **Benchmarks**:
@@ -151,9 +153,7 @@ Services (Business Logic)
 
 ### Base URL
 
-```
-http://localhost:3001/api/payroll
-```
+`http://localhost:3001/api/v1/payroll`
 
 ### Payroll Queries
 
@@ -172,7 +172,8 @@ http://localhost:3001/api/payroll
 
 | Endpoint             | Method | Purpose          |
 | -------------------- | ------ | ---------------- |
-| `/api/health`        | GET    | API health check |
+| `/api/v1/health`     | GET    | API v1 health check |
+| `/api/health`        | GET    | Legacy API health check |
 | `/status/health`     | GET    | SDS health check |
 | `/status/rate-limit` | GET    | Rate limit info  |
 | `/cache/stats`       | GET    | Cache statistics |
@@ -183,7 +184,7 @@ http://localhost:3001/api/payroll
 ### Get Employee Payroll
 
 ```bash
-curl "http://localhost:3001/api/payroll/employees/EMP-001?orgPublicKey=GBXXX&startDate=2024-01-01&endDate=2024-01-31"
+curl "http://localhost:3001/api/v1/payroll/employees/EMP-001?orgPublicKey=GBXXX&startDate=2024-01-01&endDate=2024-01-31"
 ```
 
 Response:
@@ -218,7 +219,7 @@ Response:
 ### Get Audit Report
 
 ```bash
-curl "http://localhost:3001/api/payroll/audit?orgPublicKey=GBXXX&startDate=2024-01-01&endDate=2024-12-31"
+curl "http://localhost:3001/api/v1/payroll/audit?orgPublicKey=GBXXX&startDate=2024-01-01&endDate=2024-12-31"
 ```
 
 Response:
@@ -395,7 +396,7 @@ Rotate both JWT secrets through your hosting provider's environment variable set
 ## Documentation
 
 - Swagger UI is served at `/api-docs`.
-- The generated OpenAPI spec is exposed at `/api/openapi.json` and written to `backend/openapi.json` for client generation.
+- The generated OpenAPI spec is exposed at `/api/v1/openapi.json` (legacy alias: `/api/openapi.json`) and written to `backend/openapi.json` for client generation.
 - [SDS Integration Guide](./docs/SDS_INTEGRATION.md) - Complete SDS implementation details
 - [Indexing Strategy](./docs/INDEXING_STRATEGY.md) - Technical deep-dive on payroll indexing
 - [Benchmarking Results](./docs/BENCHMARKS.md) - Performance comparison data
@@ -455,7 +456,7 @@ docker-compose logs [service-name]
 
 ```bash
 # Check API health (PostgreSQL + Redis)
-curl http://localhost:3001/api/health
+curl http://localhost:3001/api/v1/health
 
 # Check health
 curl http://localhost:3001/api/payroll/status/health

--- a/backend/src/__tests__/apiVersioning.test.ts
+++ b/backend/src/__tests__/apiVersioning.test.ts
@@ -46,6 +46,8 @@ describe('GET /api — discovery endpoint', () => {
     expect(res.body.currentVersion).toBe('v1');
     expect(res.body.supportedVersions).toContain('v1');
     expect(res.body.endpoints.v1).toBe('/api/v1');
+    expect(res.body.endpoints.health).toBe('/api/v1/health');
+    expect(res.body.endpoints.openapi).toBe('/api/v1/openapi.json');
   });
 });
 
@@ -99,6 +101,8 @@ describe('Versioned routes (/api/v1/)', () => {
     '/api/v1/path-payments',
     '/api/v1/audit',
     '/api/v1/tenant-configs',
+    '/api/v1/health',
+    '/api/v1/openapi.json',
   ];
 
   it.each(v1Paths)('%s does not return deprecation headers', async (path) => {

--- a/backend/src/__tests__/swaggerDocs.test.ts
+++ b/backend/src/__tests__/swaggerDocs.test.ts
@@ -5,9 +5,12 @@ import { swaggerSpec } from '../config/swaggerConfig.js';
 describe('Swagger/OpenAPI documentation', () => {
   it('serves the generated OpenAPI specification', async () => {
     const response = await request(app).get('/api/openapi.json');
+    const v1Response = await request(app).get('/api/v1/openapi.json');
 
     expect(response.status).toBe(200);
+    expect(v1Response.status).toBe(200);
     expect(response.body.openapi).toBe('3.0.0');
+    expect(v1Response.body.openapi).toBe('3.0.0');
     expect(response.body.paths['/api/v1/auth/register']?.post).toBeDefined();
     expect(response.body.paths['/api/v1/payments/pathfind']?.post).toBeDefined();
     expect(response.body.paths['/metrics']?.get).toBeDefined();

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -101,6 +101,9 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.get('/api/openapi.json', (_req, res) => {
   res.json(swaggerSpec);
 });
+app.get('/api/v1/openapi.json', (_req, res) => {
+  res.json(swaggerSpec);
+});
 
 // Export openapi.json for frontend
 fs.writeFileSync(path.join(__appDirname, '../openapi.json'), JSON.stringify(swaggerSpec, null, 2));
@@ -117,7 +120,11 @@ app.get('/api', (_req, res) => {
     name: 'PayD API',
     currentVersion: 'v1',
     supportedVersions: ['v1'],
-    endpoints: { v1: '/api/v1' },
+    endpoints: {
+      v1: '/api/v1',
+      health: '/api/v1/health',
+      openapi: '/api/v1/openapi.json',
+    },
   });
 });
 
@@ -137,6 +144,7 @@ app.use('/api', apiRateLimit(), contractRoutes);
 app.use('/api/stellar-throttling', apiRateLimit(), stellarThrottlingRoutes);
 
 // Health check endpoints
+app.get('/api/v1/health', HealthController.getHealthStatus);
 app.get('/api/health', HealthController.getHealthStatus);
 app.get('/health', HealthController.getHealthStatus);
 

--- a/backend/src/config/swaggerConfig.ts
+++ b/backend/src/config/swaggerConfig.ts
@@ -77,6 +77,18 @@ const options: swaggerJsdoc.Options = {
           },
         },
       },
+      '/api/v1/health': {
+        get: {
+          tags: ['System'],
+          summary: 'Get API v1 health status',
+          security: [],
+          responses: {
+            '200': {
+              description: 'Success',
+            },
+          },
+        },
+      },
       '/health': {
         get: {
           tags: ['System'],
@@ -93,6 +105,18 @@ const options: swaggerJsdoc.Options = {
         get: {
           tags: ['System'],
           summary: 'Get the generated OpenAPI specification',
+          security: [],
+          responses: {
+            '200': {
+              description: 'Success',
+            },
+          },
+        },
+      },
+      '/api/v1/openapi.json': {
+        get: {
+          tags: ['System'],
+          summary: 'Get the generated OpenAPI specification (v1 endpoint)',
           security: [],
           responses: {
             '200': {

--- a/backend/src/controllers/__tests__/healthController.test.ts
+++ b/backend/src/controllers/__tests__/healthController.test.ts
@@ -22,6 +22,7 @@ jest.mock('ioredis', () => {
 });
 const app = express();
 app.get('/api/health', HealthController.getHealthStatus);
+app.get('/api/v1/health', HealthController.getHealthStatus);
 app.get('/health', HealthController.getHealthStatus);
 
 describe('HealthController health endpoints', () => {
@@ -58,6 +59,18 @@ describe('HealthController health endpoints', () => {
     redisClient.ping.mockResolvedValueOnce('PONG');
 
     const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('ok');
+    expect(response.body.dependencies.database.status).toBe('connected');
+    expect(response.body.dependencies.redis.status).toBe('connected');
+  });
+
+  it('returns 200 OK from /api/v1/health when database and redis are healthy', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    redisClient.ping.mockResolvedValueOnce('PONG');
+
+    const response = await request(app).get('/api/v1/health');
 
     expect(response.status).toBe(200);
     expect(response.body.status).toBe('ok');

--- a/frontend/src/utils/__tests__/stellarExpert.test.ts
+++ b/frontend/src/utils/__tests__/stellarExpert.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { getTxExplorerUrl } from '../stellarExpert';
 
 describe('stellarExpert utils', () => {


### PR DESCRIPTION
## Summary
- add canonical versioned system endpoints: `/api/v1/health` and `/api/v1/openapi.json`
- keep legacy aliases (`/api/health`, `/api/openapi.json`) for backward compatibility
- update API discovery metadata, OpenAPI path definitions, and backend docs to be v1-first
- extend tests to cover v1 health and v1 OpenAPI endpoints

## Validation
- updated and executed health controller tests for v1 health route behavior
- attempted API versioning and swagger integration tests, but repository Jest ESM config currently fails on `import.meta` in app bootstrap under current test harness

Closes #351