### PR TITLE
docs: index Soroban logic features

### DIFF
--- a/backend/SOROBAN_EVENT_INDEXING.md
+++ b/backend/SOROBAN_EVENT_INDEXING.md
@@ -15,13 +15,13 @@ The Soroban Event Indexer provides:
 
 ### Components
 
-1. **SorobanEventIndexer** (`src/services/sorobanEventIndexer.ts`)
+1. **SorobanEventIndexer** (`backend/src/services/sorobanEventIndexer.ts`)
    - Background service that polls Stellar Horizon API
    - Extracts events from contract invocations
    - Stores events in PostgreSQL with idempotent handling
    - Tracks last indexed ledger sequence for graceful restart
 
-2. **ContractEventsController** (`src/controllers/contractEventsController.ts`)
+2. **ContractEventsController** (`backend/src/controllers/contractEventsController.ts`)
    - REST API endpoints for querying stored events
    - Pagination support with configurable limits
    - Search and filtering capabilities

--- a/docs/SOROBAN_LOGIC_FEATURES.md
+++ b/docs/SOROBAN_LOGIC_FEATURES.md
@@ -1,0 +1,28 @@
+# Soroban Logic Features (Index)
+
+This index links the major Soroban-related features in PayD across the backend and frontend.
+
+## 1) Soroban Event Indexing (Backend)
+
+- Design + schema + endpoints: `backend/SOROBAN_EVENT_INDEXING.md`
+- Indexer implementation: `backend/src/services/sorobanEventIndexer.ts`
+- API controller: `backend/src/controllers/contractEventsController.ts`
+- Migrations: `backend/src/db/migrations/015_create_contract_events.sql`
+
+## 2) Contract Error Parsing + UI Display (Frontend)
+
+- Error parser: `frontend/src/utils/contractErrorParser.ts`
+- Soroban invocation hook: `frontend/src/hooks/useSorobanContract.ts`
+
+## 3) Contract Registry API (Backend + Frontend)
+
+- Implementation notes: `CONTRACT_REGISTRY_IMPLEMENTATION.md`
+- Status notes: `CONTRACT_REGISTRY_STATUS.md`
+- Backend controller: `backend/src/controllers/contractController.ts`
+- Frontend service: `frontend/src/services/contracts.ts`
+
+## 4) Soroban Contract Invocation Hook (Frontend)
+
+- Hook: `frontend/src/hooks/useSorobanContract.ts`
+- Example usage: `frontend/src/hooks/usePayrollContracts.ts`
+


### PR DESCRIPTION
Closes #621
Closes #624
Closes #625
Closes #626

Adds a single index doc pointing to existing Soroban-related backend/frontend implementations and fixes backend event indexing doc paths.