### PR TITLE
Fix timezone handling for date-only inputs

### DIFF
--- a/DATEPAL_QUICK_REFERENCE.md
+++ b/DATEPAL_QUICK_REFERENCE.md
@@ -89,6 +89,18 @@ Just use your screen reader's normal navigation:
 import { AccessibleDatePicker } from "../components/AccessibleDatePicker";
 ```
 
+### Timezones (Date-only inputs)
+
+The date picker returns a **date-only** string (`YYYY-MM-DD`). Avoid parsing it with `new Date('YYYY-MM-DD')`
+since JavaScript treats that format as **UTC**, which can display as the previous/next day depending on the
+user's timezone.
+
+Use the shared helper instead:
+
+```ts
+import { parseDateString } from "../utils/dateHelpers";
+```
+
 ### Basic Usage
 
 ```tsx

--- a/frontend/src/pages/PayrollAnalytics.tsx
+++ b/frontend/src/pages/PayrollAnalytics.tsx
@@ -18,6 +18,7 @@ import {
 } from 'recharts';
 import type { PieLabelRenderProps } from 'recharts';
 import { Card } from '@stellar/design-system';
+import { parseDateString } from '../utils/dateHelpers';
 
 // recharts v3 + React 19: Legend's class-component typings conflict with React.JSX.
 // Cast it to a plain functional component to keep TypeScript happy.
@@ -59,8 +60,8 @@ async function fetchAnalytics(startDate: string, endDate: string): Promise<Analy
   // Simulates an API call — swap for `axios.get('/api/analytics/payroll', { params })`
   await new Promise((r) => setTimeout(r, 300));
 
-  const start = new Date(startDate);
-  const end = new Date(endDate);
+  const start = parseDateString(startDate) ?? new Date();
+  const end = parseDateString(endDate) ?? new Date();
 
   const trends: PayrollTrend[] = [];
   const metrics: PaymentMetric[] = [];

--- a/frontend/src/utils/dateHelpers.ts
+++ b/frontend/src/utils/dateHelpers.ts
@@ -1,8 +1,11 @@
-export function formatDate(dateString: string): string {
-  if (!dateString) return 'N/A';
+export function parseDateString(dateString: string): Date | null {
+  if (!dateString) return null;
 
+  // `new Date('YYYY-MM-DD')` is interpreted as UTC by the JS spec, which can produce
+  // off-by-one dates when rendered in local timezones. Date-only inputs in the UI
+  // should be treated as local calendar dates.
   const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
-  const date = dateOnlyMatch
+  const parsed = dateOnlyMatch
     ? new Date(
         Number.parseInt(dateOnlyMatch[1], 10),
         Number.parseInt(dateOnlyMatch[2], 10) - 1,
@@ -10,7 +13,16 @@ export function formatDate(dateString: string): string {
       )
     : new Date(dateString);
 
-  if (isNaN(date.getTime())) return dateString;
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+}
+
+export function formatDate(dateString: string): string {
+  if (!dateString) return 'N/A';
+
+  const date = parseDateString(dateString);
+  if (!date) return dateString;
+
   return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
@@ -19,7 +31,8 @@ export function formatDate(dateString: string): string {
 }
 
 export function getRemainingDays(targetDate: string | Date): number {
-  const target = typeof targetDate === 'string' ? new Date(targetDate) : targetDate;
+  const target =
+    typeof targetDate === 'string' ? (parseDateString(targetDate) ?? new Date('')) : targetDate;
   if (isNaN(target.getTime())) return 0;
 
   const now = new Date();


### PR DESCRIPTION
Fixes date-only parsing to avoid off-by-one issues across timezones (treats YYYY-MM-DD as a local calendar date).

Closes #335
Closes #620
Closes #622
Closes #623
