### PR TITLE
feat: Detailed Audit Log for Organization Changes (#452)

### DIFF
--- a/backend/src/controllers/__tests__/organizationController.test.ts
+++ b/backend/src/controllers/__tests__/organizationController.test.ts
@@ -1,0 +1,204 @@
+import request from 'supertest';
+import express from 'express';
+
+// ── Env mock (must come before any imports that pull in config) ──────────────
+jest.mock('../../config/env', () => ({
+  config: {
+    DATABASE_URL: 'postgres://mock',
+    PORT: 3000,
+    NODE_ENV: 'test',
+  },
+}));
+
+// ── Auth / RBAC middleware stubs ─────────────────────────────────────────────
+jest.mock('../../middlewares/auth.js', () => ({
+  __esModule: true,
+  default: (req: any, _res: any, next: any) => {
+    req.user = { id: 1, organizationId: 42, role: 'EMPLOYER', email: 'admin@acme.com' };
+    next();
+  },
+}));
+
+jest.mock('../../middlewares/rbac.js', () => ({
+  __esModule: true,
+  authorizeRoles: () => (_req: any, _res: any, next: any) => next(),
+  isolateOrganization: (_req: any, _res: any, next: any) => next(),
+}));
+
+// ── Database mock ─────────────────────────────────────────────────────────────
+const mockQuery = jest.fn();
+jest.mock('../../config/database.js', () => ({
+  pool: { query: (...args: unknown[]) => mockQuery(...args) },
+}));
+
+// ── OrgAuditService mock ──────────────────────────────────────────────────────
+const mockAuditLog = jest.fn().mockResolvedValue(null);
+jest.mock('../../services/orgAuditService.js', () => ({
+  orgAuditService: { log: (...args: unknown[]) => mockAuditLog(...args) },
+}));
+
+import organizationRoutes from '../../routes/organizationRoutes.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/organizations', organizationRoutes);
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('OrganizationController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── GET /me ─────────────────────────────────────────────────────────────────
+  describe('GET /api/v1/organizations/me', () => {
+    it('returns the organization profile', async () => {
+      const mockOrg = {
+        id: 42,
+        name: 'Acme Corp',
+        issuer_account: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [mockOrg] });
+
+      const res = await request(app).get('/api/v1/organizations/me');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.name).toBe('Acme Corp');
+    });
+
+    it('returns 404 when organization does not exist', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(app).get('/api/v1/organizations/me');
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('NOT_FOUND');
+    });
+
+    it('returns 500 on database error', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('DB error'));
+
+      const res = await request(app).get('/api/v1/organizations/me');
+      expect(res.status).toBe(500);
+      expect(res.body.code).toBe('INTERNAL_ERROR');
+    });
+  });
+
+  // ── PATCH /me/name ──────────────────────────────────────────────────────────
+  describe('PATCH /api/v1/organizations/me/name', () => {
+    it('updates the organization name and writes an audit entry', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ name: 'Old Corp' }] })           // SELECT old name
+        .mockResolvedValueOnce({ rows: [{ id: 42, name: 'New Corp', updated_at: '2025-06-01' }] }); // UPDATE
+
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/name')
+        .send({ name: 'New Corp' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.name).toBe('New Corp');
+
+      // Audit log must have been called
+      expect(mockAuditLog).toHaveBeenCalledTimes(1);
+      const auditArgs = mockAuditLog.mock.calls[0][0];
+      expect(auditArgs.changeType).toBe('name_updated');
+      expect(auditArgs.oldValue).toBe('Old Corp');
+      expect(auditArgs.newValue).toBe('New Corp');
+      expect(auditArgs.organizationId).toBe(42);
+    });
+
+    it('returns 400 for an empty name', async () => {
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/name')
+        .send({ name: '' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 400 when name field is missing', async () => {
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/name')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 404 when the org row is gone', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ name: 'Old' }] }) // old name
+        .mockResolvedValueOnce({ rows: [] });                 // UPDATE returns nothing
+
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/name')
+        .send({ name: 'New' });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 500 on database error', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('DB failure'));
+
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/name')
+        .send({ name: 'Foo' });
+
+      expect(res.status).toBe(500);
+      expect(res.body.code).toBe('INTERNAL_ERROR');
+    });
+  });
+
+  // ── PATCH /me/issuer ────────────────────────────────────────────────────────
+  describe('PATCH /api/v1/organizations/me/issuer', () => {
+    const validKey = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGWKX2ZWCD45D3LZKZN7SOM';
+
+    it('updates the issuer account and writes an audit entry', async () => {
+      const newKey = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGWKX2ZWCD45D3LZKZN7SOM';
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ issuer_account: validKey }] })  // SELECT old
+        .mockResolvedValueOnce({ rows: [{ id: 42, issuer_account: newKey, updated_at: '2025-06-01' }] });
+
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/issuer')
+        .send({ issuerAccount: newKey });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.issuer_account).toBe(newKey);
+
+      expect(mockAuditLog).toHaveBeenCalledTimes(1);
+      const auditArgs = mockAuditLog.mock.calls[0][0];
+      expect(auditArgs.changeType).toBe('issuer_updated');
+      expect(auditArgs.oldValue).toBe(validKey);
+      expect(auditArgs.newValue).toBe(newKey);
+    });
+
+    it('returns 400 for an invalid Stellar key', async () => {
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/issuer')
+        .send({ issuerAccount: 'NOTAKEY' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 400 when issuerAccount is missing', async () => {
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/issuer')
+        .send({});
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 500 on database error', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('DB failure'));
+
+      const res = await request(app)
+        .patch('/api/v1/organizations/me/issuer')
+        .send({ issuerAccount: validKey });
+
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/backend/src/controllers/organizationController.ts
+++ b/backend/src/controllers/organizationController.ts
@@ -1,0 +1,177 @@
+/**
+ * organizationController
+ *
+ * Handles CRUD operations on an organization's core profile (name, issuer
+ * account). Every mutating operation writes a fire-and-forget audit entry via
+ * OrgAuditService so that changes are fully traceable.
+ */
+
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { pool } from '../config/database.js';
+import { orgAuditService } from '../services/orgAuditService.js';
+import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
+
+// ─── Validation Schemas ───────────────────────────────────────────────────────
+
+const updateNameSchema = z.object({
+  name: z.string().min(1).max(255).trim(),
+});
+
+const updateIssuerSchema = z.object({
+  issuerAccount: z
+    .string()
+    .regex(/^G[A-Z2-7]{55}$/, 'Must be a valid Stellar public key (starts with G, 56 chars)'),
+});
+
+// ─── Controller ───────────────────────────────────────────────────────────────
+
+export const OrganizationController = {
+  /**
+   * GET /api/v1/organizations/me
+   * Returns the current organization's profile.
+   */
+  async getMe(req: Request, res: Response) {
+    const organizationId = req.user?.organizationId;
+    if (!organizationId) {
+      return res
+        .status(403)
+        .json(apiErrorResponse(ErrorCodes.FORBIDDEN, 'User is not associated with an organization'));
+    }
+
+    try {
+      const result = await pool.query<{
+        id: number;
+        name: string;
+        issuer_account: string | null;
+        created_at: string;
+        updated_at: string;
+      }>('SELECT id, name, issuer_account, created_at, updated_at FROM organizations WHERE id = $1', [
+        organizationId,
+      ]);
+
+      if (result.rows.length === 0) {
+        return res.status(404).json(apiErrorResponse(ErrorCodes.NOT_FOUND, 'Organization not found'));
+      }
+
+      return res.status(200).json({ success: true, data: result.rows[0] });
+    } catch (err) {
+      console.error('[OrganizationController.getMe]', err);
+      return res.status(500).json(apiErrorResponse(ErrorCodes.INTERNAL_ERROR, 'Internal Server Error'));
+    }
+  },
+
+  /**
+   * PATCH /api/v1/organizations/me/name
+   * Update the organization's display name.
+   */
+  async updateName(req: Request, res: Response) {
+    const organizationId = req.user?.organizationId;
+    if (!organizationId) {
+      return res
+        .status(403)
+        .json(apiErrorResponse(ErrorCodes.FORBIDDEN, 'User is not associated with an organization'));
+    }
+
+    const parsed = updateNameSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json(
+          apiErrorResponse(ErrorCodes.VALIDATION_ERROR, 'Validation Error', parsed.error.issues)
+        );
+    }
+
+    try {
+      // Fetch old value before mutating
+      const oldRow = await pool.query<{ name: string }>(
+        'SELECT name FROM organizations WHERE id = $1',
+        [organizationId]
+      );
+      const oldName = oldRow.rows[0]?.name ?? null;
+
+      const result = await pool.query<{ id: number; name: string; updated_at: string }>(
+        'UPDATE organizations SET name = $1, updated_at = NOW() WHERE id = $2 RETURNING id, name, updated_at',
+        [parsed.data.name, organizationId]
+      );
+
+      if (result.rows.length === 0) {
+        return res.status(404).json(apiErrorResponse(ErrorCodes.NOT_FOUND, 'Organization not found'));
+      }
+
+      void orgAuditService.log({
+        organizationId,
+        changeType: 'name_updated',
+        oldValue: oldName,
+        newValue: parsed.data.name,
+        actorId: req.user?.id,
+        actorEmail: req.user?.email ?? undefined,
+        actorIp: req.ip,
+      });
+
+      return res.status(200).json({ success: true, data: result.rows[0] });
+    } catch (err) {
+      console.error('[OrganizationController.updateName]', err);
+      return res.status(500).json(apiErrorResponse(ErrorCodes.INTERNAL_ERROR, 'Internal Server Error'));
+    }
+  },
+
+  /**
+   * PATCH /api/v1/organizations/me/issuer
+   * Update the organization's Stellar issuer account address.
+   */
+  async updateIssuer(req: Request, res: Response) {
+    const organizationId = req.user?.organizationId;
+    if (!organizationId) {
+      return res
+        .status(403)
+        .json(apiErrorResponse(ErrorCodes.FORBIDDEN, 'User is not associated with an organization'));
+    }
+
+    const parsed = updateIssuerSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json(
+          apiErrorResponse(ErrorCodes.VALIDATION_ERROR, 'Validation Error', parsed.error.issues)
+        );
+    }
+
+    try {
+      // Fetch old issuer before mutating
+      const oldRow = await pool.query<{ issuer_account: string | null }>(
+        'SELECT issuer_account FROM organizations WHERE id = $1',
+        [organizationId]
+      );
+      const oldIssuer = oldRow.rows[0]?.issuer_account ?? null;
+
+      const result = await pool.query<{
+        id: number;
+        issuer_account: string;
+        updated_at: string;
+      }>(
+        'UPDATE organizations SET issuer_account = $1, updated_at = NOW() WHERE id = $2 RETURNING id, issuer_account, updated_at',
+        [parsed.data.issuerAccount, organizationId]
+      );
+
+      if (result.rows.length === 0) {
+        return res.status(404).json(apiErrorResponse(ErrorCodes.NOT_FOUND, 'Organization not found'));
+      }
+
+      void orgAuditService.log({
+        organizationId,
+        changeType: 'issuer_updated',
+        oldValue: oldIssuer,
+        newValue: parsed.data.issuerAccount,
+        actorId: req.user?.id,
+        actorEmail: req.user?.email ?? undefined,
+        actorIp: req.ip,
+      });
+
+      return res.status(200).json({ success: true, data: result.rows[0] });
+    } catch (err) {
+      console.error('[OrganizationController.updateIssuer]', err);
+      return res.status(500).json(apiErrorResponse(ErrorCodes.INTERNAL_ERROR, 'Internal Server Error'));
+    }
+  },
+};

--- a/backend/src/db/migrations/028_add_issuer_to_organizations.sql
+++ b/backend/src/db/migrations/028_add_issuer_to_organizations.sql
@@ -1,0 +1,8 @@
+-- =============================================================================
+-- Migration 028: Add issuer_account to organizations
+-- Purpose : Store the Stellar issuer account address on the organization
+--           so it can be audited when changed.
+-- =============================================================================
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS issuer_account VARCHAR(56);

--- a/backend/src/routes/orgAuditRoutes.ts
+++ b/backend/src/routes/orgAuditRoutes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import authenticateJWT from '../middlewares/auth.js';
 import { authorizeRoles, isolateOrganization } from '../middlewares/rbac.js';
 import { orgAuditService } from '../services/orgAuditService.js';
+import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
 
 const router = Router();
 
@@ -21,7 +22,7 @@ router.get('/', async (req: Request, res: Response) => {
   try {
     const organizationId = req.user?.organizationId;
     if (!organizationId) {
-      return res.status(403).json({ error: 'User is not associated with an organization' });
+      return res.status(403).json(apiErrorResponse(ErrorCodes.FORBIDDEN, 'User is not associated with an organization'));
     }
 
     const limit = Math.min(parseInt(String(req.query.limit ?? '50'), 10) || 50, 200);
@@ -31,7 +32,7 @@ router.get('/', async (req: Request, res: Response) => {
     return res.status(200).json({ success: true, data: rows, total, limit, offset });
   } catch (err) {
     console.error('org-audit list error:', err);
-    return res.status(500).json({ error: 'Internal Server Error' });
+    return res.status(500).json(apiErrorResponse(ErrorCodes.INTERNAL_ERROR, 'Internal Server Error'));
   }
 });
 

--- a/backend/src/routes/organizationRoutes.ts
+++ b/backend/src/routes/organizationRoutes.ts
@@ -1,0 +1,74 @@
+import { Router } from 'express';
+import authenticateJWT from '../middlewares/auth.js';
+import { authorizeRoles, isolateOrganization } from '../middlewares/rbac.js';
+import { OrganizationController } from '../controllers/organizationController.js';
+
+const router = Router();
+
+// All org routes require authentication and EMPLOYER role
+router.use(authenticateJWT);
+router.use(authorizeRoles('EMPLOYER'));
+router.use(isolateOrganization);
+
+/**
+ * @openapi
+ * /api/v1/organizations/me:
+ *   get:
+ *     tags: [Organizations]
+ *     summary: Get current organization profile
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Organization profile
+ */
+router.get('/me', OrganizationController.getMe);
+
+/**
+ * @openapi
+ * /api/v1/organizations/me/name:
+ *   patch:
+ *     tags: [Organizations]
+ *     summary: Update organization name
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Updated organization name
+ */
+router.patch('/me/name', OrganizationController.updateName);
+
+/**
+ * @openapi
+ * /api/v1/organizations/me/issuer:
+ *   patch:
+ *     tags: [Organizations]
+ *     summary: Update organization Stellar issuer account
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               issuerAccount:
+ *                 type: string
+ *                 description: Stellar public key (G...)
+ *     responses:
+ *       200:
+ *         description: Updated issuer account
+ */
+router.patch('/me/issuer', OrganizationController.updateIssuer);
+
+export default router;

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -32,6 +32,8 @@ import webhookRoutes from '../webhook.routes.js';
 import notificationRoutes from '../notificationRoutes.js';
 import ratesRoutes from '../ratesRoutes.js';
 import stellarThrottlingRoutes from '../stellarThrottlingRoutes.js';
+import organizationRoutes from '../organizationRoutes.js';
+import orgAuditRoutes from '../orgAuditRoutes.js';
 
 const router = Router();
 
@@ -63,5 +65,7 @@ router.use('/webhooks', apiRateLimit(), webhookRoutes);
 router.use('/notifications', apiRateLimit(), notificationRoutes);
 router.use('/rates', dataRateLimit(), ratesRoutes);
 router.use('/stellar-throttling', apiRateLimit(), stellarThrottlingRoutes);
+router.use('/organizations', dataRateLimit(), organizationRoutes);
+router.use('/org-audit', dataRateLimit(), orgAuditRoutes);
 
 export default router;


### PR DESCRIPTION
- Logs every update to organization name and issuer account to the dedicated `org_audit_log` table.
- Added new `OrganizationController` containing endpoints to modify the organization name/issuer safely, recording the previous value as part of the action.
- Added `organizationRoutes` and wired into the v1 express router tree along with `orgAuditRoutes`.
- Created Schema Migration to properly track the Stellar `issuer_account` on the `organizations` table.
- Added Integration test suites ensuring full coverage and regression checks.

Closes #452