### PR TITLE
backend: on-chain tx verification queue

### DIFF
--- a/backend/src/config/queue.ts
+++ b/backend/src/config/queue.ts
@@ -8,6 +8,7 @@ export const redisConnection: ConnectionOptions = {
 export const PAYROLL_QUEUE_NAME = 'payroll-processing';
 export const NOTIFICATION_QUEUE_NAME = 'payment-notifications';
 export const SCHEDULER_QUEUE_NAME = 'payroll-scheduler';
+export const TX_VERIFICATION_QUEUE_NAME = 'tx-verification';
 
 export const notificationQueueConfig = {
   attempts: 3,

--- a/backend/src/services/contractUpgradeService.ts
+++ b/backend/src/services/contractUpgradeService.ts
@@ -23,6 +23,7 @@ import {
   xdr,
 } from '@stellar/stellar-sdk';
 import { pool } from '../config/database.js';
+import { TransactionVerificationQueueService } from './transactionVerificationQueueService.js';
 
 // ---------------------------------------------------------------------------
 // Environment helpers (mirror the pattern from stellarService.ts)
@@ -600,6 +601,18 @@ export class ContractUpgradeService {
       txHash,
       upgradeLogId,
     ]);
+
+    // Verify on-chain & persist immutable audit record (async).
+    // Even though Soroban RPC confirmation succeeded, this ensures we also
+    // capture the canonical Horizon envelope/result XDR for audit/compliance.
+    try {
+      await TransactionVerificationQueueService.enqueue({
+        txHash,
+        source: 'contract_upgrade',
+      });
+    } catch {
+      // Best-effort
+    }
 
     // Run migration steps asynchronously (fire-and-forget from the
     // caller's perspective; the client polls /status).

--- a/backend/src/services/freezeService.ts
+++ b/backend/src/services/freezeService.ts
@@ -1,6 +1,7 @@
 import { Asset, Keypair, Operation, TransactionBuilder } from '@stellar/stellar-sdk';
 import { StellarService } from './stellarService.js';
 import { pool } from '../config/database.js';
+import { TransactionVerificationQueueService } from './transactionVerificationQueueService.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -228,6 +229,16 @@ export class FreezeService {
       reason,
     });
 
+    // Verify on-chain & store immutable audit record (async).
+    try {
+      await TransactionVerificationQueueService.enqueue({
+        txHash: result.hash,
+        source: 'freeze',
+      });
+    } catch {
+      // Best-effort; the core freeze operation already succeeded on-chain.
+    }
+
     return {
       txHash: result.hash,
       action,
@@ -299,6 +310,16 @@ export class FreezeService {
 
         // Collect valid holders (skip issuer — it doesn't hold its own trustline)
         const validHolders = batch.filter((h) => h.account_id !== assetIssuer);
+
+        // Verify on-chain & store immutable audit record (async).
+        try {
+          await TransactionVerificationQueueService.enqueue({
+            txHash: txResult.hash,
+            source: 'freeze',
+          });
+        } catch {
+          // Best-effort
+        }
 
         // Single bulk INSERT instead of N round-trips
         await writeBulkAuditLog(

--- a/backend/src/services/transactionVerificationQueueService.ts
+++ b/backend/src/services/transactionVerificationQueueService.ts
@@ -1,0 +1,74 @@
+import { Queue } from 'bullmq';
+import { redisConnection, TX_VERIFICATION_QUEUE_NAME } from '../config/queue.js';
+import logger from '../utils/logger.js';
+
+export interface TxVerificationJobData {
+  txHash: string;
+  /**
+   * Optional context for log correlation and future routing.
+   * Keep permissive so callers don't need to change often.
+   */
+  source?: 'payroll' | 'freeze' | 'contract_upgrade' | 'unknown';
+  organizationId?: number;
+}
+
+export class TransactionVerificationQueueService {
+  private static queue: Queue<TxVerificationJobData> | null = null;
+
+  static getQueue(): Queue<TxVerificationJobData> {
+    if (!this.queue) {
+      this.queue = new Queue<TxVerificationJobData>(TX_VERIFICATION_QUEUE_NAME, {
+        connection: redisConnection,
+        defaultJobOptions: {
+          attempts: 15,
+          backoff: {
+            type: 'exponential',
+            delay: 2000,
+          },
+          removeOnComplete: {
+            age: 86400,
+            count: 5000,
+          },
+          removeOnFail: {
+            age: 604800,
+          },
+        },
+      });
+    }
+    return this.queue;
+  }
+
+  static async enqueue(data: TxVerificationJobData): Promise<string> {
+    const queue = this.getQueue();
+    const jobId = `tx:${data.txHash}`;
+
+    try {
+      const job = await queue.add('verify-tx', data, { jobId });
+      logger.info('Tx verification job enqueued', {
+        jobId: job.id,
+        txHash: data.txHash,
+        source: data.source ?? 'unknown',
+        organizationId: data.organizationId,
+      });
+      return job.id!;
+    } catch (error: any) {
+      // If job already exists, BullMQ throws; treat as success (idempotent).
+      const message = typeof error?.message === 'string' ? error.message : '';
+      if (message.includes('Job') && message.includes('already exists')) {
+        logger.info('Tx verification job already enqueued', {
+          jobId,
+          txHash: data.txHash,
+          source: data.source ?? 'unknown',
+        });
+        return jobId;
+      }
+      logger.error('Failed to enqueue tx verification job', {
+        txHash: data.txHash,
+        source: data.source ?? 'unknown',
+        error: message || 'Unknown error',
+      });
+      throw error;
+    }
+  }
+}
+

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -1,6 +1,7 @@
 import { payrollWorker } from './payrollWorker.js';
 import { notificationWorker } from './notificationWorker.js';
 import { schedulerWorker } from './schedulerWorker.js';
+import { transactionVerificationWorker } from './transactionVerificationWorker.js';
 import { webhookNotificationService } from '../services/webhookNotificationService.js';
 import logger from '../utils/logger.js';
 
@@ -13,6 +14,7 @@ export const startWorkers = () => {
   }
 
   logger.info('Notification worker initialized');
+  logger.info('Transaction verification worker initialized');
 
   // Start polling for pending webhook retries
   setInterval(async () => {

--- a/backend/src/workers/payrollWorker.ts
+++ b/backend/src/workers/payrollWorker.ts
@@ -8,6 +8,7 @@ import { emitBulkUpdate } from '../services/socketService.js';
 import { BalanceService } from '../services/balanceService.js';
 import { webhookNotificationService } from '../services/webhookNotificationService.js';
 import { NotificationQueueService } from '../services/notificationQueueService.js';
+import { TransactionVerificationQueueService } from '../services/transactionVerificationQueueService.js';
 import taxService from '../services/taxService.js';
 import logger from '../utils/logger.js';
 import { Keypair, Asset, Operation, TransactionBuilder } from '@stellar/stellar-sdk';
@@ -17,6 +18,7 @@ import { getAssetIssuer } from '../config/assets.js';
  * Worker to process payroll runs in the background.
  */
 const notificationQueueService = new NotificationQueueService();
+const txVerificationQueueService = TransactionVerificationQueueService;
 
 export const payrollWorker = new Worker<PayrollJobData>(
   PAYROLL_QUEUE_NAME,
@@ -179,6 +181,20 @@ export const payrollWorker = new Worker<PayrollJobData>(
 
           const result = await StellarService.submitTransaction(tx);
           logger.info(`Chunk ${i + 1} submitted successfully. Tx Hash: ${result.hash}`);
+
+          // Verify on-chain & persist immutable audit record (async).
+          try {
+            await txVerificationQueueService.enqueue({
+              txHash: result.hash,
+              source: 'payroll',
+              organizationId: payroll_run.organization_id,
+            });
+          } catch (enqueueError) {
+            logger.warn('Failed to enqueue tx verification (continuing)', {
+              txHash: result.hash,
+              error: enqueueError instanceof Error ? enqueueError.message : 'Unknown error',
+            });
+          }
 
           // Update database for items in this chunk and log audit entries
           for (const item of chunk) {

--- a/backend/src/workers/transactionVerificationWorker.ts
+++ b/backend/src/workers/transactionVerificationWorker.ts
@@ -1,0 +1,90 @@
+import { Worker, Job } from 'bullmq';
+import { redisConnection, TX_VERIFICATION_QUEUE_NAME } from '../config/queue.js';
+import { TxVerificationJobData } from '../services/transactionVerificationQueueService.js';
+import { TransactionAuditService } from '../services/transactionAuditService.js';
+import logger from '../utils/logger.js';
+
+function isHorizonNotFound(error: any): boolean {
+  const status = error?.response?.status;
+  // stellar-sdk Horizon call() errors typically include response.status
+  return status === 404;
+}
+
+/**
+ * Worker that verifies submitted tx hashes on-chain via Horizon and stores an
+ * immutable record in transaction_audit_logs.
+ *
+ * The queue is intentionally retry-heavy: Horizon indexing can lag, and
+ * Soroban transactions may not be visible immediately.
+ */
+export const transactionVerificationWorker = new Worker<TxVerificationJobData>(
+  TX_VERIFICATION_QUEUE_NAME,
+  async (job: Job<TxVerificationJobData>) => {
+    const { txHash, source, organizationId } = job.data;
+
+    logger.info('Processing tx verification job', {
+      jobId: job.id,
+      txHash,
+      source: source ?? 'unknown',
+      organizationId,
+      attempt: job.attemptsMade,
+    });
+
+    try {
+      const record = await TransactionAuditService.fetchAndStore(txHash);
+
+      logger.info('Tx verified and stored', {
+        jobId: job.id,
+        txHash,
+        ledger: record.ledger_sequence,
+        successful: record.successful,
+        source: source ?? 'unknown',
+      });
+
+      return;
+    } catch (error: any) {
+      if (isHorizonNotFound(error)) {
+        // Trigger retry with backoff; tx may not be indexed yet.
+        logger.warn('Tx not yet available on Horizon (will retry)', {
+          jobId: job.id,
+          txHash,
+          source: source ?? 'unknown',
+          attempt: job.attemptsMade,
+        });
+        throw error;
+      }
+
+      logger.error('Tx verification failed', {
+        jobId: job?.id,
+        txHash,
+        source: source ?? 'unknown',
+        attempt: job.attemptsMade,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw error;
+    }
+  },
+  {
+    connection: redisConnection,
+    concurrency: 5,
+  }
+);
+
+transactionVerificationWorker.on('completed', (job) => {
+  logger.info('Tx verification job completed', {
+    jobId: job.id,
+    txHash: job.data.txHash,
+    source: job.data.source ?? 'unknown',
+  });
+});
+
+transactionVerificationWorker.on('failed', (job, err) => {
+  logger.error('Tx verification job failed', {
+    jobId: job?.id,
+    txHash: job?.data?.txHash,
+    source: job?.data?.source ?? 'unknown',
+    attemptsMade: job?.attemptsMade,
+    error: err.message,
+  });
+});
+


### PR DESCRIPTION
Closes #747

---

## Summary\n- Add BullMQ tx verification queue + worker to fetch authoritative Horizon tx records and persist immutable audit logs.\n- Enqueue verification after payroll submissions, freeze/unfreeze, and contract upgrades.\n\n## Test plan\n- Start backend with Redis and DB.\n- Submit a payroll/freeze/upgrade tx and confirm a job is enqueued to 	x-verification.\n- Wait for Horizon indexing; verify row appears in 	ransaction_audit_logs and Socket.IO emits 	ransaction:update.\n

Made with [Cursor](https://cursor.com)