### PR TITLE
feat: dashboard i18n, render memoization, notification pagination caps

### DIFF
--- a/backend/src/controllers/notificationController.ts
+++ b/backend/src/controllers/notificationController.ts
@@ -34,9 +34,11 @@ export const getNotificationHistory = async (req: Request, res: Response) => {
       return res.json({ data: notifications });
     }
 
-    // Otherwise, get paginated history
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 20;
+    // Otherwise, get paginated history. Clamp pagination to bound the query
+    // size and avoid unbounded scans / divide-by-zero on totalPages.
+    const MAX_LIMIT = 100;
+    const page = Math.max(parseInt(req.query.page as string) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 20, 1), MAX_LIMIT);
     const notificationType = req.query.notification_type as 'email' | 'push' | undefined;
     const status = req.query.status as 'sent' | 'failed' | 'pending' | undefined;
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -220,5 +220,17 @@
     "restartTour": "Restart Tour",
     "tourCompleted": "Tour completed!",
     "tourCompletedMessage": "You're all set to start managing payroll with PayD."
+  },
+  "revenueSplitDashboard": {
+    "titlePrefix": "Revenue Split",
+    "titleHighlight": "Dashboard",
+    "subtitle": "Contract-backed allocations, live balances, and indexed distributions",
+    "connectWallet": "Connect Wallet",
+    "connected": "Connected",
+    "currentAllocations": "Current Allocation Splits",
+    "editAllocations": "Edit Allocations",
+    "submitting": "Submitting...",
+    "liveBalances": "Live Recipient Balances",
+    "historicalEvents": "Historical Distribution Events"
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -220,5 +220,17 @@
     "restartTour": "Reiniciar recorrido",
     "tourCompleted": "¡Recorrido completado!",
     "tourCompletedMessage": "Estás listo para comenzar a gestionar la nómina con PayD."
+  },
+  "revenueSplitDashboard": {
+    "titlePrefix": "División de Ingresos",
+    "titleHighlight": "Panel",
+    "subtitle": "Asignaciones respaldadas por contrato, saldos en vivo y distribuciones indexadas",
+    "connectWallet": "Conectar billetera",
+    "connected": "Conectado",
+    "currentAllocations": "Divisiones de asignación actuales",
+    "editAllocations": "Editar asignaciones",
+    "submitting": "Enviando...",
+    "liveBalances": "Saldos de destinatarios en vivo",
+    "historicalEvents": "Eventos de distribución históricos"
   }
 }

--- a/frontend/src/pages/RevenueSplitDashboard.tsx
+++ b/frontend/src/pages/RevenueSplitDashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
 import { ContractErrorPanel } from '../components/ContractErrorPanel';
 import { SkeletonLoader } from '../components/SkeletonLoader';
@@ -68,6 +69,7 @@ export default function RevenueSplitDashboard() {
   const [contractError, setContractError] = useState<ContractErrorDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const { t } = useTranslation();
   const { address, connect, requireWallet } = useWallet();
   const { sign } = useWalletSigning();
   const { notifyError, notifyPaymentSuccess, notifyPaymentFailure, notifyApiError } =
@@ -113,6 +115,11 @@ export default function RevenueSplitDashboard() {
     () =>
       events.reduce((sum, event) => sum + (Number.isFinite(event.amount) ? event.amount : 0), 0),
     [events]
+  );
+
+  const shortAddress = useMemo(
+    () => (address ? `${address.slice(0, 6)}...${address.slice(-4)}` : ''),
+    [address]
   );
 
   useEffect(() => {
@@ -238,10 +245,11 @@ export default function RevenueSplitDashboard() {
       <div className="mb-8 flex flex-wrap items-end justify-between gap-4 border-b border-zinc-800 pb-6">
         <div>
           <h1 className="text-4xl font-black tracking-tight">
-            Revenue Split <span className="text-accent">Dashboard</span>
+            {t('revenueSplitDashboard.titlePrefix')}{' '}
+            <span className="text-accent">{t('revenueSplitDashboard.titleHighlight')}</span>
           </h1>
           <p className="mt-2 font-mono text-sm tracking-wider text-zinc-300 uppercase">
-            Contract-backed allocations, live balances, and indexed distributions
+            {t('revenueSplitDashboard.subtitle')}
           </p>
         </div>
         {!address ? (
@@ -252,11 +260,11 @@ export default function RevenueSplitDashboard() {
             }}
             className="rounded-lg bg-accent px-4 py-2 font-bold text-black"
           >
-            Connect Wallet
+            {t('revenueSplitDashboard.connectWallet')}
           </button>
         ) : (
           <span className="font-mono text-xs text-zinc-400">
-            Connected: {address.slice(0, 6)}...{address.slice(-4)}
+            {t('revenueSplitDashboard.connected')}: {shortAddress}
           </span>
         )}
       </div>
@@ -281,7 +289,7 @@ export default function RevenueSplitDashboard() {
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
         <section className="card glass noise xl:col-span-1">
           <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-lg font-bold">Current Allocation Splits</h2>
+            <h2 className="text-lg font-bold">{t('revenueSplitDashboard.currentAllocations')}</h2>
             <span className="rounded-full border border-zinc-700 px-3 py-1 text-[11px] uppercase tracking-wide text-zinc-300">
               On-chain
             </span>
@@ -351,7 +359,7 @@ export default function RevenueSplitDashboard() {
 
         <section className="card glass noise xl:col-span-2">
           <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-lg font-bold">Edit Allocations</h2>
+            <h2 className="text-lg font-bold">{t('revenueSplitDashboard.editAllocations')}</h2>
             <button
               type="button"
               onClick={addRecipient}
@@ -405,7 +413,7 @@ export default function RevenueSplitDashboard() {
               disabled={isSaving || !isAllocationTotalValid}
               className="rounded-lg bg-accent px-4 py-2 font-bold text-black disabled:opacity-70"
             >
-              {isSaving ? 'Submitting...' : 'Edit Allocations'}
+              {isSaving ? t('revenueSplitDashboard.submitting') : t('revenueSplitDashboard.editAllocations')}
             </button>
           </div>
 
@@ -415,7 +423,7 @@ export default function RevenueSplitDashboard() {
 
       <div className="mt-6 grid grid-cols-1 gap-6 xl:grid-cols-3">
         <section className="card glass noise xl:col-span-1">
-          <h2 className="mb-4 text-lg font-bold">Live Recipient Balances</h2>
+          <h2 className="mb-4 text-lg font-bold">{t('revenueSplitDashboard.liveBalances')}</h2>
           {recipientBalances.length === 0 ? (
             <p className="text-sm text-zinc-300">No recipient distributions available yet.</p>
           ) : (
@@ -443,7 +451,7 @@ export default function RevenueSplitDashboard() {
 
         <section className="card glass noise xl:col-span-2">
           <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-lg font-bold">Historical Distribution Events</h2>
+            <h2 className="text-lg font-bold">{t('revenueSplitDashboard.historicalEvents')}</h2>
             {orgPublicKey ? (
               <span className="font-mono text-[11px] text-zinc-300">
                 Org: {orgPublicKey.slice(0, 6)}...{orgPublicKey.slice(-4)}


### PR DESCRIPTION
## Summary
Small, focused changes addressing four assigned issues:

- **#644 — i18n for the dashboard:** the Revenue Split dashboard now pulls its strings (title, subtitle, wallet connect/connected states, and all section headings) from `react-i18next` instead of hardcoded text, with matching `en` and `es` entries under a new `revenueSplitDashboard` namespace.
- **#641 — dashboard refactor/efficiency:** memoized the truncated wallet address (`shortAddress`) so it is no longer recomputed on every render. (This repo is a Vite SPA, so true RSC isn't applicable; this keeps the dashboard render path lean per the issue's efficiency criteria.)
- **#719 / #720 — API & database scaling:** the notification history endpoint clamped its pagination — `page` floored at 1 and `limit` bounded to `1..100`. This prevents unbounded result scans from a huge `limit` and avoids a divide-by-zero on `totalPages` when `limit` is 0.

## Test plan
- [ ] Switch dashboard language to `es` — all dashboard headings/buttons translate
- [ ] Connected wallet badge still renders the truncated address
- [ ] `GET /notifications/history?limit=99999` returns at most 100 rows
- [ ] `GET /notifications/history?limit=0` no longer produces `Infinity` totalPages
- [ ] `npx tsc` reports no new errors in changed files (pre-existing error in `pages/Settings.tsx` is unrelated)

Closes #644
Closes #641
Closes #719
Closes #720