### PR TITLE
feat: rate limiting lockout, org settings cache, transaction metadata, and frontend a11y

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -7,8 +7,67 @@ import { config } from '../config/env.js';
 import jwt from 'jsonwebtoken';
 import { validatePasswordStrength } from '../utils/passwordStrength.js';
 import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
+import { getRedisClient } from '../services/rateLimitService.js';
 
 const pool = new Pool({ connectionString: config.DATABASE_URL });
+
+const MAX_FAILED_ATTEMPTS = 5;
+const LOCKOUT_SECONDS = 15 * 60; // 15 minutes
+
+async function recordFailedAttempt(walletAddress: string): Promise<void> {
+  const redis = getRedisClient();
+  const key = `login:failures:${walletAddress}`;
+  if (redis) {
+    const attempts = await redis.incr(key);
+    if (attempts === 1) await redis.expire(key, LOCKOUT_SECONDS);
+  } else {
+    await pool.query(
+      `UPDATE users
+       SET failed_login_attempts = failed_login_attempts + 1,
+           locked_until = CASE
+             WHEN failed_login_attempts + 1 >= $1
+               THEN NOW() + INTERVAL '${LOCKOUT_SECONDS} seconds'
+             ELSE locked_until
+           END
+       WHERE wallet_address = $2`,
+      [MAX_FAILED_ATTEMPTS, walletAddress]
+    );
+  }
+}
+
+async function clearFailedAttempts(walletAddress: string): Promise<void> {
+  const redis = getRedisClient();
+  if (redis) {
+    await redis.del(`login:failures:${walletAddress}`);
+  } else {
+    await pool.query(
+      `UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE wallet_address = $1`,
+      [walletAddress]
+    );
+  }
+}
+
+async function isLockedOut(walletAddress: string): Promise<{ locked: boolean; retryAfter?: number }> {
+  const redis = getRedisClient();
+  if (redis) {
+    const key = `login:failures:${walletAddress}`;
+    const attempts = parseInt((await redis.get(key)) ?? '0', 10);
+    if (attempts >= MAX_FAILED_ATTEMPTS) {
+      const ttl = await redis.ttl(key);
+      return { locked: true, retryAfter: ttl > 0 ? ttl : LOCKOUT_SECONDS };
+    }
+    return { locked: false };
+  }
+  const result = await pool.query(
+    `SELECT locked_until FROM users WHERE wallet_address = $1`,
+    [walletAddress]
+  );
+  const lockedUntil: Date | null = result.rows[0]?.locked_until ?? null;
+  if (lockedUntil && lockedUntil > new Date()) {
+    return { locked: true, retryAfter: Math.ceil((lockedUntil.getTime() - Date.now()) / 1000) };
+  }
+  return { locked: false };
+}
 
 export class AuthController {
   /**
@@ -176,6 +235,14 @@ export class AuthController {
     }
 
     try {
+      const lockout = await isLockedOut(walletAddress);
+      if (lockout.locked) {
+        return res.status(429).json({
+          ...apiErrorResponse(ErrorCodes.TOO_MANY_REQUESTS ?? 'TOO_MANY_REQUESTS', 'Account temporarily locked due to too many failed attempts.'),
+          retryAfter: lockout.retryAfter,
+        });
+      }
+
       const result = await pool.query(
         'SELECT id, wallet_address, organization_id, role, totp_secret FROM users WHERE wallet_address = $1',
         [walletAddress]
@@ -188,11 +255,11 @@ export class AuthController {
       const isValid = authenticator.check(token, user.totp_secret);
 
       if (isValid) {
+        await clearFailedAttempts(walletAddress);
         await pool.query('UPDATE users SET is_2fa_enabled = true WHERE wallet_address = $1', [
           walletAddress,
         ]);
 
-        // Issue tokens upon successful 2FA verification
         const accessToken = jwt.sign(
           {
             id: user.id,
@@ -221,6 +288,7 @@ export class AuthController {
           message: '2FA verified successfully',
         });
       } else {
+        await recordFailedAttempt(walletAddress);
         res.status(401).json(apiErrorResponse(ErrorCodes.UNAUTHORIZED, 'Invalid 2FA token'));
       }
     } catch (error: any) {
@@ -276,6 +344,14 @@ export class AuthController {
     }
 
     try {
+      const lockout = await isLockedOut(walletAddress);
+      if (lockout.locked) {
+        return res.status(429).json({
+          ...apiErrorResponse(ErrorCodes.TOO_MANY_REQUESTS ?? 'TOO_MANY_REQUESTS', 'Account temporarily locked due to too many failed attempts.'),
+          retryAfter: lockout.retryAfter,
+        });
+      }
+
       const result = await pool.query(
         'SELECT id, wallet_address, organization_id, role, is_2fa_enabled FROM users WHERE wallet_address = $1',
         [walletAddress]

--- a/backend/src/controllers/organizationController.ts
+++ b/backend/src/controllers/organizationController.ts
@@ -11,6 +11,18 @@ import { z } from 'zod';
 import { pool } from '../config/database.js';
 import { orgAuditService } from '../services/orgAuditService.js';
 import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
+import { getRedisClient } from '../services/rateLimitService.js';
+
+const ORG_CACHE_TTL = 300; // 5 minutes
+
+function orgCacheKey(organizationId: number | string): string {
+  return `org:settings:${organizationId}`;
+}
+
+async function invalidateOrgCache(organizationId: number | string): Promise<void> {
+  const redis = getRedisClient();
+  if (redis) await redis.del(orgCacheKey(organizationId));
+}
 
 // ─── Validation Schemas ───────────────────────────────────────────────────────
 
@@ -40,6 +52,16 @@ export const OrganizationController = {
     }
 
     try {
+      const redis = getRedisClient();
+      const cacheKey = orgCacheKey(organizationId);
+
+      if (redis) {
+        const cached = await redis.get(cacheKey);
+        if (cached) {
+          return res.status(200).json({ success: true, data: JSON.parse(cached) });
+        }
+      }
+
       const result = await pool.query<{
         id: number;
         name: string;
@@ -53,6 +75,8 @@ export const OrganizationController = {
       if (result.rows.length === 0) {
         return res.status(404).json(apiErrorResponse(ErrorCodes.NOT_FOUND, 'Organization not found'));
       }
+
+      if (redis) await redis.setex(cacheKey, ORG_CACHE_TTL, JSON.stringify(result.rows[0]));
 
       return res.status(200).json({ success: true, data: result.rows[0] });
     } catch (err) {
@@ -108,6 +132,8 @@ export const OrganizationController = {
         actorEmail: req.user?.email ?? undefined,
         actorIp: req.ip,
       });
+
+      void invalidateOrgCache(organizationId);
 
       return res.status(200).json({ success: true, data: result.rows[0] });
     } catch (err) {
@@ -167,6 +193,8 @@ export const OrganizationController = {
         actorEmail: req.user?.email ?? undefined,
         actorIp: req.ip,
       });
+
+      void invalidateOrgCache(organizationId);
 
       return res.status(200).json({ success: true, data: result.rows[0] });
     } catch (err) {

--- a/backend/src/db/migrations/029_add_login_lockout_to_users.sql
+++ b/backend/src/db/migrations/029_add_login_lockout_to_users.sql
@@ -1,0 +1,14 @@
+-- =============================================================================
+-- Migration 029: Add login lockout tracking columns to users
+-- Purpose : Track consecutive failed login / 2FA attempts per user so the
+--           application can enforce a temporary lockout after repeated failures
+--           without relying solely on Redis (persists across restarts).
+-- =============================================================================
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS failed_login_attempts INT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_users_locked_until
+  ON users (locked_until)
+  WHERE locked_until IS NOT NULL;

--- a/backend/src/db/migrations/030_add_metadata_to_transaction_audit_logs.sql
+++ b/backend/src/db/migrations/030_add_metadata_to_transaction_audit_logs.sql
@@ -1,0 +1,13 @@
+-- =============================================================================
+-- Migration 030: Add metadata column to transaction_audit_logs
+-- Purpose : Allow callers to attach arbitrary key-value context to an audit
+--           record (e.g. payroll run ID, employee ID, notes) without polluting
+--           the core immutable fields.  JSONB enables indexed queries.
+-- =============================================================================
+
+ALTER TABLE transaction_audit_logs
+  ADD COLUMN IF NOT EXISTS metadata JSONB;
+
+CREATE INDEX IF NOT EXISTS idx_tx_audit_metadata
+  ON transaction_audit_logs USING gin (metadata)
+  WHERE metadata IS NOT NULL;

--- a/backend/src/services/transactionAuditService.ts
+++ b/backend/src/services/transactionAuditService.ts
@@ -14,6 +14,7 @@ export interface AuditRecord {
   operation_count: number;
   memo: string | null;
   successful: boolean;
+  metadata: Record<string, unknown> | null;
   created_at: string;
 }
 
@@ -23,7 +24,10 @@ export class TransactionAuditService {
    * then store it as an immutable audit record in the DB.
    * Returns the existing record if the hash was already audited.
    */
-  static async fetchAndStore(txHash: string): Promise<AuditRecord> {
+  static async fetchAndStore(
+    txHash: string,
+    metadata?: Record<string, unknown>
+  ): Promise<AuditRecord> {
     // Check if already stored
     const existing = await pool.query('SELECT * FROM transaction_audit_logs WHERE tx_hash = $1', [
       txHash,
@@ -38,8 +42,8 @@ export class TransactionAuditService {
       `INSERT INTO transaction_audit_logs
         (tx_hash, ledger_sequence, stellar_created_at, envelope_xdr,
          result_xdr, source_account, fee_charged, operation_count,
-         memo, successful)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         memo, successful, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         tx.hash,
@@ -52,6 +56,7 @@ export class TransactionAuditService {
         tx.operation_count,
         tx.memo || null,
         tx.successful,
+        metadata ? JSON.stringify(metadata) : null,
       ]
     );
 
@@ -159,5 +164,23 @@ export class TransactionAuditService {
       record.ledger_sequence === tx.ledger_attr;
 
     return { verified, record };
+  }
+
+  /**
+   * Attach or replace arbitrary metadata on an existing audit record.
+   * Returns the updated record, or null if the hash is not found.
+   */
+  static async setMetadata(
+    txHash: string,
+    metadata: Record<string, unknown>
+  ): Promise<AuditRecord | null> {
+    const result = await pool.query(
+      `UPDATE transaction_audit_logs
+       SET metadata = $1
+       WHERE tx_hash = $2
+       RETURNING *`,
+      [JSON.stringify(metadata), txHash]
+    );
+    return result.rows[0] ?? null;
   }
 }

--- a/frontend/src/components/BulkPaymentStatusTracker.tsx
+++ b/frontend/src/components/BulkPaymentStatusTracker.tsx
@@ -444,13 +444,16 @@ function FragmentRow({
                     rowCount={summary.items.length}
                     rowHeight={92}
                     rowComponent={VirtualizedRecipientRow}
-                    rowProps={{
-                      items: summary.items,
-                      run,
-                      onChainState,
-                      retryingKey,
-                      onRetry,
-                    }}
+                    rowProps={
+                      {
+                        items: summary.items,
+                        run,
+                        onChainState,
+                        retryingKey,
+                        onRetry,
+                        // index and style are injected per-row by List at render time
+                      } as any
+                    }
                     style={{ height: 400, width: '100%' }}
                   />
                 ) : (

--- a/frontend/src/components/SchedulingWizard.tsx
+++ b/frontend/src/components/SchedulingWizard.tsx
@@ -363,7 +363,8 @@ export const SchedulingWizard = ({
             </div>
 
             <div className="md:col-span-2 rounded-2xl border border-hi bg-black/15 p-4 text-sm text-muted">
-              Previewed dates are rendered in <span className="font-semibold text-text">{timezoneLabel}</span>.
+              Previewed dates are rendered in{' '}
+              <span className="font-semibold text-text">{timezoneLabel}</span>.
             </div>
           </div>
         ) : null}
@@ -454,7 +455,9 @@ export const SchedulingWizard = ({
                     <span className="font-mono text-text">{config.timeOfDay}</span>
                   </div>
                   <div>
-                    <span className="block text-xs uppercase tracking-wider text-muted">Timezone</span>
+                    <span className="block text-xs uppercase tracking-wider text-muted">
+                      Timezone
+                    </span>
                     <span className="font-semibold text-text">{timezoneLabel}</span>
                   </div>
                   <div>
@@ -528,9 +531,7 @@ export const SchedulingWizard = ({
             role="alert"
           >
             <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-            <div>
-              {errors.dayOfMonth ?? errors.dayOfWeek ?? errors.timeOfDay}
-            </div>
+            <div>{errors.dayOfMonth ?? errors.dayOfWeek ?? errors.timeOfDay}</div>
           </div>
         ) : null}
 

--- a/frontend/src/components/TransactionPendingOverlay.tsx
+++ b/frontend/src/components/TransactionPendingOverlay.tsx
@@ -74,9 +74,7 @@ export const TransactionPendingOverlay: React.FC<TransactionPendingOverlayProps>
     >
       {visibleTransactions.map((transaction) => {
         const title = getStatusLabel(transaction.status);
-        const explorerUrl = transaction.hash
-          ? getTxExplorerUrl(transaction.hash, network)
-          : null;
+        const explorerUrl = transaction.hash ? getTxExplorerUrl(transaction.hash, network) : null;
 
         return (
           <article
@@ -98,10 +96,7 @@ export const TransactionPendingOverlay: React.FC<TransactionPendingOverlayProps>
                     />
                   ) : null}
                   {transaction.status === 'confirmed' ? (
-                    <CheckCircle2
-                      className="h-5 w-5 text-[var(--success)]"
-                      aria-hidden="true"
-                    />
+                    <CheckCircle2 className="h-5 w-5 text-[var(--success)]" aria-hidden="true" />
                   ) : null}
                   {transaction.status === 'failed' ? (
                     <XCircle className="h-5 w-5 text-[var(--danger)]" aria-hidden="true" />

--- a/frontend/src/hooks/useWalletManager.ts
+++ b/frontend/src/hooks/useWalletManager.ts
@@ -32,7 +32,7 @@ function hasAnyWalletExtension(): boolean {
   return Boolean(extendedWindow.freighterApi || extendedWindow.xBullSDK || extendedWindow.lobstr);
 }
 
-export function useWalletManager() {
+export function useWalletManager(connectionTimeoutMs: number = 15000) {
   const [address, setAddress] = useState<string | null>(null);
   const [walletName, setWalletName] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
@@ -117,7 +117,7 @@ export function useWalletManager() {
         const timeoutPromise = new Promise<{ address: string }>((_, reject) => {
           timeoutId = setTimeout(
             () => reject(new Error('Connection timed out after 15 seconds.')),
-            15000
+            connectionTimeoutMs
           );
         });
 

--- a/frontend/src/pages/DeveloperSettings/WebhookLogs.tsx
+++ b/frontend/src/pages/DeveloperSettings/WebhookLogs.tsx
@@ -284,7 +284,7 @@ const WebhookLogs: React.FC = () => {
               </div>
 
               <div className="pt-4 border-t border-white/5">
-                <Button fullWidth variant="secondary" onClick={() => setSelectedLog(null)}>
+                <Button isFullWidth variant="secondary" onClick={() => setSelectedLog(null)}>
                   Close Details
                 </Button>
               </div>
@@ -309,7 +309,7 @@ const WebhookLogs: React.FC = () => {
             <p className="text-xs text-slate-400">
               Manually trigger a test event to verify your endpoint configuration.
             </p>
-            <Button fullWidth variant="primary" size="sm" className="glow-mint">
+            <Button isFullWidth variant="primary" size="sm" className="glow-mint">
               Send Test Ping
             </Button>
           </div>

--- a/frontend/src/pages/DeveloperSettings/WebhookLogs.tsx
+++ b/frontend/src/pages/DeveloperSettings/WebhookLogs.tsx
@@ -1,17 +1,17 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { 
-  Activity, 
-  RefreshCcw, 
-  CheckCircle2, 
-  XCircle, 
-  Clock, 
-  ChevronRight, 
+import {
+  Activity,
+  RefreshCcw,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  ChevronRight,
   Terminal,
   Filter,
   Search,
   ExternalLink,
-  Code2
+  Code2,
 } from 'lucide-react';
 import { Button } from '@stellar/design-system';
 import axiosInstance from '../../api/axiosInstance';
@@ -119,7 +119,10 @@ const WebhookLogs: React.FC = () => {
             {t('webhooks.logs.title', 'Webhook Delivery Logs')}
           </h1>
           <p className="text-slate-400 mt-1">
-            {t('webhooks.logs.subtitle', 'Monitor and debug event deliveries to your configured endpoints.')}
+            {t(
+              'webhooks.logs.subtitle',
+              'Monitor and debug event deliveries to your configured endpoints.'
+            )}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -143,7 +146,10 @@ const WebhookLogs: React.FC = () => {
           <div className="card !p-0 overflow-hidden">
             <div className="p-4 border-b border-white/5 bg-white/2 flex items-center justify-between">
               <div className="relative flex-1 max-w-sm">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={16} />
+                <Search
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500"
+                  size={16}
+                />
                 <input
                   type="text"
                   placeholder="Filter by event or ID..."
@@ -190,7 +196,9 @@ const WebhookLogs: React.FC = () => {
                       >
                         <td className="px-6 py-4">
                           <div className="font-medium text-slate-200">{log.eventType}</div>
-                          <div className="text-xs text-slate-500 font-mono">#{log.id.toString().slice(-8)}</div>
+                          <div className="text-xs text-slate-500 font-mono">
+                            #{log.id.toString().slice(-8)}
+                          </div>
                         </td>
                         <td className="px-6 py-4 text-center">
                           {getStatusBadge(log.status)}
@@ -230,12 +238,18 @@ const WebhookLogs: React.FC = () => {
               <div className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div className="p-3 bg-white/2 rounded-lg border border-white/5 text-center">
-                    <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-1">Attempt</p>
+                    <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-1">
+                      Attempt
+                    </p>
                     <p className="text-lg font-bold font-mono">#{selectedLog.attemptNumber}</p>
                   </div>
                   <div className="p-3 bg-white/2 rounded-lg border border-white/5 text-center">
-                    <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-1">Status</p>
-                    <div className="flex justify-center mt-1">{getStatusBadge(selectedLog.status)}</div>
+                    <p className="text-[10px] uppercase tracking-wider text-slate-500 mb-1">
+                      Status
+                    </p>
+                    <div className="flex justify-center mt-1">
+                      {getStatusBadge(selectedLog.status)}
+                    </div>
                   </div>
                 </div>
 

--- a/frontend/src/pages/EmployeePortal.tsx
+++ b/frontend/src/pages/EmployeePortal.tsx
@@ -492,6 +492,7 @@ const EmployeePortal: React.FC = () => {
               className={styles.pageBtn}
               onClick={() => setCurrentPage(currentPage - 1)}
               disabled={currentPage <= 1}
+              aria-label="Previous page"
             >
               ‹
             </button>
@@ -500,6 +501,8 @@ const EmployeePortal: React.FC = () => {
                 key={p}
                 className={`${styles.pageBtn} ${p === currentPage ? styles.pageBtnActive : ''}`}
                 onClick={() => setCurrentPage(p)}
+                aria-label={`Page ${p}`}
+                aria-current={p === currentPage ? 'page' : undefined}
               >
                 {p}
               </button>
@@ -508,6 +511,7 @@ const EmployeePortal: React.FC = () => {
               className={styles.pageBtn}
               onClick={() => setCurrentPage(currentPage + 1)}
               disabled={currentPage >= totalPages}
+              aria-label="Next page"
             >
               ›
             </button>

--- a/frontend/src/pages/PayrollAnalytics.tsx
+++ b/frontend/src/pages/PayrollAnalytics.tsx
@@ -171,7 +171,9 @@ export default function PayrollAnalytics() {
           <motion.div variants={cardVariants}>
             <Card>
               <div className="p-6">
-                <p className="text-sm font-medium text-gray-500 uppercase tracking-wider">Total Payroll</p>
+                <p className="text-sm font-medium text-gray-500 uppercase tracking-wider">
+                  Total Payroll
+                </p>
                 <h3 className="text-3xl font-bold mt-1 text-indigo-500">
                   ${data.trends.reduce((acc, curr) => acc + curr.total, 0).toLocaleString()}
                 </h3>
@@ -184,7 +186,9 @@ export default function PayrollAnalytics() {
           <motion.div variants={cardVariants}>
             <Card>
               <div className="p-6">
-                <p className="text-sm font-medium text-gray-500 uppercase tracking-wider">Avg. Salary</p>
+                <p className="text-sm font-medium text-gray-500 uppercase tracking-wider">
+                  Avg. Salary
+                </p>
                 <h3 className="text-3xl font-bold mt-1 text-cyan-500">$5,420</h3>
                 <p className="text-xs text-gray-400 mt-2">Across 42 employees</p>
               </div>
@@ -193,7 +197,9 @@ export default function PayrollAnalytics() {
           <motion.div variants={cardVariants}>
             <Card>
               <div className="p-6">
-                <p className="text-sm font-medium text-gray-500 uppercase tracking-wider">Payment Success</p>
+                <p className="text-sm font-medium text-gray-500 uppercase tracking-wider">
+                  Payment Success
+                </p>
                 <h3 className="text-3xl font-bold mt-1 text-amber-500">98.4%</h3>
                 <p className="text-xs text-gray-400 mt-2">Historical average</p>
               </div>

--- a/frontend/src/pages/PayrollScheduler.tsx
+++ b/frontend/src/pages/PayrollScheduler.tsx
@@ -304,10 +304,7 @@ export default function PayrollScheduler() {
         const errorMessage = axios.isAxiosError(err)
           ? ((err as AxiosError<{ error?: string }>).response?.data?.error ?? fallback)
           : fallback;
-        notifyApiError(
-          'Webhook trigger failed',
-          errorMessage
-        );
+        notifyApiError('Webhook trigger failed', errorMessage);
         console.warn('Webhook trigger error:', err);
       }
 

--- a/frontend/src/pages/PayrollScheduler.tsx
+++ b/frontend/src/pages/PayrollScheduler.tsx
@@ -2,7 +2,7 @@ import { Button, Card, Heading, Input, Select, Text } from '@stellar/design-syst
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import axios, { AxiosError } from 'axios';
-import { CalendarDays, Clock3, PencilLine } from 'lucide-react';
+import { CalendarDays, Clock3, PencilLine, Inbox } from 'lucide-react';
 
 // Type assertion for Stellar components to work around library typing issues
 const InputComponent = Input as unknown as React.FC<Record<string, unknown>>;
@@ -588,9 +588,12 @@ export default function PayrollScheduler() {
         </Heading>
         <Card>
           {pendingClaims.length === 0 ? (
-            <Text as="p" size="sm" weight="regular" addlClassName="text-muted">
-              No pending claimable balances.
-            </Text>
+            <div className="flex flex-col items-center justify-center py-10 gap-3 text-center">
+              <Inbox size={40} className="text-muted opacity-50" aria-hidden="true" />
+              <Text as="p" size="sm" weight="regular" addlClassName="text-muted">
+                No pending claimable balances.
+              </Text>
+            </div>
           ) : (
             <ul className="flex flex-col gap-4">
               {pendingClaims.map((claim: PendingClaim) => (

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -11,7 +11,9 @@ export default function Settings() {
     <div className="flex-1 flex flex-col items-center justify-start p-6 md:p-12 max-w-3xl mx-auto w-full">
       <div className="w-full mb-8 md:mb-12 flex items-end justify-between border-b border-hi pb-6 md:pb-8">
         <div>
-          <h1 className="text-3xl md:text-4xl font-black mb-2 tracking-tight">{t('settings.title')}</h1>
+          <h1 className="text-3xl md:text-4xl font-black mb-2 tracking-tight">
+            {t('settings.title')}
+          </h1>
         </div>
       </div>
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -8,22 +8,27 @@ export default function Settings() {
   };
 
   return (
-    <div className="flex-1 flex flex-col items-center justify-start p-12 max-w-3xl mx-auto w-full">
-      <div className="w-full mb-12 flex items-end justify-between border-b border-hi pb-8">
+    <div className="flex-1 flex flex-col items-center justify-start p-6 md:p-12 max-w-3xl mx-auto w-full">
+      <div className="w-full mb-8 md:mb-12 flex items-end justify-between border-b border-hi pb-6 md:pb-8">
         <div>
-          <h1 className="text-4xl font-black mb-2 tracking-tight">{t('settings.title')}</h1>
+          <h1 className="text-3xl md:text-4xl font-black mb-2 tracking-tight">{t('settings.title')}</h1>
         </div>
       </div>
 
-      <div className="w-full card glass noise p-8">
+      <div className="w-full card glass noise p-6 md:p-8">
         <div className="flex flex-col gap-3">
-          <label className="block text-xs font-bold uppercase tracking-widest text-muted">
+          <label
+            htmlFor="language-select"
+            className="block text-xs font-bold uppercase tracking-widest text-muted"
+          >
             {t('settings.languageLabel')}
           </label>
           <p className="text-sm text-muted">{t('settings.languageDescription')}</p>
           <select
+            id="language-select"
             value={i18n.language}
             onChange={handleChangeLanguage}
+            aria-label={t('settings.languageLabel')}
             className="w-full bg-black/20 border border-hi rounded-xl p-4 text-text outline-none focus:border-accent/50 focus:bg-accent/5 transition-all"
           >
             <option value="en">{t('settings.languageEnglish')}</option>

--- a/frontend/src/providers/WalletProvider.tsx
+++ b/frontend/src/providers/WalletProvider.tsx
@@ -3,7 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { WalletContext } from '../hooks/useWallet';
 import { useWalletManager } from '../hooks/useWalletManager';
 
-export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const WalletProvider: React.FC<{
+  children: React.ReactNode;
+  connectionTimeoutMs?: number;
+}> = ({ children, connectionTimeoutMs }) => {
   const { t } = useTranslation();
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
@@ -23,7 +26,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     setWalletModalOpen,
     walletOptions,
     connectWithWallet: baseConnectWithWallet,
-  } = useWalletManager();
+  } = useWalletManager(connectionTimeoutMs);
 
   const connectWithWallet = async (selectedWalletId: string): Promise<string | null> => {
     setConnectionError(null);

--- a/frontend/src/providers/__tests__/WalletProvider.test.tsx
+++ b/frontend/src/providers/__tests__/WalletProvider.test.tsx
@@ -37,9 +37,9 @@ vi.mock('@creit.tech/stellar-wallets-kit', () => ({
     TESTNET: 'TESTNET',
     PUBLIC: 'PUBLIC',
   },
-  FreighterModule: class { },
-  xBullModule: class { },
-  LobstrModule: class { },
+  FreighterModule: class {},
+  xBullModule: class {},
+  LobstrModule: class {},
   FREIGHTER_ID: 'freighter',
   LOBSTR_ID: 'lobstr',
 }));

--- a/frontend/src/services/bulkPaymentStatus.ts
+++ b/frontend/src/services/bulkPaymentStatus.ts
@@ -91,8 +91,6 @@ function getNetworkPassphrase(): string {
   return network === 'MAINNET' ? Networks.PUBLIC : Networks.TESTNET;
 }
 
-
-
 function getReadMethodName(key: 'batch' | 'payment' | 'retry'): string {
   if (key === 'batch') {
     return (
@@ -293,12 +291,12 @@ export async function fetchPayrollRuns(
   page = 1,
   limit = 20
 ): Promise<{ data: PayrollRunRecord[]; total: number }> {
-  const response = await axiosInstance.get<{ success: boolean; data: { data: PayrollRunRecord[]; total: number } }>(
-    `/api/v1/payroll-bonus/runs`,
-    {
-      params: { page, limit },
-    }
-  );
+  const response = await axiosInstance.get<{
+    success: boolean;
+    data: { data: PayrollRunRecord[]; total: number };
+  }>(`/api/v1/payroll-bonus/runs`, {
+    params: { page, limit },
+  });
 
   return response.data.data;
 }

--- a/frontend/src/services/claimableBalance.ts
+++ b/frontend/src/services/claimableBalance.ts
@@ -50,7 +50,9 @@ class ClaimableBalanceService {
   }
 
   async getClaimsSummary(): Promise<ClaimsSummary> {
-    const response = await axiosInstance.get<{ success: boolean; data: ClaimsSummary }>(`${this.baseUrl}/summary`);
+    const response = await axiosInstance.get<{ success: boolean; data: ClaimsSummary }>(
+      `${this.baseUrl}/summary`
+    );
     return response.data.data;
   }
 
@@ -58,14 +60,19 @@ class ClaimableBalanceService {
     employeeId: number,
     options: { status?: string; page?: number; limit?: number } = {}
   ): Promise<PaginatedClaims> {
-    const response = await axiosInstance.get<PaginatedClaims>(`${this.baseUrl}/employee/${employeeId}`, {
-      params: options,
-    });
+    const response = await axiosInstance.get<PaginatedClaims>(
+      `${this.baseUrl}/employee/${employeeId}`,
+      {
+        params: options,
+      }
+    );
     return response.data;
   }
 
   async getClaimById(id: number): Promise<ClaimableBalance> {
-    const response = await axiosInstance.get<{ success: boolean; data: ClaimableBalance }>(`${this.baseUrl}/${id}`);
+    const response = await axiosInstance.get<{ success: boolean; data: ClaimableBalance }>(
+      `${this.baseUrl}/${id}`
+    );
     return response.data.data;
   }
 

--- a/frontend/src/services/contracts.ts
+++ b/frontend/src/services/contracts.ts
@@ -37,7 +37,9 @@ class ContractService {
 
     for (let attempt = 1; attempt <= this.MAX_RETRIES; attempt++) {
       try {
-        const response = await axiosInstance.get<ContractRegistry>(`${this.API_BASE_URL}/api/contracts`);
+        const response = await axiosInstance.get<ContractRegistry>(
+          `${this.API_BASE_URL}/api/contracts`
+        );
 
         // Update cache
         this.cache = response.data;

--- a/frontend/src/services/transactionHistoryApi.ts
+++ b/frontend/src/services/transactionHistoryApi.ts
@@ -29,8 +29,6 @@ import { AxiosError } from 'axios';
 // Configuration
 // ============================================================================
 
-
-
 // ============================================================================
 // Error Handling
 // ============================================================================
@@ -88,8 +86,6 @@ export function categorizeError(error: unknown): ErrorState {
 // ============================================================================
 // Query Parameter Building
 // ============================================================================
-
-
 
 // ============================================================================
 // Audit API Functions
@@ -158,15 +154,18 @@ export async function fetchContractEvents(
   const { contractId, page, limit, eventType, category } = options;
 
   try {
-    const response = await axiosInstance.get<ContractEventsApiResponse>(`/api/events/${contractId}`, {
-      params: {
-        page,
-        limit,
-        eventType,
-        category,
-      },
-      signal,
-    });
+    const response = await axiosInstance.get<ContractEventsApiResponse>(
+      `/api/events/${contractId}`,
+      {
+        params: {
+          page,
+          limit,
+          eventType,
+          category,
+        },
+        signal,
+      }
+    );
 
     return response.data;
   } catch (error) {

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -60,9 +60,7 @@ export async function getWalletInfo(): Promise<WalletInfo | null> {
   }
 }
 
-export async function signTransactionWithWallet(
-  options: SignTransactionOptions
-): Promise<string> {
+export async function signTransactionWithWallet(options: SignTransactionOptions): Promise<string> {
   const { transactionXdr, network } = options;
   const freighter = getFreighterApi();
   if (!freighter) {
@@ -76,10 +74,7 @@ export async function signTransactionWithWallet(
   return signed;
 }
 
-export function signTransactionObject(
-  keypair: Keypair,
-  transaction: Transaction
-): Transaction {
+export function signTransactionObject(keypair: Keypair, transaction: Transaction): Transaction {
   const signable = transaction as Transaction & { sign: (kp: Keypair) => void };
   signable.sign(keypair);
   return transaction;

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -89,7 +89,7 @@ export class LocalStorageHelper<T> {
     window.localStorage.setItem(this.key, JSON.stringify(payload));
   }
 
-  /** 
+  /**
    * Remove the stored key and its value from localStorage.
    * No-op during server-side rendering (SSR).
    */

--- a/frontend/src/utils/scheduling.ts
+++ b/frontend/src/utils/scheduling.ts
@@ -39,9 +39,7 @@ export function clampDayOfMonth(year: number, monthIndex: number, desired: numbe
   return Math.max(1, Math.min(desired, lastDay));
 }
 
-export function validateSchedulingConfig(
-  config: SchedulingConfig
-): SchedulingValidationErrors {
+export function validateSchedulingConfig(config: SchedulingConfig): SchedulingValidationErrors {
   const errors: SchedulingValidationErrors = {};
 
   if (!TIME_OF_DAY_PATTERN.test(config.timeOfDay)) {
@@ -65,10 +63,7 @@ export function validateSchedulingConfig(
   return errors;
 }
 
-export function computeNextRunDate(
-  config: SchedulingConfig,
-  from: Date = new Date()
-): Date {
+export function computeNextRunDate(config: SchedulingConfig, from: Date = new Date()): Date {
   const { hours, minutes } = parseTimeOfDay(config.timeOfDay);
 
   if (config.frequency === 'monthly') {

--- a/frontend/src/utils/stellarExpert.ts
+++ b/frontend/src/utils/stellarExpert.ts
@@ -17,7 +17,7 @@ const EXPLORER_BASE =
   'https://stellar.expert/explorer/testnet/tx/';
 
 /**
- * Resolve a human-friendly network string to the specific path segment 
+ * Resolve a human-friendly network string to the specific path segment
  * recognized by Stellar Expert (`public` or `testnet`).
  *
  * @param network - Network identifier (e.g., 'MAINNET', 'TESTNET', 'public')
@@ -32,7 +32,7 @@ function resolveNetwork(network: string): 'public' | 'testnet' {
  * Build a full Stellar Expert transaction explorer URL.
  *
  * @param txHash - The 64-character hex transaction hash
- * @param network - Optional network identifier; when omitted, the 
+ * @param network - Optional network identifier; when omitted, the
  *                `VITE_STELLAR_EXPLORER_TX_URL` env var is used as a base
  * @returns The complete transaction explorer URL
  */


### PR DESCRIPTION
## Summary

- **#342** — Rate limiting for login attempts: track consecutive failed 2FA/login attempts per wallet address using Redis (with DB fallback). Account is locked for 15 minutes after 5 failures; cleared on success.
- **#343** — Caching layer for organization settings: `GET /api/v1/organizations/me` now reads from a 5-minute Redis cache and invalidates on name/issuer updates.
- **#344** — Metadata on transaction records: adds a `JSONB metadata` column to `transaction_audit_logs`, exposes it via `fetchAndStore(hash, metadata?)` and a new `setMetadata(hash, metadata)` method.
- **#658** — Frontend UI/UX refinement: responsive padding in Settings, `htmlFor`/`aria-label` on language select, `aria-label`/`aria-current` on EmployeePortal pagination, and a styled icon empty state for pending claims in PayrollScheduler.

## Changes

| File | Purpose |
|------|---------|
| `backend/src/db/migrations/029_add_login_lockout_to_users.sql` | Add `failed_login_attempts` + `locked_until` columns |
| `backend/src/controllers/authController.ts` | Lockout helpers + checks in `login` and `verify2fa` |
| `backend/src/controllers/organizationController.ts` | Redis cache read/write/invalidate for org settings |
| `backend/src/db/migrations/030_add_metadata_to_transaction_audit_logs.sql` | Add `metadata JSONB` + GIN index |
| `backend/src/services/transactionAuditService.ts` | `metadata` in interface, `fetchAndStore`, and new `setMetadata` |
| `frontend/src/pages/Settings.tsx` | Responsive padding, `htmlFor`/`aria-label` on language select |
| `frontend/src/pages/EmployeePortal.tsx` | `aria-label` + `aria-current` on pagination buttons |
| `frontend/src/pages/PayrollScheduler.tsx` | Styled Inbox icon empty state for pending claims |

Closes #342
Closes #343
Closes #344
Closes #658