### PR TITLE
fix: add dark mode toggle, drag-and-drop reordering, a11y fixes, and …

### DIFF
--- a/backend/src/controllers/socialAuthController.ts
+++ b/backend/src/controllers/socialAuthController.ts
@@ -1,0 +1,135 @@
+import { Request, Response } from 'express';
+import { Pool } from 'pg';
+import { config } from '../config/env.js';
+import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
+
+const pool = new Pool({ connectionString: config.DATABASE_URL });
+
+const SUPPORTED_PROVIDERS = ['google', 'github'] as const;
+type Provider = (typeof SUPPORTED_PROVIDERS)[number];
+
+export const SocialAuthController = {
+  /**
+   * GET /auth/social-identities
+   * Returns all social identities linked to the authenticated user.
+   */
+  async listIdentities(req: Request, res: Response) {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res
+        .status(401)
+        .json(apiErrorResponse(ErrorCodes.UNAUTHORIZED, 'Authentication required'));
+    }
+
+    try {
+      const result = await pool.query(
+        `SELECT provider, provider_id, created_at
+         FROM social_identities
+         WHERE user_id = $1
+         ORDER BY created_at ASC`,
+        [userId]
+      );
+
+      return res.status(200).json({
+        success: true,
+        data: result.rows,
+      });
+    } catch (err) {
+      console.error('[SocialAuth] listIdentities error:', err);
+      return res
+        .status(500)
+        .json(apiErrorResponse(ErrorCodes.INTERNAL_ERROR, 'Failed to retrieve social identities'));
+    }
+  },
+
+  /**
+   * DELETE /auth/social-identities/:provider
+   * Unlinks a specific OAuth provider from the authenticated user's account.
+   * Requires the user to have at least one other login method (wallet or password).
+   */
+  async unlinkProvider(req: Request, res: Response) {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res
+        .status(401)
+        .json(apiErrorResponse(ErrorCodes.UNAUTHORIZED, 'Authentication required'));
+    }
+
+    const provider = req.params.provider as Provider;
+    if (!SUPPORTED_PROVIDERS.includes(provider)) {
+      return res
+        .status(400)
+        .json(
+          apiErrorResponse(
+            ErrorCodes.VALIDATION_ERROR,
+            `Unsupported provider. Must be one of: ${SUPPORTED_PROVIDERS.join(', ')}`
+          )
+        );
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Check the identity to unlink actually exists for this user
+      const identityResult = await client.query(
+        'SELECT id FROM social_identities WHERE user_id = $1 AND provider = $2',
+        [userId, provider]
+      );
+      if (identityResult.rows.length === 0) {
+        await client.query('ROLLBACK');
+        return res
+          .status(404)
+          .json(
+            apiErrorResponse(ErrorCodes.NOT_FOUND, `No linked ${provider} identity found for this account`)
+          );
+      }
+
+      // Safety check: ensure at least one other auth method remains
+      const userResult = await client.query(
+        'SELECT wallet_address, password_hash FROM users WHERE id = $1',
+        [userId]
+      );
+      const user = userResult.rows[0];
+      const remainingIdentitiesResult = await client.query(
+        'SELECT COUNT(*) FROM social_identities WHERE user_id = $1 AND provider != $2',
+        [userId, provider]
+      );
+      const remainingCount = parseInt(remainingIdentitiesResult.rows[0].count, 10);
+
+      const hasWallet = Boolean(user?.wallet_address);
+      const hasPassword = Boolean(user?.password_hash);
+      if (!hasWallet && !hasPassword && remainingCount === 0) {
+        await client.query('ROLLBACK');
+        return res
+          .status(409)
+          .json(
+            apiErrorResponse(
+              ErrorCodes.CONFLICT,
+              'Cannot unlink the only login method. Add a password or another provider first.'
+            )
+          );
+      }
+
+      await client.query(
+        'DELETE FROM social_identities WHERE user_id = $1 AND provider = $2',
+        [userId, provider]
+      );
+
+      await client.query('COMMIT');
+
+      return res.status(200).json({
+        success: true,
+        message: `${provider} account successfully unlinked`,
+      });
+    } catch (err) {
+      await client.query('ROLLBACK');
+      console.error('[SocialAuth] unlinkProvider error:', err);
+      return res
+        .status(500)
+        .json(apiErrorResponse(ErrorCodes.INTERNAL_ERROR, 'Failed to unlink social identity'));
+    } finally {
+      client.release();
+    }
+  },
+};

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -2,7 +2,9 @@ import { Router } from 'express';
 import passport from 'passport';
 import { generateToken } from '../services/authService.js';
 import { AuthController } from '../controllers/authController.js';
+import { SocialAuthController } from '../controllers/socialAuthController.js';
 import { authRateLimit } from '../middlewares/rateLimitMiddleware.js';
+import { authenticateJWT } from '../middlewares/auth.js';
 
 const router = Router();
 
@@ -56,5 +58,9 @@ router.get(
     );
   }
 );
+
+// Social identity management (requires authenticated user)
+router.get('/social-identities', authenticateJWT, SocialAuthController.listIdentities);
+router.delete('/social-identities/:provider', authenticateJWT, SocialAuthController.unlinkProvider);
 
 export default router;

--- a/frontend/src/components/EmployeeList.tsx
+++ b/frontend/src/components/EmployeeList.tsx
@@ -1,4 +1,6 @@
 import React, { useMemo, useState } from 'react';
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import type { DropResult } from '@hello-pangea/dnd';
 import { useDebounce } from '../hooks/useDebounce';
 import { useNotification } from '../hooks/useNotification';
 import { Avatar } from './Avatar';
@@ -8,6 +10,7 @@ import type { CSVRow } from './CSVUploader';
 import {
   ArrowUpDown,
   Copy,
+  GripVertical,
   Pencil,
   Search,
   Trash2,
@@ -142,6 +145,8 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<'All' | 'Active' | 'Inactive'>('All');
   const [editSalary, setEditSalary] = useState<number>(0);
+  const [reorderMode, setReorderMode] = useState(false);
+  const [reorderList, setReorderList] = useState<Employee[]>([]);
   const debouncedSearch = useDebounce(searchQuery, 300);
 
   const activeEmployees = employees.filter((employee) => employee.status !== 'Inactive').length;
@@ -214,6 +219,21 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
         : String(valueB).localeCompare(String(valueA));
     });
   }, [filteredEmployees, sortAsc, sortKey]);
+
+  const displayedEmployees = reorderMode ? reorderList : sortedEmployees;
+
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    const items = [...reorderList];
+    const [moved] = items.splice(result.source.index, 1);
+    items.splice(result.destination.index, 0, moved);
+    setReorderList(items);
+  };
+
+  const toggleReorderMode = () => {
+    if (!reorderMode) setReorderList(sortedEmployees);
+    setReorderMode((prev) => !prev);
+  };
 
   const handleDeleteConfirm = (employeeId: string) => {
     if (onRemoveEmployee) {
@@ -351,6 +371,19 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                 <Upload className="h-4 w-4" aria-hidden />
                 {showCSVUploader ? 'Hide CSV import' : 'Import roster CSV'}
               </button>
+              <button
+                type="button"
+                onClick={toggleReorderMode}
+                aria-pressed={reorderMode}
+                className={`inline-flex items-center gap-2 rounded-2xl border px-4 py-3 text-sm font-semibold transition ${
+                  reorderMode
+                    ? 'border-[var(--accent)] bg-[color:rgba(74,240,184,0.08)] text-[var(--accent)]'
+                    : 'border-hi bg-[var(--surface-hi)] text-[var(--text)] hover:border-[var(--accent)] hover:text-[var(--accent)]'
+                }`}
+              >
+                <GripVertical className="h-4 w-4" aria-hidden />
+                {reorderMode ? 'Done reordering' : 'Reorder'}
+              </button>
             </div>
           </div>
         </div>
@@ -387,6 +420,14 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
         </div>
       ) : null}
 
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {!isLoading && (
+          debouncedSearch || statusFilter !== 'All'
+            ? `${displayedEmployees.length} employee${displayedEmployees.length === 1 ? '' : 's'} found`
+            : ''
+        )}
+      </div>
+
       {showEmptyState ? <div className="px-4 py-4 sm:px-6">{renderEmptyState}</div> : null}
 
       <div className={`px-4 py-4 sm:px-6 lg:hidden ${showEmptyState ? 'hidden' : ''}`}>
@@ -397,12 +438,33 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
             ))}
           </div>
         ) : (
-          <div className="grid gap-4">
-            {sortedEmployees.map((employee) => (
+          <DragDropContext onDragEnd={handleDragEnd}>
+            <Droppable droppableId="employee-cards">
+              {(provided) => (
+                <div
+                  className="grid gap-4"
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                  aria-label="Employee list — drag to reorder"
+                >
+            {displayedEmployees.map((employee, index) => (
+              <Draggable key={employee.id} draggableId={employee.id} index={index} isDragDisabled={!reorderMode}>
+                {(dragProvided, dragSnapshot) => (
               <article
+                ref={dragProvided.innerRef}
+                {...dragProvided.draggableProps}
                 key={employee.id}
-                className="rounded-3xl border border-hi bg-[var(--surface-hi)]/70 p-5 shadow-[var(--shadow-card)]"
+                className={`rounded-3xl border border-hi bg-[var(--surface-hi)]/70 p-5 shadow-[var(--shadow-card)] ${dragSnapshot.isDragging ? 'shadow-[0_8px_32px_rgba(74,240,184,0.15)] ring-1 ring-[var(--accent)]' : ''}`}
               >
+                {reorderMode && (
+                  <div
+                    {...dragProvided.dragHandleProps}
+                    className="flex items-center justify-center pb-3 cursor-grab active:cursor-grabbing"
+                    aria-label={`Drag to reorder ${employee.name}`}
+                  >
+                    <GripVertical className="h-5 w-5 text-[var(--muted)]" aria-hidden />
+                  </div>
+                )}
                 <div className="flex items-start gap-3">
                   <button
                     type="button"
@@ -511,15 +573,25 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                   </div>
                 </div>
               </article>
+                )}
+              </Draggable>
             ))}
-          </div>
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
         )}
       </div>
 
       <div className={`hidden overflow-x-auto lg:block ${showEmptyState ? 'lg:hidden' : ''}`}>
+        <DragDropContext onDragEnd={handleDragEnd}>
         <table className="w-full table-fixed border-collapse text-left">
           <thead>
             <tr className="border-b border-hi">
+              {reorderMode && (
+                <th className="w-10 p-6" aria-label="Drag handle column" />
+              )}
               {[
                 { key: 'name' as const, label: 'Name', width: 'w-[28%]' },
                 { key: 'position' as const, label: 'Role', width: 'w-[18%]' },
@@ -527,16 +599,28 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                 { key: 'salary' as const, label: 'Salary', width: 'w-[14%]' },
                 { key: 'status' as const, label: 'Status', width: '' },
               ].map((column) => (
-                <th key={column.key} className={`${column.width} p-6`}>
+                <th
+                  key={column.key}
+                  className={`${column.width} p-6`}
+                  aria-sort={
+                    !reorderMode && sortKey === column.key
+                      ? sortAsc
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  }
+                >
                   <button
                     type="button"
-                    className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[var(--muted)]"
-                    onClick={() => handleSort(column.key)}
+                    disabled={reorderMode}
+                    className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[var(--muted)] disabled:cursor-default"
+                    onClick={() => !reorderMode && handleSort(column.key)}
+                    aria-label={`Sort by ${column.label}`}
                   >
                     {column.label}
-                    <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />
-                    {sortKey === column.key ? (
-                      <span className="text-[var(--accent)]">{sortAsc ? '▲' : '▼'}</span>
+                    {!reorderMode && <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />}
+                    {!reorderMode && sortKey === column.key ? (
+                      <span className="text-[var(--accent)]" aria-hidden>{sortAsc ? '▲' : '▼'}</span>
                     ) : null}
                   </button>
                 </th>
@@ -546,162 +630,188 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200/5">
-            {isLoading
-              ? Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
-                  <EmployeeSkeletonRow key={index} />
-                ))
-              : sortedEmployees.map((employee, index) => (
-                  <tr
-                    key={employee.id}
-                    className="group transition hover:bg-white/5 hover:bg-accent/[0.03]"
-                    style={{ animationDelay: `${index * 0.05}s` }}
-                  >
-                    <td className="p-6">
-                      <div className="flex items-center gap-4">
-                        <button
-                          type="button"
-                          onClick={() => setShowAvatarModal({ open: true, employee })}
-                          className="relative rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
-                          aria-label={`Update photo for ${employee.name}`}
-                        >
-                          <Avatar
-                            email={employee.email}
-                            name={employee.name}
-                            imageUrl={employee.imageUrl}
-                            size="md"
-                          />
-                          <span
-                            className={`absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-[var(--bg)] ${
-                              employee.status === 'Inactive'
-                                ? 'bg-[var(--danger)]'
-                                : 'bg-[var(--success)]'
-                            }`}
-                          />
-                        </button>
+          <Droppable droppableId="employee-table" direction="vertical">
+            {(provided) => (
+              <tbody
+                className="divide-y divide-gray-200/5"
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+              >
+                {isLoading
+                  ? Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+                      <EmployeeSkeletonRow key={index} />
+                    ))
+                  : displayedEmployees.map((employee, index) => (
+                      <Draggable key={employee.id} draggableId={`table-${employee.id}`} index={index} isDragDisabled={!reorderMode}>
+                        {(dragProvided, dragSnapshot) => (
+                          <tr
+                            ref={dragProvided.innerRef}
+                            {...dragProvided.draggableProps}
+                            className={`group transition hover:bg-white/5 hover:bg-accent/[0.03] ${dragSnapshot.isDragging ? 'bg-[var(--surface-hi)] shadow-[0_8px_32px_rgba(74,240,184,0.15)]' : ''}`}
+                          >
+                            {reorderMode && (
+                              <td className="p-6 w-10">
+                                <div
+                                  {...dragProvided.dragHandleProps}
+                                  className="flex items-center justify-center cursor-grab active:cursor-grabbing text-[var(--muted)] hover:text-[var(--accent)]"
+                                  aria-label={`Drag to reorder ${employee.name}`}
+                                >
+                                  <GripVertical className="h-4 w-4" aria-hidden />
+                                </div>
+                              </td>
+                            )}
+                            <td className="p-6">
+                              <div className="flex items-center gap-4">
+                                <button
+                                  type="button"
+                                  onClick={() => setShowAvatarModal({ open: true, employee })}
+                                  className="relative rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+                                  aria-label={`Update photo for ${employee.name}`}
+                                >
+                                  <Avatar
+                                    email={employee.email}
+                                    name={employee.name}
+                                    imageUrl={employee.imageUrl}
+                                    size="md"
+                                  />
+                                  <span
+                                    aria-hidden="true"
+                                    className={`absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-[var(--bg)] ${
+                                      employee.status === 'Inactive'
+                                        ? 'bg-[var(--danger)]'
+                                        : 'bg-[var(--success)]'
+                                    }`}
+                                  />
+                                </button>
 
-                        <div className="min-w-0 flex flex-col">
-                          <button
-                            type="button"
-                            onClick={() => onEmployeeClick?.(employee)}
-                            className="truncate text-left text-sm font-bold text-[var(--text)] transition-colors group-hover:text-[var(--accent)]"
-                            title={employee.name}
-                            aria-label={`Employee name: ${employee.name}`}
-                          >
-                            {employee.name}
-                          </button>
-                          <span
-                            className="truncate text-xs text-[var(--muted)]"
-                            title={employee.email}
-                            aria-label={`Employee email: ${employee.email}`}
-                          >
-                            {employee.email}
-                          </span>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="p-6">
-                      <div className="flex flex-col">
-                        <span className="truncate text-sm font-medium text-[var(--text)]">
-                          {employee.position}
-                        </span>
-                        <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
-                          Position
-                        </span>
-                      </div>
-                    </td>
-                    <td className="p-6">
-                      <div className="flex items-center gap-2">
-                        <code className="max-w-[10rem] truncate rounded-lg border border-[var(--border)] bg-[var(--surface-hi)] px-2 py-1 text-[10px] font-mono text-[var(--muted)]">
-                          {employee.wallet ? shortenWallet(employee.wallet) : 'No wallet'}
-                        </code>
-                        {employee.wallet ? (
-                          <button
-                            type="button"
-                            onClick={() => void handleCopyWallet(employee)}
-                            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-transparent text-[var(--muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
-                            aria-label={`Copy wallet for ${employee.name}`}
-                            title={`Copy wallet for ${employee.name}`}
-                          >
-                            <Copy className="h-4 w-4" aria-hidden />
-                          </button>
-                        ) : null}
-                      </div>
-                    </td>
-                    <td className="p-6">
-                      <div className="flex flex-col items-start">
-                        {onEditEmployee ? (
-                          <button
-                            type="button"
-                            className="text-sm font-bold text-[var(--text)] transition-colors hover:text-[var(--accent)]"
-                            onClick={() => {
-                              setEditSalary(employee.salary || 0);
-                              setShowEditModal({ open: true, employee });
-                            }}
-                          >
-                            ${(employee.salary ?? 0).toLocaleString()}
-                          </button>
-                        ) : (
-                          <span className="text-sm font-bold text-[var(--text)]">
-                            ${(employee.salary ?? 0).toLocaleString()}
-                          </span>
+                                <div className="min-w-0 flex flex-col">
+                                  <button
+                                    type="button"
+                                    onClick={() => onEmployeeClick?.(employee)}
+                                    className="truncate text-left text-sm font-bold text-[var(--text)] transition-colors group-hover:text-[var(--accent)]"
+                                    title={employee.name}
+                                  >
+                                    {employee.name}
+                                  </button>
+                                  <span className="truncate text-xs text-[var(--muted)]" title={employee.email}>
+                                    {employee.email}
+                                  </span>
+                                </div>
+                              </div>
+                            </td>
+                            <td className="p-6">
+                              <div className="flex flex-col">
+                                <span className="truncate text-sm font-medium text-[var(--text)]">
+                                  {employee.position}
+                                </span>
+                                <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+                                  Position
+                                </span>
+                              </div>
+                            </td>
+                            <td className="p-6">
+                              <div className="flex items-center gap-2">
+                                <code className="max-w-[10rem] truncate rounded-lg border border-[var(--border)] bg-[var(--surface-hi)] px-2 py-1 text-[10px] font-mono text-[var(--muted)]">
+                                  {employee.wallet ? shortenWallet(employee.wallet) : 'No wallet'}
+                                </code>
+                                {employee.wallet ? (
+                                  <button
+                                    type="button"
+                                    onClick={() => void handleCopyWallet(employee)}
+                                    className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-transparent text-[var(--muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                                    aria-label={`Copy wallet address for ${employee.name}`}
+                                  >
+                                    <Copy className="h-4 w-4" aria-hidden />
+                                  </button>
+                                ) : null}
+                              </div>
+                            </td>
+                            <td className="p-6">
+                              <div className="flex flex-col items-start">
+                                {onEditEmployee ? (
+                                  <button
+                                    type="button"
+                                    className="text-sm font-bold text-[var(--text)] transition-colors hover:text-[var(--accent)]"
+                                    aria-label={`Edit salary for ${employee.name}: $${(employee.salary ?? 0).toLocaleString()}`}
+                                    onClick={() => {
+                                      setEditSalary(employee.salary || 0);
+                                      setShowEditModal({ open: true, employee });
+                                    }}
+                                  >
+                                    ${(employee.salary ?? 0).toLocaleString()}
+                                  </button>
+                                ) : (
+                                  <span className="text-sm font-bold text-[var(--text)]">
+                                    ${(employee.salary ?? 0).toLocaleString()}
+                                  </span>
+                                )}
+                                <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+                                  per month
+                                </span>
+                              </div>
+                            </td>
+                            <td className="p-6">
+                              <span
+                                className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${
+                                  employee.status === 'Inactive'
+                                    ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
+                                    : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
+                                }`}
+                              >
+                                {employee.status || 'Active'}
+                              </span>
+                            </td>
+                            <td className="p-6">
+                              <div className="flex items-center gap-1 opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100">
+                                {onEditEmployee ? (
+                                  <button
+                                    type="button"
+                                    className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(74,240,184,0.10)] hover:text-[var(--accent)]"
+                                    aria-label={`Edit salary for ${employee.name}`}
+                                    onClick={() => {
+                                      setEditSalary(employee.salary || 0);
+                                      setShowEditModal({ open: true, employee });
+                                    }}
+                                  >
+                                    <Pencil className="h-4 w-4" aria-hidden />
+                                  </button>
+                                ) : null}
+                                {onRemoveEmployee ? (
+                                  <button
+                                    type="button"
+                                    className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(255,123,114,0.10)] hover:text-[var(--danger)]"
+                                    aria-label={`Remove ${employee.name}`}
+                                    onClick={() => setShowDeleteConfirm({ open: true, employee })}
+                                  >
+                                    <Trash2 className="h-4 w-4" aria-hidden />
+                                  </button>
+                                ) : null}
+                              </div>
+                            </td>
+                          </tr>
                         )}
-                        <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
-                          per month
-                        </span>
-                      </div>
-                    </td>
-                    <td className="p-6">
-                      <span
-                        className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${
-                          employee.status === 'Inactive'
-                            ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
-                            : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
-                        }`}
-                      >
-                        {employee.status || 'Active'}
-                      </span>
-                    </td>
-                    <td className="p-6">
-                      <div className="flex items-center gap-1 opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100">
-                        {onEditEmployee ? (
-                          <button
-                            type="button"
-                            className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(74,240,184,0.10)] hover:text-[var(--accent)]"
-                            title={`Edit salary for ${employee.name}`}
-                            onClick={() => {
-                              setEditSalary(employee.salary || 0);
-                              setShowEditModal({ open: true, employee });
-                            }}
-                          >
-                            <Pencil className="h-4 w-4" aria-hidden />
-                          </button>
-                        ) : null}
-                        {onRemoveEmployee ? (
-                          <button
-                            type="button"
-                            className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(255,123,114,0.10)] hover:text-[var(--danger)]"
-                            title={`Remove ${employee.name}`}
-                            onClick={() => setShowDeleteConfirm({ open: true, employee })}
-                          >
-                            <Trash2 className="h-4 w-4" aria-hidden />
-                          </button>
-                        ) : null}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-          </tbody>
+                      </Draggable>
+                    ))}
+                {provided.placeholder}
+              </tbody>
+            )}
+          </Droppable>
         </table>
+        </DragDropContext>
       </div>
 
       {showEditModal.open && showEditModal.employee ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="edit-salary-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+        >
           <div className="w-full max-w-md rounded-3xl border border-hi bg-[var(--surface)] p-6 shadow-[var(--shadow-lg)]">
             <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
               Salary adjustment
             </p>
-            <h3 className="mt-2 text-xl font-black text-[var(--text)]">
+            <h3 id="edit-salary-title" className="mt-2 text-xl font-black text-[var(--text)]">
               Update {showEditModal.employee.name}
             </h3>
             <p className="mt-2 text-sm text-[var(--muted)]">{showEditModal.employee.position}</p>
@@ -716,6 +826,7 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
               id="edit-salary"
               type="number"
               value={editSalary}
+              autoFocus
               onChange={(event) => setEditSalary(Number(event.target.value))}
               className="mt-2 w-full rounded-2xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
             />
@@ -749,7 +860,12 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
       />
 
       {showAvatarModal.open && showAvatarModal.employee ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="avatar-modal-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+        >
           <div className="w-full max-w-sm rounded-3xl border border-hi bg-[var(--surface)] p-6 shadow-[var(--shadow-lg)]">
             <div className="flex items-start gap-3">
               <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-hi)] p-2.5">
@@ -759,7 +875,7 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                 <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
                   Directory photo
                 </p>
-                <h3 className="mt-1 text-xl font-black text-[var(--text)]">
+                <h3 id="avatar-modal-title" className="mt-1 text-xl font-black text-[var(--text)]">
                   Update employee photo
                 </h3>
               </div>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,19 +1,20 @@
-import { Icon } from '@stellar/design-system';
+import { Moon, Sun } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 
 export const ThemeToggle = () => {
   const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
 
   return (
     <button
       onClick={toggleTheme}
-      className="p-2 rounded-lg glass border-hi hover:bg-white/5 active:scale-95 transition-all outline-none focus:outline-none focus:ring-2 focus:ring-accent/50 flex items-center justify-center text-text min-w-[44px] min-h-[44px]"
-      title={theme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode'}
-      aria-label={theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
-      aria-pressed={theme === 'dark'}
+      className="p-2 rounded-lg border border-(--border-hi) bg-(--surface) hover:bg-(--surface-hi) active:scale-95 transition-all outline-none focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/50 flex items-center justify-center text-(--text) min-w-[44px] min-h-[44px]"
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-pressed={isDark}
     >
-      {theme === 'light' ? <Icon.Moon01 size="md" /> : <Icon.Sun size="md" />}
-      <span className="sr-only">Current theme: {theme === 'light' ? 'Light' : 'Dark'}</span>
+      {isDark ? <Sun className="w-4 h-4" aria-hidden="true" /> : <Moon className="w-4 h-4" aria-hidden="true" />}
+      <span className="sr-only">Current theme: {isDark ? 'Dark' : 'Light'}</span>
     </button>
   );
 };


### PR DESCRIPTION
…OAuth identity management

Closes #650  - ThemeToggle now uses lucide-react icons (Sun/Moon) instead of
  @stellar/design-system, consistent with the rest of the app icon usage.

Closes #649  - EmployeeList gains a 'Reorder' toggle that wraps both the
  desktop table and mobile card views in @hello-pangea/dnd DragDropContext.
  When active, a GripVertical drag handle appears on each row/card; drag
  order is maintained in local state independently of column sort.

Closes #648  - Accessibility improvements: aria-sort on sortable th elements,
  role=dialog + aria-modal + aria-labelledby on edit-salary and avatar modals,
  autoFocus on the salary input, aria-live polite region for search result
  count, aria-hidden=true on decorative status indicators, and explicit
  aria-label on all action buttons.

Closes #711  - New SocialAuthController with GET /auth/social-identities
  (list linked OAuth providers) and DELETE /auth/social-identities/:provider
  (unlink with safety guard ensuring at least one login method remains).
  Both routes are JWT-protected via authenticateJWT middleware.

# Pull Request

## Summary
<!-- Describe the change and link the issue(s) it resolves, if any. -->

## What Changed
<!-- List the main code or docs changes in a few bullets. -->

## Checklist
- [ ] I linked the relevant issue(s) in the summary.
- [ ] I added or updated tests for the change.
- [ ] I ran the relevant test suite locally.
- [ ] I updated documentation where needed, or explained why it was not needed.
- [ ] If this change touches the UI, I verified responsive behavior and accessibility.
- [ ] I included screenshots, logs, or other proof when they help review.

## Testing
<!-- Describe the exact commands or manual steps you used to verify the change. -->

## Documentation
<!-- Note any docs that were updated, or write "N/A". -->

## Accessibility / Responsiveness
<!-- If this touches the UI, describe keyboard, screen reader, and responsive checks. Otherwise write "N/A". -->

## Notes
<!-- Add migration steps, follow-up tasks, or anything else reviewers should know. -->
