### PR TITLE
Add vesting escrow invariant checks

### DIFF
--- a/contracts/vesting_escrow/src/lib.rs
+++ b/contracts/vesting_escrow/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, contractevent, token, Address, Env, String};
+#![allow(clippy::too_many_arguments)]
+use soroban_sdk::{
+    Address, Env, String, contract, contractevent, contractimpl, contracttype, token,
+};
 
 #[contracttype]
 #[derive(Clone)]
@@ -12,6 +15,19 @@ pub struct VestingConfig {
     pub total_amount: i128,
     pub claimed_amount: i128,
     pub clawback_admin: Address,
+    pub is_active: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct VestingSnapshot {
+    pub timestamp: u64,
+    pub vested_amount: i128,
+    pub claimable_amount: i128,
+    pub locked_amount: i128,
+    pub claimed_amount: i128,
+    pub total_amount: i128,
+    pub progress_bps: u32,
     pub is_active: bool,
 }
 
@@ -62,6 +78,7 @@ pub struct BeneficiaryTransferredEvent {
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
+const BASIS_POINTS_DENOMINATOR: u32 = 10_000;
 
 #[contract]
 pub struct VestingContract;
@@ -85,6 +102,11 @@ impl VestingContract {
         String::from_str(&env, env!("CARGO_PKG_AUTHORS"))
     }
 
+    /// Funds and initializes the vesting escrow.
+    ///
+    /// This function can only be called once. The `funder` authorizes the
+    /// transfer of `amount` tokens into the contract, after which the grant
+    /// becomes claimable according to the configured cliff and duration.
     pub fn initialize(
         e: Env,
         funder: Address,
@@ -99,15 +121,15 @@ impl VestingContract {
         if e.storage().persistent().has(&DataKey::Config) {
             panic!("Already initialized");
         }
-        
+
         funder.require_auth();
 
         if duration_seconds < cliff_seconds {
             panic!("Duration must be greater than or equal to cliff");
         }
-        
+
         if amount <= 0 {
-             panic!("Amount must be positive");
+            panic!("Amount must be positive");
         }
 
         let config = VestingConfig {
@@ -127,7 +149,7 @@ impl VestingContract {
 
         // Transfer tokens from funder to contract
         let client = token::Client::new(&e, &token);
-        client.transfer(&funder, &e.current_contract_address(), &amount);
+        client.transfer(&funder, e.current_contract_address(), &amount);
 
         VestingInitializedEvent {
             beneficiary,
@@ -136,19 +158,28 @@ impl VestingContract {
             cliff_seconds,
             duration_seconds,
             start_time,
-        }.publish(&e);
+        }
+        .publish(&e);
     }
 
+    /// Claims all currently vested and unclaimed tokens for the beneficiary.
+    ///
+    /// The beneficiary must authorize the call. If no new tokens have vested,
+    /// the function is a no-op.
     pub fn claim(e: Env) {
-        let mut config: VestingConfig = e.storage().persistent().get(&DataKey::Config).expect("Config entry unavailable; restore and retry");
-        
+        let mut config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
+
         config.beneficiary.require_auth();
 
         // Ledger sequence verification: prevent duplicate claims in the same ledger
         Self::require_unique_ledger(&e, &DataKey::LastClaimLedger);
-        
+
         let vested = Self::calc_vested(&e, &config);
-        let claimable = vested - config.claimed_amount;
+        let claimable = Self::calc_claimable(vested, config.claimed_amount);
 
         if claimable <= 0 {
             // Nothing to claim, just return
@@ -162,36 +193,53 @@ impl VestingContract {
 
         // Transfer tokens
         let client = token::Client::new(&e, &config.token);
-        client.transfer(&e.current_contract_address(), &config.beneficiary, &claimable);
+        client.transfer(
+            &e.current_contract_address(),
+            &config.beneficiary,
+            &claimable,
+        );
 
         TokensClaimedEvent {
             beneficiary: config.beneficiary,
             amount: claimable,
             total_claimed: config.claimed_amount,
-        }.publish(&e);
+        }
+        .publish(&e);
     }
-    
+
+    /// Terminates future vesting and returns unvested tokens to the admin.
+    ///
+    /// Already vested but unclaimed tokens remain in escrow for the beneficiary.
+    /// The clawback admin must authorize the call.
     pub fn clawback(e: Env) {
-        let mut config: VestingConfig = e.storage().persistent().get(&DataKey::Config).expect("Config entry unavailable; restore and retry");
-        
+        let mut config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
+
         config.clawback_admin.require_auth();
 
         // Ledger sequence verification: prevent duplicate clawback in the same ledger
         Self::require_unique_ledger(&e, &DataKey::LastClawbackLedger);
-        
+
         if !config.is_active {
             panic!("Already revoked/inactive");
         }
 
         // Calculate what has vested so far
         let vested = Self::calc_vested(&e, &config);
-        
-        // The unvested amount is the total scheduled minus what has vested
-        let unvested = config.total_amount - vested;
-        
+        let vested_floor = Self::max_i128(vested, config.claimed_amount);
+
+        // The unvested amount is the total scheduled minus what has vested.
+        // Never reduce the grant below what was already claimed; this makes
+        // the operation conservative even under unusual local-test timestamp
+        // manipulation.
+        let unvested = config.total_amount - vested_floor;
+
         // Update config to stop future vesting
         // We set total_amount to vested, so effectively the grant is capped at what was vested at this moment
-        config.total_amount = vested;
+        config.total_amount = vested_floor;
         config.is_active = false;
         e.storage().persistent().set(&DataKey::Config, &config);
         Self::bump_config_ttl(&e);
@@ -199,35 +247,113 @@ impl VestingContract {
         if unvested > 0 {
             // Return unvested tokens to admin
             let client = token::Client::new(&e, &config.token);
-            client.transfer(&e.current_contract_address(), &config.clawback_admin, &unvested);
+            client.transfer(
+                &e.current_contract_address(),
+                &config.clawback_admin,
+                &unvested,
+            );
         }
 
         // vested_remaining = vested - already_claimed (still held in contract for beneficiary)
-        let vested_remaining = vested - config.claimed_amount;
+        let vested_remaining = Self::calc_claimable(vested_floor, config.claimed_amount);
         ClawbackExecutedEvent {
             clawback_admin: config.clawback_admin,
             unvested_returned: unvested,
             vested_remaining,
-        }.publish(&e);
+        }
+        .publish(&e);
     }
 
+    /// Returns the amount that has vested at the current ledger timestamp.
     pub fn get_vested_amount(e: Env) -> i128 {
-        let config: VestingConfig = e.storage().persistent().get(&DataKey::Config).expect("Config entry unavailable; restore and retry");
+        let config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
         // Reading state should not modify TTL; extend only on write
         Self::calc_vested(&e, &config)
     }
-    
+
+    /// Returns the amount that is vested and not yet claimed.
     pub fn get_claimable_amount(e: Env) -> i128 {
-        let config: VestingConfig = e.storage().persistent().get(&DataKey::Config).expect("Config entry unavailable; restore and retry");
+        let config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
         // Reading state should not modify TTL; extend only on write
         let vested = Self::calc_vested(&e, &config);
-        vested - config.claimed_amount
+        Self::calc_claimable(vested, config.claimed_amount)
     }
-    
+
+    /// Returns the current escrow configuration.
     pub fn get_config(e: Env) -> VestingConfig {
-        let config: VestingConfig = e.storage().persistent().get(&DataKey::Config).expect("Config entry unavailable; restore and retry");
+        let config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
         // Reading state should not modify TTL; extend only on write
         config
+    }
+
+    /// Returns the amount still held by the escrow contract for this grant.
+    ///
+    /// This includes vested-but-unclaimed tokens and, while the grant is active,
+    /// future unvested tokens. It never returns a negative value.
+    pub fn get_locked_amount(e: Env) -> i128 {
+        let config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
+        Self::calc_locked(config.total_amount, config.claimed_amount)
+    }
+
+    /// Returns the vested amount at an arbitrary timestamp without changing state.
+    pub fn preview_vested_amount(e: Env, timestamp: u64) -> i128 {
+        let config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
+        Self::calc_vested_at(timestamp, &config)
+    }
+
+    /// Returns current vesting progress in basis points where 10_000 is 100%.
+    pub fn get_vesting_progress_bps(e: Env) -> u32 {
+        let config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
+        let vested = Self::calc_vested(&e, &config);
+        Self::calc_progress_bps(vested, config.total_amount)
+    }
+
+    /// Returns a compact read-only snapshot of the current escrow state.
+    pub fn get_vesting_snapshot(e: Env) -> VestingSnapshot {
+        let config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
+        let timestamp = e.ledger().timestamp();
+        let vested_amount = Self::calc_vested_at(timestamp, &config);
+        let claimable_amount = Self::calc_claimable(vested_amount, config.claimed_amount);
+        let locked_amount = Self::calc_locked(config.total_amount, config.claimed_amount);
+
+        VestingSnapshot {
+            timestamp,
+            vested_amount,
+            claimable_amount,
+            locked_amount,
+            claimed_amount: config.claimed_amount,
+            total_amount: config.total_amount,
+            progress_bps: Self::calc_progress_bps(vested_amount, config.total_amount),
+            is_active: config.is_active,
+        }
     }
 
     /// Transfers the vesting grant to a new beneficiary address. Only the
@@ -260,43 +386,102 @@ impl VestingContract {
 
     /// Extends TTL for the vesting configuration entry.
     pub fn bump_ttl(e: Env) {
-        let config: VestingConfig = e.storage().persistent().get(&DataKey::Config).expect("Config entry unavailable; restore and retry");
+        let config: VestingConfig = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("Config entry unavailable; restore and retry");
         config.clawback_admin.require_auth();
         Self::bump_config_ttl(&e);
     }
 
     fn calc_vested(e: &Env, config: &VestingConfig) -> i128 {
-        let now = e.ledger().timestamp();
-        
-        if now < config.start_time + config.cliff_seconds {
+        Self::calc_vested_at(e.ledger().timestamp(), config)
+    }
+
+    fn calc_vested_at(now: u64, config: &VestingConfig) -> i128 {
+        let cliff_at = config.start_time.saturating_add(config.cliff_seconds);
+        let end_at = config.start_time.saturating_add(config.duration_seconds);
+
+        if now < cliff_at {
             return 0;
         }
-        
-        if now >= config.start_time + config.duration_seconds || !config.is_active {
+
+        if now >= end_at || !config.is_active {
             return config.total_amount;
         }
-        
+
         // Linear vesting — overflow-safe: divide total by duration first,
         // then scale by elapsed to avoid intermediate multiplication overflow.
-        let time_elapsed = now - config.start_time;
-        let total    = config.total_amount;
-        let elapsed  = time_elapsed as i128;
-        let duration = config.duration_seconds as i128;
+        let time_elapsed = now.saturating_sub(config.start_time);
+        let total = config.total_amount;
+        let elapsed = time_elapsed as u128;
+        let duration = config.duration_seconds as u128;
 
         // vested = (total / duration) * elapsed + (total % duration) * elapsed / duration
-        let per_unit = total / duration;
-        let remainder = total % duration;
-        per_unit * elapsed + (remainder * elapsed) / duration
+        let duration_i128 = config.duration_seconds as i128;
+        let per_unit = total / duration_i128;
+        let remainder = (total % duration_i128) as u128;
+        let remainder_component = ((remainder * elapsed) / duration) as i128;
+        per_unit * time_elapsed as i128 + remainder_component
+    }
+
+    fn calc_claimable(vested: i128, claimed: i128) -> i128 {
+        if vested <= claimed {
+            0
+        } else {
+            vested - claimed
+        }
+    }
+
+    fn calc_locked(total: i128, claimed: i128) -> i128 {
+        if total <= claimed { 0 } else { total - claimed }
+    }
+
+    fn calc_progress_bps(vested: i128, total: i128) -> u32 {
+        if total <= 0 || vested <= 0 {
+            return 0;
+        }
+        if vested >= total {
+            return BASIS_POINTS_DENOMINATOR;
+        }
+
+        let multiplier = BASIS_POINTS_DENOMINATOR as i128;
+        match vested.checked_mul(multiplier) {
+            Some(scaled) => (scaled / total) as u32,
+            None => {
+                let units = total / multiplier;
+                if units <= 0 {
+                    return 0;
+                }
+                let coarse = vested / units;
+                if coarse >= multiplier {
+                    BASIS_POINTS_DENOMINATOR
+                } else {
+                    coarse as u32
+                }
+            }
+        }
+    }
+
+    fn max_i128(lhs: i128, rhs: i128) -> i128 {
+        if lhs >= rhs { lhs } else { rhs }
     }
 
     /// Returns the ledger sequence of the last successful claim.
     pub fn get_last_claim_ledger(e: Env) -> u32 {
-        e.storage().persistent().get(&DataKey::LastClaimLedger).unwrap_or(0)
+        e.storage()
+            .persistent()
+            .get(&DataKey::LastClaimLedger)
+            .unwrap_or(0)
     }
 
     /// Returns the ledger sequence of the last successful clawback.
     pub fn get_last_clawback_ledger(e: Env) -> u32 {
-        e.storage().persistent().get(&DataKey::LastClawbackLedger).unwrap_or(0)
+        e.storage()
+            .persistent()
+            .get(&DataKey::LastClawbackLedger)
+            .unwrap_or(0)
     }
 
     /// Ensures the operation has not already been executed in the current ledger

--- a/contracts/vesting_escrow/src/test.rs
+++ b/contracts/vesting_escrow/src/test.rs
@@ -1,17 +1,19 @@
-#![cfg(test)]
-
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, token};
+use soroban_sdk::{
+    Address, Env,
+    testutils::{Address as _, Ledger},
+    token,
+};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn setup() -> (
     Env,
-    Address,                       // funder
-    Address,                       // beneficiary
-    Address,                       // clawback admin
-    Address,                       // token contract address
-    token::Client<'static>,        // token client
+    Address,                            // funder
+    Address,                            // beneficiary
+    Address,                            // clawback admin
+    Address,                            // token contract address
+    token::Client<'static>,             // token client
     token::StellarAssetClient<'static>, // token admin client
     VestingContractClient<'static>,     // vesting contract client
 ) {
@@ -25,13 +27,24 @@ fn setup() -> (
     let client = VestingContractClient::new(&e, &contract_id);
 
     let token_admin = Address::generate(&e);
-    let token_contract = e.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract = e
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::Client::new(&e, &token_contract);
     let token_admin_client = token::StellarAssetClient::new(&e, &token_contract);
 
     token_admin_client.mint(&funder, &100_000);
 
-    (e, funder, beneficiary, clawback_admin, token_contract, token_client, token_admin_client, client)
+    (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        token_admin_client,
+        client,
+    )
 }
 
 fn init_default(
@@ -62,14 +75,21 @@ fn init_default(
 #[test]
 fn test_initialize_success() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let config = client.get_config();
     assert_eq!(config.beneficiary, beneficiary);
     assert_eq!(config.token, token_contract);
     assert_eq!(config.total_amount, 10000);
     assert_eq!(config.claimed_amount, 0);
-    assert_eq!(config.is_active, true);
+    assert!(config.is_active);
     assert_eq!(config.cliff_seconds, 100);
     assert_eq!(config.duration_seconds, 1000);
     assert_eq!(config.clawback_admin, clawback_admin);
@@ -82,9 +102,23 @@ fn test_initialize_success() {
 #[should_panic(expected = "Already initialized")]
 fn test_initialize_twice_panics() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
     // Second initialization should fail
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 }
 
 #[test]
@@ -93,10 +127,14 @@ fn test_initialize_cliff_greater_than_duration_panics() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
     let start_time = e.ledger().timestamp();
     client.initialize(
-        &funder, &beneficiary, &token_contract, &start_time,
-        &500,  // cliff > duration
-        &100,  // duration
-        &1000, &clawback_admin,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &500, // cliff > duration
+        &100, // duration
+        &1000,
+        &clawback_admin,
     );
 }
 
@@ -106,8 +144,12 @@ fn test_initialize_zero_amount_panics() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
     let start_time = e.ledger().timestamp();
     client.initialize(
-        &funder, &beneficiary, &token_contract, &start_time,
-        &100, &1000,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &100,
+        &1000,
         &0, // zero amount
         &clawback_admin,
     );
@@ -119,8 +161,12 @@ fn test_initialize_negative_amount_panics() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
     let start_time = e.ledger().timestamp();
     client.initialize(
-        &funder, &beneficiary, &token_contract, &start_time,
-        &100, &1000,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &100,
+        &1000,
         &-100, // negative amount
         &clawback_admin,
     );
@@ -132,8 +178,14 @@ fn test_initialize_cliff_equals_duration() {
     let start_time = e.ledger().timestamp();
     // cliff == duration should succeed (all tokens vest at once after cliff)
     client.initialize(
-        &funder, &beneficiary, &token_contract, &start_time,
-        &1000, &1000, &5000, &clawback_admin,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &1000,
+        &1000,
+        &5000,
+        &clawback_admin,
     );
     let config = client.get_config();
     assert_eq!(config.cliff_seconds, 1000);
@@ -146,8 +198,14 @@ fn test_initialize_zero_cliff() {
     let start_time = e.ledger().timestamp();
     // Zero cliff should succeed — tokens begin vesting immediately
     client.initialize(
-        &funder, &beneficiary, &token_contract, &start_time,
-        &0, &1000, &5000, &clawback_admin,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &0,
+        &1000,
+        &5000,
+        &clawback_admin,
     );
     let config = client.get_config();
     assert_eq!(config.cliff_seconds, 0);
@@ -160,7 +218,14 @@ fn test_initialize_zero_cliff() {
 #[test]
 fn test_vested_amount_before_cliff() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     // Before cliff (< start + 100), nothing is vested
     let start = e.ledger().timestamp();
@@ -172,7 +237,14 @@ fn test_vested_amount_before_cliff() {
 #[test]
 fn test_vested_amount_at_cliff_boundary() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     // Exactly at cliff (start + 100): 100/1000 = 10% = 1000 tokens
@@ -183,7 +255,14 @@ fn test_vested_amount_at_cliff_boundary() {
 #[test]
 fn test_vested_amount_linear_progression() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
 
@@ -203,7 +282,14 @@ fn test_vested_amount_linear_progression() {
 #[test]
 fn test_vested_amount_at_duration_end() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 1000);
@@ -213,7 +299,14 @@ fn test_vested_amount_at_duration_end() {
 #[test]
 fn test_vested_amount_after_duration_end() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     // Well past duration — should cap at total
@@ -228,7 +321,14 @@ fn test_vested_amount_after_duration_end() {
 #[test]
 fn test_claim_before_cliff_does_nothing() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 50);
@@ -243,7 +343,14 @@ fn test_claim_before_cliff_does_nothing() {
 #[test]
 fn test_claim_partial_vesting() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 200);
@@ -258,7 +365,14 @@ fn test_claim_partial_vesting() {
 #[test]
 fn test_claim_multiple_partial_claims() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
 
@@ -284,7 +398,14 @@ fn test_claim_multiple_partial_claims() {
 #[test]
 fn test_claim_full_after_duration() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 2000);
@@ -298,7 +419,14 @@ fn test_claim_full_after_duration() {
 #[test]
 fn test_claim_idempotent_when_nothing_new() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 200);
@@ -319,21 +447,35 @@ fn test_claim_idempotent_when_nothing_new() {
 #[test]
 fn test_clawback_before_any_vesting() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     // Clawback immediately (before cliff) — all tokens go back to admin
     client.clawback();
 
     assert_eq!(token_client.balance(&clawback_admin), 10000);
     let config = client.get_config();
-    assert_eq!(config.is_active, false);
+    assert!(!config.is_active);
     assert_eq!(config.total_amount, 0);
 }
 
 #[test]
 fn test_clawback_partial_vesting() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     // 30% vested = 3000 tokens
@@ -344,14 +486,21 @@ fn test_clawback_partial_vesting() {
     // Admin gets unvested (7000)
     assert_eq!(token_client.balance(&clawback_admin), 7000);
     let config = client.get_config();
-    assert_eq!(config.is_active, false);
+    assert!(!config.is_active);
     assert_eq!(config.total_amount, 3000); // Capped at vested
 }
 
 #[test]
 fn test_clawback_then_beneficiary_can_claim_vested() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 400);
@@ -372,7 +521,14 @@ fn test_clawback_then_beneficiary_can_claim_vested() {
 #[should_panic(expected = "Already revoked/inactive")]
 fn test_clawback_twice_panics() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     e.ledger().set_sequence_number(10);
     client.clawback();
@@ -383,7 +539,14 @@ fn test_clawback_twice_panics() {
 #[test]
 fn test_clawback_after_full_vesting() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 2000);
@@ -393,14 +556,21 @@ fn test_clawback_after_full_vesting() {
     assert_eq!(token_client.balance(&clawback_admin), 0);
 
     let config = client.get_config();
-    assert_eq!(config.is_active, false);
+    assert!(!config.is_active);
     assert_eq!(config.total_amount, 10000); // Fully vested
 }
 
 #[test]
 fn test_clawback_after_partial_claim() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
 
@@ -433,7 +603,14 @@ fn test_clawback_after_partial_claim() {
 fn test_contract_balance_after_full_claim() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
     let contract_id = client.address.clone();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 2000);
@@ -449,7 +626,14 @@ fn test_contract_balance_after_full_claim() {
 fn test_contract_balance_after_clawback_and_claim() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
     let contract_id = client.address.clone();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
 
@@ -483,7 +667,14 @@ fn test_contract_balance_after_clawback_and_claim() {
 #[should_panic(expected = "Operation already processed in this ledger sequence")]
 fn test_claim_replay_same_ledger() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 500);
@@ -497,7 +688,14 @@ fn test_claim_replay_same_ledger() {
 #[test]
 fn test_claim_allowed_different_ledgers() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let start = e.ledger().timestamp();
 
@@ -529,16 +727,22 @@ fn test_zero_cliff_immediate_vesting() {
     let client = VestingContractClient::new(&e, &contract_id);
 
     let token_admin = Address::generate(&e);
-    let token_contract = e.register_stellar_asset_contract_v2(token_admin.clone()).address();
-    let token_client = token::Client::new(&e, &token_contract);
+    let token_contract = e
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&e, &token_contract);
     token_admin_client.mint(&funder, &10000);
 
     let start_time = e.ledger().timestamp();
     client.initialize(
-        &funder, &beneficiary, &token_contract, &start_time,
-        &0,    // zero cliff
-        &1000, &10000, &clawback_admin,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &0, // zero cliff
+        &1000,
+        &10000,
+        &clawback_admin,
     );
 
     // At time = start + 1, tokens should already be vesting
@@ -559,7 +763,9 @@ fn test_original_vesting_flow() {
     let client = VestingContractClient::new(&e, &contract_id);
 
     let token_admin = Address::generate(&e);
-    let token_contract = e.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract = e
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::Client::new(&e, &token_contract);
     let token_admin_client = token::StellarAssetClient::new(&e, &token_contract);
     token_admin_client.mint(&funder, &10000);
@@ -570,13 +776,19 @@ fn test_original_vesting_flow() {
     let amount = 10000;
 
     client.initialize(
-        &funder, &beneficiary, &token_contract, &start_time,
-        &cliff_seconds, &duration_seconds, &amount, &clawback_admin,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &start_time,
+        &cliff_seconds,
+        &duration_seconds,
+        &amount,
+        &clawback_admin,
     );
 
     let config = client.get_config();
     assert_eq!(config.total_amount, amount);
-    assert_eq!(config.is_active, true);
+    assert!(config.is_active);
     assert_eq!(token_client.balance(&contract_id), 10000);
     assert_eq!(token_client.balance(&funder), 0);
 
@@ -610,7 +822,7 @@ fn test_original_vesting_flow() {
     assert_eq!(token_client.balance(&contract_id), 3000);
 
     let config_revoked = client.get_config();
-    assert_eq!(config_revoked.is_active, false);
+    assert!(!config_revoked.is_active);
     assert_eq!(config_revoked.total_amount, 5000);
 
     // 6. Advance past end — vested still capped at 5000
@@ -638,9 +850,18 @@ fn test_contract_metadata() {
     let version = client.version();
     let author = client.author();
 
-    assert_eq!(name, soroban_sdk::String::from_str(&e, env!("CARGO_PKG_NAME")));
-    assert_eq!(version, soroban_sdk::String::from_str(&e, env!("CARGO_PKG_VERSION")));
-    assert_eq!(author, soroban_sdk::String::from_str(&e, env!("CARGO_PKG_AUTHORS")));
+    assert_eq!(
+        name,
+        soroban_sdk::String::from_str(&e, env!("CARGO_PKG_NAME"))
+    );
+    assert_eq!(
+        version,
+        soroban_sdk::String::from_str(&e, env!("CARGO_PKG_VERSION"))
+    );
+    assert_eq!(
+        author,
+        soroban_sdk::String::from_str(&e, env!("CARGO_PKG_AUTHORS"))
+    );
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -650,7 +871,14 @@ fn test_contract_metadata() {
 #[test]
 fn test_transfer_beneficiary_updates_config() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let new_beneficiary = Address::generate(&e);
     client.transfer_beneficiary(&new_beneficiary);
@@ -662,7 +890,14 @@ fn test_transfer_beneficiary_updates_config() {
 #[test]
 fn test_transferred_beneficiary_can_claim() {
     let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     let new_beneficiary = Address::generate(&e);
     client.transfer_beneficiary(&new_beneficiary);
@@ -681,7 +916,14 @@ fn test_transferred_beneficiary_can_claim() {
 #[should_panic(expected = "Vesting grant is no longer active")]
 fn test_transfer_beneficiary_panics_when_inactive() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client) = setup();
-    init_default(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin);
+    init_default(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+    );
 
     // Clawback deactivates the grant
     client.clawback();

--- a/contracts/vesting_escrow/src/test_escrow_logic.rs
+++ b/contracts/vesting_escrow/src/test_escrow_logic.rs
@@ -1,7 +1,5 @@
-#![cfg(test)]
-
 //! Comprehensive Unit Tests for Escrow Logic
-//! 
+//!
 //! This test suite covers:
 //! - Escrow fund locking and holding
 //! - Vesting calculations and time-based releases
@@ -10,7 +8,11 @@
 //! - Token balance invariants
 
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, token};
+use soroban_sdk::{
+    Address, Env,
+    testutils::{Address as _, Ledger},
+    token,
+};
 
 // ══════════════════════════════════════════════════════════════════════════════
 // ── TEST HELPERS ──────────────────────────────────────────────────────────────
@@ -33,20 +35,32 @@ fn setup_escrow() -> (
     let funder = Address::generate(&e);
     let beneficiary = Address::generate(&e);
     let clawback_admin = Address::generate(&e);
-    
+
     let contract_id = e.register(VestingContract, ());
     let client = VestingContractClient::new(&e, &contract_id);
     let contract_address = contract_id.clone();
 
     let token_admin = Address::generate(&e);
-    let token_contract = e.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract = e
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::Client::new(&e, &token_contract);
     let token_admin_client = token::StellarAssetClient::new(&e, &token_contract);
 
     // Mint initial tokens to funder
-    token_admin_client.mint(&funder, &1_000_000);
+    token_admin_client.mint(&funder, &2_000_000_000_000);
 
-    (e, funder, beneficiary, clawback_admin, token_contract, token_client, token_admin_client, client, contract_address)
+    (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        token_admin_client,
+        client,
+        contract_address,
+    )
 }
 
 fn init_escrow(
@@ -73,40 +87,131 @@ fn init_escrow(
     );
 }
 
+fn init_escrow_at(
+    client: &VestingContractClient,
+    funder: &Address,
+    beneficiary: &Address,
+    token: &Address,
+    clawback_admin: &Address,
+    start_time: u64,
+    amount: i128,
+    cliff_seconds: u64,
+    duration_seconds: u64,
+) {
+    client.initialize(
+        funder,
+        beneficiary,
+        token,
+        &start_time,
+        &cliff_seconds,
+        &duration_seconds,
+        &amount,
+        clawback_admin,
+    );
+}
+
+fn assert_snapshot_matches_config(
+    e: &Env,
+    client: &VestingContractClient,
+    token_client: &token::Client<'static>,
+    contract_address: &Address,
+) {
+    let config = client.get_config();
+    let snapshot = client.get_vesting_snapshot();
+    let vested = client.get_vested_amount();
+    let claimable = client.get_claimable_amount();
+    let locked = client.get_locked_amount();
+
+    assert_eq!(snapshot.timestamp, e.ledger().timestamp());
+    assert_eq!(snapshot.vested_amount, vested);
+    assert_eq!(snapshot.claimable_amount, claimable);
+    assert_eq!(snapshot.locked_amount, locked);
+    assert_eq!(snapshot.claimed_amount, config.claimed_amount);
+    assert_eq!(snapshot.total_amount, config.total_amount);
+    assert_eq!(snapshot.is_active, config.is_active);
+    assert!(snapshot.progress_bps <= 10_000);
+    assert_eq!(token_client.balance(contract_address), locked);
+    assert!(config.claimed_amount <= config.total_amount);
+    assert!(claimable <= locked);
+}
+
 // ══════════════════════════════════════════════════════════════════════════════
 // ── ESCROW FUND LOCKING TESTS ─────────────────────────────────────────────────
 // ══════════════════════════════════════════════════════════════════════════════
 
 #[test]
 fn test_escrow_locks_funds_on_initialization() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let initial_funder_balance = token_client.balance(&funder);
     let escrow_amount = 50_000;
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 100, 1000);
-    
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        100,
+        1000,
+    );
+
     // Verify funds transferred from funder to contract
-    assert_eq!(token_client.balance(&funder), initial_funder_balance - escrow_amount);
+    assert_eq!(
+        token_client.balance(&funder),
+        initial_funder_balance - escrow_amount
+    );
     assert_eq!(token_client.balance(&contract_address), escrow_amount);
     assert_eq!(token_client.balance(&beneficiary), 0);
 }
 
 #[test]
 fn test_escrow_holds_funds_during_cliff_period() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let escrow_amount = 100_000;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 500, 2000);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        500,
+        2000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // During cliff period, funds remain locked
     e.ledger().set_timestamp(start + 250);
     assert_eq!(client.get_vested_amount(), 0);
     assert_eq!(client.get_claimable_amount(), 0);
     assert_eq!(token_client.balance(&contract_address), escrow_amount);
-    
+
     // Even at cliff boundary (but before), still locked
     e.ledger().set_timestamp(start + 499);
     assert_eq!(client.get_vested_amount(), 0);
@@ -115,46 +220,87 @@ fn test_escrow_holds_funds_during_cliff_period() {
 
 #[test]
 fn test_escrow_prevents_unauthorized_withdrawal() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let escrow_amount = 75_000;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 100, 1000);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 500);
-    
+
     // Beneficiary can only claim through the claim function (which requires auth)
     // Contract holds funds securely
     assert_eq!(token_client.balance(&contract_address), escrow_amount);
-    
+
     // No direct token transfer possible from contract without proper authorization
     // This is enforced by Soroban's auth system
 }
 
 #[test]
 fn test_escrow_multiple_schedules_independent() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, _, _) = setup_escrow();
-    
+    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, _, _) =
+        setup_escrow();
+
     // Create first escrow
     let contract_id_1 = e.register(VestingContract, ());
     let client_1 = VestingContractClient::new(&e, &contract_id_1);
-    init_escrow(&client_1, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 10_000, 100, 1000);
-    
+    init_escrow(
+        &client_1,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        10_000,
+        100,
+        1000,
+    );
+
     // Create second escrow
     let contract_id_2 = e.register(VestingContract, ());
     let client_2 = VestingContractClient::new(&e, &contract_id_2);
-    init_escrow(&client_2, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 20_000, 200, 2000);
-    
+    init_escrow(
+        &client_2,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        20_000,
+        200,
+        2000,
+    );
+
     // Each contract holds its own funds independently
     assert_eq!(token_client.balance(&contract_id_1), 10_000);
     assert_eq!(token_client.balance(&contract_id_2), 20_000);
-    
+
     // Claiming from one doesn't affect the other
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 500);
     e.ledger().set_sequence_number(10);
     client_1.claim();
-    
+
     assert_eq!(token_client.balance(&contract_id_1), 5_000); // 50% claimed
     assert_eq!(token_client.balance(&contract_id_2), 20_000); // Unchanged
 }
@@ -166,11 +312,21 @@ fn test_escrow_multiple_schedules_independent() {
 #[test]
 fn test_linear_vesting_calculation() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 10_000, 0, 1000);
-    
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        10_000,
+        0,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Test various points in vesting schedule
     let test_cases: [(u64, i128); 7] = [
         (0, 0),         // Start: 0%
@@ -181,36 +337,51 @@ fn test_linear_vesting_calculation() {
         (1000, 10_000), // 100%
         (1500, 10_000), // Past end: capped at 100%
     ];
-    
+
     for (elapsed, expected_vested) in test_cases {
         e.ledger().set_timestamp(start + elapsed);
-        assert_eq!(client.get_vested_amount(), expected_vested, 
-            "Failed at elapsed={}, expected={}", elapsed, expected_vested);
+        assert_eq!(
+            client.get_vested_amount(),
+            expected_vested,
+            "Failed at elapsed={}, expected={}",
+            elapsed,
+            expected_vested
+        );
     }
 }
 
 #[test]
 fn test_vesting_with_cliff_calculation() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
+
     let cliff = 300;
     let duration = 1200;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 12_000, cliff, duration);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        12_000,
+        cliff,
+        duration,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Before cliff: 0 vested
     e.ledger().set_timestamp(start + 299);
     assert_eq!(client.get_vested_amount(), 0);
-    
+
     // At cliff: vesting starts
     e.ledger().set_timestamp(start + 300);
     assert_eq!(client.get_vested_amount(), 3_000); // 300/1200 * 12000 = 3000
-    
+
     // Mid-vesting
     e.ledger().set_timestamp(start + 600);
     assert_eq!(client.get_vested_amount(), 6_000); // 50%
-    
+
     // End
     e.ledger().set_timestamp(start + 1200);
     assert_eq!(client.get_vested_amount(), 12_000);
@@ -219,22 +390,32 @@ fn test_vesting_with_cliff_calculation() {
 #[test]
 fn test_claimable_amount_calculation() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 10_000, 100, 1000);
-    
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        10_000,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // At 30%: claimable = vested - claimed = 3000 - 0 = 3000
     e.ledger().set_timestamp(start + 300);
     assert_eq!(client.get_claimable_amount(), 3_000);
-    
+
     // Claim
     e.ledger().set_sequence_number(10);
     client.claim();
-    
+
     // After claim: claimable = 3000 - 3000 = 0
     assert_eq!(client.get_claimable_amount(), 0);
-    
+
     // At 60%: claimable = 6000 - 3000 = 3000
     e.ledger().set_timestamp(start + 600);
     assert_eq!(client.get_claimable_amount(), 3_000);
@@ -243,18 +424,28 @@ fn test_claimable_amount_calculation() {
 #[test]
 fn test_vesting_precision_no_rounding_errors() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
+
     // Use prime numbers to test precision
     let amount = 999_997;
     let duration = 997;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, amount, 0, duration);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        amount,
+        0,
+        duration,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Test that calculation doesn't overflow or lose precision
     e.ledger().set_timestamp(start + 500);
     let vested = client.get_vested_amount();
-    
+
     // Should be approximately 50% (within rounding)
     let expected = (amount * 500) / duration as i128;
     assert_eq!(vested, expected);
@@ -266,36 +457,67 @@ fn test_vesting_precision_no_rounding_errors() {
 
 #[test]
 fn test_partial_claim_releases_correct_amount() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let escrow_amount = 20_000;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 100, 1000);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Claim at 25%
     e.ledger().set_timestamp(start + 250);
     e.ledger().set_sequence_number(10);
     client.claim();
-    
+
     assert_eq!(token_client.balance(&beneficiary), 5_000);
     assert_eq!(token_client.balance(&contract_address), 15_000);
-    
+
     // Claim at 75%
     e.ledger().set_timestamp(start + 750);
     e.ledger().set_sequence_number(20);
     client.claim();
-    
+
     assert_eq!(token_client.balance(&beneficiary), 15_000); // 5000 + 10000
     assert_eq!(token_client.balance(&contract_address), 5_000);
 }
 
 #[test]
 fn test_multiple_small_claims() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, _) = setup_escrow();
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 10_000, 0, 1000);
-    
+    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, _) =
+        setup_escrow();
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        10_000,
+        0,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
     let mut total_claimed: i128 = 0;
 
@@ -315,17 +537,37 @@ fn test_multiple_small_claims() {
 
 #[test]
 fn test_claim_after_full_vesting_releases_all() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let escrow_amount = 50_000;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 200, 1000);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        200,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Wait until well past vesting end
     e.ledger().set_timestamp(start + 5000);
     client.claim();
-    
+
     // All funds released
     assert_eq!(token_client.balance(&beneficiary), escrow_amount);
     assert_eq!(token_client.balance(&contract_address), 0);
@@ -337,64 +579,106 @@ fn test_claim_after_full_vesting_releases_all() {
 
 #[test]
 fn test_clawback_returns_unvested_to_admin() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let escrow_amount = 10_000;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 100, 1000);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Clawback at 40% vested
     e.ledger().set_timestamp(start + 400);
     client.clawback();
-    
+
     // Admin receives 60% (unvested)
     assert_eq!(token_client.balance(&clawback_admin), 6_000);
-    
+
     // Contract retains 40% (vested) for beneficiary
     assert_eq!(token_client.balance(&contract_address), 4_000);
 }
 
 #[test]
 fn test_clawback_before_cliff_returns_all() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, _) = setup_escrow();
-    
+    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, _) =
+        setup_escrow();
+
     let escrow_amount = 25_000;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 500, 2000);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        500,
+        2000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Clawback before cliff
     e.ledger().set_timestamp(start + 250);
     client.clawback();
-    
+
     // Admin receives all funds (nothing vested)
     assert_eq!(token_client.balance(&clawback_admin), escrow_amount);
 }
 
 #[test]
 fn test_clawback_after_partial_claim() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, _) = setup_escrow();
-    
+    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, _) =
+        setup_escrow();
+
     let escrow_amount = 10_000;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 100, 1000);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Beneficiary claims at 30%
     e.ledger().set_timestamp(start + 300);
     e.ledger().set_sequence_number(10);
     client.claim();
     assert_eq!(token_client.balance(&beneficiary), 3_000);
-    
+
     // Admin clawback at 60%
     e.ledger().set_timestamp(start + 600);
     e.ledger().set_sequence_number(20);
     client.clawback();
-    
+
     // Admin gets 40% unvested (10000 - 6000)
     assert_eq!(token_client.balance(&clawback_admin), 4_000);
-    
+
     // Beneficiary can still claim remaining 30% (6000 - 3000)
     e.ledger().set_timestamp(start + 2000);
     e.ledger().set_sequence_number(30);
@@ -405,19 +689,29 @@ fn test_clawback_after_partial_claim() {
 #[test]
 fn test_clawback_deactivates_future_vesting() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 10_000, 100, 1000);
-    
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        10_000,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Clawback at 50%
     e.ledger().set_timestamp(start + 500);
     client.clawback();
-    
+
     let config = client.get_config();
-    assert_eq!(config.is_active, false);
+    assert!(!config.is_active);
     assert_eq!(config.total_amount, 5_000); // Capped at vested amount
-    
+
     // Future vesting doesn't increase
     e.ledger().set_timestamp(start + 2000);
     assert_eq!(client.get_vested_amount(), 5_000); // Still capped
@@ -427,12 +721,22 @@ fn test_clawback_deactivates_future_vesting() {
 #[should_panic(expected = "Already revoked/inactive")]
 fn test_clawback_twice_panics() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 10_000, 100, 1000);
-    
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        10_000,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 500);
-    
+
     client.clawback();
     client.clawback(); // Should panic
 }
@@ -443,58 +747,101 @@ fn test_clawback_twice_panics() {
 
 #[test]
 fn test_total_supply_conservation() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let initial_supply = token_client.balance(&funder);
     let escrow_amount = 30_000;
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 100, 1000);
-    
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        100,
+        1000,
+    );
+
     // Total tokens = funder + contract + beneficiary
-    let total = token_client.balance(&funder) 
-        + token_client.balance(&contract_address) 
+    let total = token_client.balance(&funder)
+        + token_client.balance(&contract_address)
         + token_client.balance(&beneficiary);
     assert_eq!(total, initial_supply);
-    
+
     // After partial claim
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 500);
     e.ledger().set_sequence_number(10);
     client.claim();
-    
-    let total_after_claim = token_client.balance(&funder) 
-        + token_client.balance(&contract_address) 
+
+    let total_after_claim = token_client.balance(&funder)
+        + token_client.balance(&contract_address)
         + token_client.balance(&beneficiary);
     assert_eq!(total_after_claim, initial_supply);
 }
 
 #[test]
 fn test_escrow_balance_equals_unclaimed_vested() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let escrow_amount = 10_000;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 0, 1000);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        0,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // At 70% vested, claim 30%
     e.ledger().set_timestamp(start + 700);
     e.ledger().set_sequence_number(10);
-    
+
     // Claim only 3000 out of 7000 vested (simulate partial claim by claiming at 30% first)
     e.ledger().set_timestamp(start + 300);
     e.ledger().set_sequence_number(5);
     client.claim();
-    
+
     // Now at 70%
     e.ledger().set_timestamp(start + 700);
-    
+
     let config = client.get_config();
     let vested = client.get_vested_amount();
     let contract_balance = token_client.balance(&contract_address);
-    
+
     // Contract holds all tokens not yet claimed (vested + unvested)
-    assert_eq!(contract_balance, config.total_amount - config.claimed_amount);
+    assert_eq!(
+        contract_balance,
+        config.total_amount - config.claimed_amount
+    );
     // Claimable right now is only the vested portion minus what was already claimed
     let claimable = vested - config.claimed_amount;
     assert_eq!(claimable, 4_000);
@@ -502,31 +849,51 @@ fn test_escrow_balance_equals_unclaimed_vested() {
 
 #[test]
 fn test_no_token_loss_after_clawback_and_full_claim() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, contract_address) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
     let initial_funder_balance = token_client.balance(&funder);
     let escrow_amount = 10_000;
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, escrow_amount, 100, 1000);
-    
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        escrow_amount,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Clawback at 40%
     e.ledger().set_timestamp(start + 400);
     e.ledger().set_sequence_number(10);
     client.clawback();
-    
+
     // Beneficiary claims all vested
     e.ledger().set_timestamp(start + 2000);
     e.ledger().set_sequence_number(20);
     client.claim();
-    
+
     // Verify all tokens accounted for
-    let final_total = token_client.balance(&funder) 
-        + token_client.balance(&contract_address) 
+    let final_total = token_client.balance(&funder)
+        + token_client.balance(&contract_address)
         + token_client.balance(&beneficiary)
         + token_client.balance(&clawback_admin);
-    
+
     assert_eq!(final_total, initial_funder_balance);
     assert_eq!(token_client.balance(&contract_address), 0); // Contract empty
 }
@@ -539,33 +906,73 @@ fn test_no_token_loss_after_clawback_and_full_claim() {
 #[should_panic(expected = "Amount must be positive")]
 fn test_zero_amount_escrow_panics() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 0, 100, 1000);
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        0,
+        100,
+        1000,
+    );
 }
 
 #[test]
 #[should_panic(expected = "Amount must be positive")]
 fn test_negative_amount_escrow_panics() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, -1000, 100, 1000);
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        -1000,
+        100,
+        1000,
+    );
 }
 
 #[test]
 fn test_very_large_escrow_amount() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, token_admin_client, client, _) = setup_escrow();
-    
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        token_admin_client,
+        client,
+        _,
+    ) = setup_escrow();
+
     // Mint large amount
     let large_amount = i128::MAX / 2;
     token_admin_client.mint(&funder, &large_amount);
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, large_amount, 100, 1000);
-    
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        large_amount,
+        100,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 500);
     e.ledger().set_sequence_number(10);
     client.claim();
-    
+
     // Should handle large numbers without overflow
     assert_eq!(token_client.balance(&beneficiary), large_amount / 2);
 }
@@ -573,13 +980,23 @@ fn test_very_large_escrow_amount() {
 #[test]
 fn test_very_long_vesting_duration() {
     let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) = setup_escrow();
-    
+
     // 10 years in seconds
     let ten_years = 10 * 365 * 24 * 60 * 60;
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 10_000, 0, ten_years);
-    
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        10_000,
+        0,
+        ten_years,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // After 1 year (10%)
     e.ledger().set_timestamp(start + (ten_years / 10));
     assert_eq!(client.get_vested_amount(), 1_000);
@@ -587,46 +1004,321 @@ fn test_very_long_vesting_duration() {
 
 #[test]
 fn test_claim_with_no_vested_amount_is_noop() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, _) = setup_escrow();
-    
-    init_escrow(&client, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 10_000, 500, 1000);
-    
+    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, client, _) =
+        setup_escrow();
+
+    init_escrow(
+        &client,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        10_000,
+        500,
+        1000,
+    );
+
     let start = e.ledger().timestamp();
-    
+
     // Before cliff
     e.ledger().set_timestamp(start + 100);
     client.claim();
-    
+
     // No tokens transferred
     assert_eq!(token_client.balance(&beneficiary), 0);
-    
+
     let config = client.get_config();
     assert_eq!(config.claimed_amount, 0);
 }
 
 #[test]
 fn test_concurrent_escrows_same_beneficiary() {
-    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, _, _) = setup_escrow();
-    
+    let (e, funder, beneficiary, clawback_admin, token_contract, token_client, _, _, _) =
+        setup_escrow();
+
     // Create two separate escrows for same beneficiary
     let contract_1 = e.register(VestingContract, ());
     let client_1 = VestingContractClient::new(&e, &contract_1);
-    init_escrow(&client_1, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 5_000, 0, 1000);
-    
+    init_escrow(
+        &client_1,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        5_000,
+        0,
+        1000,
+    );
+
     let contract_2 = e.register(VestingContract, ());
     let client_2 = VestingContractClient::new(&e, &contract_2);
-    init_escrow(&client_2, &e, &funder, &beneficiary, &token_contract, &clawback_admin, 8_000, 0, 2000);
-    
+    init_escrow(
+        &client_2,
+        &e,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        8_000,
+        0,
+        2000,
+    );
+
     let start = e.ledger().timestamp();
     e.ledger().set_timestamp(start + 1000);
-    
+
     // Claim from both
     e.ledger().set_sequence_number(10);
     client_1.claim(); // 100% of 5000 = 5000
-    
+
     e.ledger().set_sequence_number(11);
     client_2.claim(); // 50% of 8000 = 4000
-    
+
     // Beneficiary receives from both
     assert_eq!(token_client.balance(&beneficiary), 9_000);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// ── PROPERTY-STYLE ESCROW INVARIANT TESTS ────────────────────────────────────
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn property_vested_preview_is_monotonic_capped_and_query_consistent() {
+    let cases: [(i128, u64, u64); 6] = [
+        (1, 0, 1),
+        (10_000, 0, 1_000),
+        (12_345, 25, 250),
+        (999_997, 13, 997),
+        (1_000_000_000_000, 37, 7_777),
+        (50_000, 0, 0),
+    ];
+
+    for (amount, cliff, duration) in cases {
+        let (e, funder, beneficiary, clawback_admin, token_contract, _, _, client, _) =
+            setup_escrow();
+        init_escrow(
+            &client,
+            &e,
+            &funder,
+            &beneficiary,
+            &token_contract,
+            &clawback_admin,
+            amount,
+            cliff,
+            duration,
+        );
+
+        let start = e.ledger().timestamp();
+        let last_elapsed = duration.saturating_add(duration / 2).saturating_add(cliff);
+        let mut previous_vested = 0;
+
+        for step in 0u64..=24 {
+            let elapsed = if last_elapsed == 0 {
+                0
+            } else {
+                last_elapsed.saturating_mul(step) / 24
+            };
+            let timestamp = start.saturating_add(elapsed);
+            e.ledger().set_timestamp(timestamp);
+
+            let vested = client.get_vested_amount();
+            let preview = client.preview_vested_amount(&timestamp);
+
+            assert_eq!(vested, preview);
+            assert!(vested >= previous_vested);
+            assert!(vested >= 0);
+            assert!(vested <= amount);
+
+            if elapsed < cliff {
+                assert_eq!(vested, 0);
+            }
+            if elapsed >= duration {
+                assert_eq!(vested, amount);
+            }
+
+            previous_vested = vested;
+        }
+    }
+}
+
+#[test]
+fn property_claiming_preserves_supply_and_locks_only_unclaimed_tokens() {
+    let cases: [(i128, u64, u64, [u64; 5]); 3] = [
+        (10_000, 0, 1_000, [0, 125, 500, 750, 1_000]),
+        (99_999, 50, 999, [25, 50, 333, 777, 1_500]),
+        (1_000_000, 100, 10_000, [99, 100, 1_000, 5_000, 10_000]),
+    ];
+
+    for (amount, cliff, duration, claim_offsets) in cases {
+        let (
+            e,
+            funder,
+            beneficiary,
+            clawback_admin,
+            token_contract,
+            token_client,
+            _,
+            client,
+            contract_address,
+        ) = setup_escrow();
+
+        let initial_supply = token_client.balance(&funder);
+        init_escrow(
+            &client,
+            &e,
+            &funder,
+            &beneficiary,
+            &token_contract,
+            &clawback_admin,
+            amount,
+            cliff,
+            duration,
+        );
+
+        let start = e.ledger().timestamp();
+
+        for (index, elapsed) in claim_offsets.iter().enumerate() {
+            e.ledger().set_timestamp(start.saturating_add(*elapsed));
+            e.ledger().set_sequence_number(100 + index as u32);
+            client.claim();
+
+            let config = client.get_config();
+            let beneficiary_balance = token_client.balance(&beneficiary);
+            let contract_balance = token_client.balance(&contract_address);
+            let funder_balance = token_client.balance(&funder);
+
+            assert_eq!(config.claimed_amount, beneficiary_balance);
+            assert_eq!(contract_balance, client.get_locked_amount());
+            assert_eq!(contract_balance, amount - config.claimed_amount);
+            assert_eq!(
+                funder_balance + beneficiary_balance + contract_balance,
+                initial_supply
+            );
+            assert_snapshot_matches_config(&e, &client, &token_client, &contract_address);
+        }
+    }
+}
+
+#[test]
+fn property_clawback_caps_future_vesting_and_preserves_accounting() {
+    let cases: [(i128, u64, u64, u64, u64); 3] = [
+        (10_000, 0, 1_000, 250, 400),
+        (20_000, 100, 2_000, 500, 1_000),
+        (999_997, 13, 997, 300, 700),
+    ];
+
+    for (amount, cliff, duration, claim_elapsed, clawback_elapsed) in cases {
+        let (
+            e,
+            funder,
+            beneficiary,
+            clawback_admin,
+            token_contract,
+            token_client,
+            _,
+            client,
+            contract_address,
+        ) = setup_escrow();
+
+        let initial_supply = token_client.balance(&funder);
+        init_escrow(
+            &client,
+            &e,
+            &funder,
+            &beneficiary,
+            &token_contract,
+            &clawback_admin,
+            amount,
+            cliff,
+            duration,
+        );
+
+        let start = e.ledger().timestamp();
+        e.ledger()
+            .set_timestamp(start.saturating_add(claim_elapsed));
+        e.ledger().set_sequence_number(10);
+        client.claim();
+        let claimed_before_clawback = client.get_config().claimed_amount;
+
+        e.ledger()
+            .set_timestamp(start.saturating_add(clawback_elapsed));
+        let vested_at_clawback = client.get_vested_amount();
+        e.ledger().set_sequence_number(20);
+        client.clawback();
+
+        let config_after_clawback = client.get_config();
+        let capped_total = if vested_at_clawback > claimed_before_clawback {
+            vested_at_clawback
+        } else {
+            claimed_before_clawback
+        };
+
+        assert!(!config_after_clawback.is_active);
+        assert_eq!(config_after_clawback.total_amount, capped_total);
+        assert_eq!(token_client.balance(&clawback_admin), amount - capped_total);
+        assert_eq!(
+            token_client.balance(&contract_address),
+            capped_total - claimed_before_clawback
+        );
+        assert_snapshot_matches_config(&e, &client, &token_client, &contract_address);
+
+        e.ledger()
+            .set_timestamp(start.saturating_add(duration).saturating_add(10_000));
+        assert_eq!(client.get_vested_amount(), capped_total);
+        e.ledger().set_sequence_number(30);
+        client.claim();
+
+        assert_eq!(token_client.balance(&beneficiary), capped_total);
+        assert_eq!(token_client.balance(&contract_address), 0);
+        assert_eq!(
+            token_client.balance(&funder)
+                + token_client.balance(&beneficiary)
+                + token_client.balance(&clawback_admin)
+                + token_client.balance(&contract_address),
+            initial_supply
+        );
+    }
+}
+
+#[test]
+fn property_saturating_schedule_boundaries_do_not_overflow() {
+    let (
+        e,
+        funder,
+        beneficiary,
+        clawback_admin,
+        token_contract,
+        token_client,
+        _,
+        client,
+        contract_address,
+    ) = setup_escrow();
+
+    let start_time = u64::MAX - 10;
+    init_escrow_at(
+        &client,
+        &funder,
+        &beneficiary,
+        &token_contract,
+        &clawback_admin,
+        start_time,
+        10_000,
+        5,
+        10,
+    );
+
+    assert_eq!(client.preview_vested_amount(&(start_time + 4)), 0);
+    assert_eq!(client.preview_vested_amount(&(start_time + 5)), 5_000);
+    assert_eq!(client.preview_vested_amount(&u64::MAX), 10_000);
+
+    e.ledger().set_timestamp(u64::MAX);
+    e.ledger().set_sequence_number(50);
+    client.claim();
+
+    assert_eq!(token_client.balance(&beneficiary), 10_000);
+    assert_eq!(token_client.balance(&contract_address), 0);
+    assert_eq!(client.get_vesting_progress_bps(), 10_000);
+    assert_eq!(client.get_locked_amount(), 0);
 }


### PR DESCRIPTION
## Summary
- Added read-only vesting snapshot/progress/preview helpers for escrow state inspection.
- Hardened vesting math around saturated timestamp boundaries, claimable floors, and clawback caps.
- Added property-style escrow invariant coverage for monotonic vesting, claiming, clawback accounting, and overflow boundaries.
- Cleaned vesting escrow tests for warning-free clippy on the touched crate.

## Verification
- cargo clippy -p vesting_escrow --all-targets -- -D warnings
- cargo test

Closes #596
Closes #601
Closes #602
Closes #603
