### PR TITLE
[BACKEND] Issue #256 - API & Database Scaling Part 11

### DIFF
--- a/backend/src/__tests__/circuitBreaker.test.ts
+++ b/backend/src/__tests__/circuitBreaker.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Integration tests for the Circuit-Breaker service and management API.
+ * Part of the API & Database Scaling effort (Issue #256 – Part 11).
+ *
+ * Strategy
+ * ─────────
+ * • Mock `dbPoolService` so tests run without a live PostgreSQL instance.
+ * • Mock `circuitBreakerService` on route-level tests to control state.
+ * • Unit-test the CircuitBreakerService state machine in isolation.
+ */
+
+import request from 'supertest';
+import app from '../app.js';
+
+// ─── Mock dbPoolService ────────────────────────────────────────────────────────
+
+const mockPoolQuery = jest.fn();
+
+jest.mock('../services/dbPoolService.js', () => ({
+  getPool: () => ({ query: mockPoolQuery }),
+  getPoolStats: jest.fn().mockReturnValue({
+    totalConns: 5,
+    idleConns: 3,
+    waitingClients: 0,
+    recordedAt: new Date(),
+  }),
+  query: mockPoolQuery,
+  closePool: jest.fn(),
+}));
+
+// ─── Mock circuitBreakerService ───────────────────────────────────────────────
+
+const mockGetAll = jest.fn();
+const mockGet = jest.fn();
+const mockReset = jest.fn();
+
+jest.mock('../services/circuitBreakerService.js', () => {
+  const actual = jest.requireActual('../services/circuitBreakerService.js');
+  return {
+    ...actual,
+    circuitBreakerService: {
+      register: jest.fn(),
+      getAll: mockGetAll,
+      get: mockGet,
+      reset: mockReset,
+      execute: jest.fn((_name: string, fn: () => Promise<unknown>) => fn()),
+    },
+    CircuitOpenError: actual.CircuitOpenError,
+  };
+});
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const closedSnapshot = {
+  name: 'database',
+  state: 'CLOSED' as const,
+  failureCount: 0,
+  successCount: 0,
+  lastFailureAt: null,
+  openedAt: null,
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const openSnapshot = {
+  name: 'redis',
+  state: 'OPEN' as const,
+  failureCount: 5,
+  successCount: 0,
+  lastFailureAt: new Date('2026-01-01T00:01:00Z'),
+  openedAt: new Date('2026-01-01T00:01:00Z'),
+  updatedAt: new Date('2026-01-01T00:01:00Z'),
+};
+
+// ─── GET /api/v1/circuit-breakers ─────────────────────────────────────────────
+
+describe('GET /api/v1/circuit-breakers', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns 200 with all circuits', async () => {
+    mockGetAll.mockReturnValue([closedSnapshot, openSnapshot]);
+
+    const res = await request(app).get('/api/v1/circuit-breakers');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.meta.count).toBe(2);
+  });
+
+  it('returns an empty array when no circuits are registered', async () => {
+    mockGetAll.mockReturnValue([]);
+
+    const res = await request(app).get('/api/v1/circuit-breakers');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.meta.count).toBe(0);
+  });
+});
+
+// ─── GET /api/v1/circuit-breakers/summary ────────────────────────────────────
+
+describe('GET /api/v1/circuit-breakers/summary', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns aggregated health counts', async () => {
+    mockGetAll.mockReturnValue([closedSnapshot, openSnapshot]);
+
+    const res = await request(app).get('/api/v1/circuit-breakers/summary');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.total).toBe(2);
+    expect(res.body.data.closed).toBe(1);
+    expect(res.body.data.open).toBe(1);
+    expect(res.body.data.halfOpen).toBe(0);
+    expect(res.body.data.healthy).toBe(false);
+  });
+
+  it('marks system healthy when all circuits are closed', async () => {
+    mockGetAll.mockReturnValue([closedSnapshot]);
+
+    const res = await request(app).get('/api/v1/circuit-breakers/summary');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.healthy).toBe(true);
+  });
+});
+
+// ─── GET /api/v1/circuit-breakers/:name ──────────────────────────────────────
+
+describe('GET /api/v1/circuit-breakers/:name', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns 200 with the circuit snapshot', async () => {
+    mockGet.mockReturnValue(closedSnapshot);
+
+    const res = await request(app).get('/api/v1/circuit-breakers/database');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.name).toBe('database');
+    expect(res.body.data.state).toBe('CLOSED');
+  });
+
+  it('returns 404 when the circuit does not exist', async () => {
+    mockGet.mockReturnValue(null);
+
+    const res = await request(app).get('/api/v1/circuit-breakers/unknown');
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('NOT_FOUND');
+  });
+});
+
+// ─── POST /api/v1/circuit-breakers/:name/reset ───────────────────────────────
+
+describe('POST /api/v1/circuit-breakers/:name/reset', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns 200 and resets the circuit', async () => {
+    mockGet
+      .mockReturnValueOnce(openSnapshot)  // before reset
+      .mockReturnValueOnce({ ...closedSnapshot, name: 'redis' }); // after reset
+    mockReset.mockResolvedValue(undefined);
+
+    const res = await request(app).post('/api/v1/circuit-breakers/redis/reset');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toMatch(/reset to CLOSED/i);
+    expect(mockReset).toHaveBeenCalledWith('redis');
+  });
+
+  it('returns 404 when trying to reset an unknown circuit', async () => {
+    mockGet.mockReturnValue(null);
+
+    const res = await request(app).post('/api/v1/circuit-breakers/ghost/reset');
+
+    expect(res.status).toBe(404);
+    expect(mockReset).not.toHaveBeenCalled();
+  });
+});
+
+// ─── GET /api/v1/circuit-breakers/:name/events ───────────────────────────────
+
+describe('GET /api/v1/circuit-breakers/:name/events', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns 200 with event rows', async () => {
+    const fakeEvents = [
+      {
+        id: '1',
+        event_type: 'OPENED',
+        from_state: 'CLOSED',
+        to_state: 'OPEN',
+        failure_count: 5,
+        message: null,
+        recorded_at: new Date().toISOString(),
+      },
+    ];
+    mockPoolQuery.mockResolvedValue({ rows: fakeEvents, rowCount: 1 });
+
+    const res = await request(app).get(
+      '/api/v1/circuit-breakers/database/events?limit=10&sinceHours=1',
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].event_type).toBe('OPENED');
+    expect(res.body.meta).toMatchObject({
+      circuit: 'database',
+      sinceHours: 1,
+      limit: 10,
+      count: 1,
+    });
+  });
+
+  it('caps limit at 200', async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    await request(app).get('/api/v1/circuit-breakers/database/events?limit=9999');
+
+    const passedLimit = mockPoolQuery.mock.calls[0][1][2];
+    expect(passedLimit).toBe(200);
+  });
+
+  it('returns 400 for an invalid limit', async () => {
+    const res = await request(app).get(
+      '/api/v1/circuit-breakers/database/events?limit=0',
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('BAD_REQUEST');
+  });
+});
+
+// ─── CircuitBreakerService unit tests ─────────────────────────────────────────
+
+describe('CircuitBreakerService (unit)', () => {
+  // Import real implementation for unit tests (bypassing module mock)
+  let CircuitBreakerService: typeof import('../services/circuitBreakerService.js').CircuitBreakerService;
+  let CircuitOpenError: typeof import('../services/circuitBreakerService.js').CircuitOpenError;
+
+  beforeAll(async () => {
+    // Use the actual module (not the mock used for route tests above)
+    jest.resetModules();
+    const mod = await import('../services/circuitBreakerService.js');
+    CircuitBreakerService = mod.CircuitBreakerService;
+    CircuitOpenError = mod.CircuitOpenError;
+  });
+
+  it('starts in CLOSED state', () => {
+    const svc = (CircuitBreakerService as any)._instance = null;
+    const instance = CircuitBreakerService.getInstance();
+    instance.register('test-unit', { persist: false });
+    expect(instance.get('test-unit')?.state).toBe('CLOSED');
+  });
+
+  it('opens after exceeding failure threshold', async () => {
+    // Suppress DB persistence in unit tests
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const instance = CircuitBreakerService.getInstance();
+    instance.register('test-fail', { failureThreshold: 3, persist: false });
+
+    const fail = () => Promise.reject(new Error('boom'));
+
+    for (let i = 0; i < 3; i++) {
+      await instance.execute('test-fail', fail).catch(() => undefined);
+    }
+
+    expect(instance.get('test-fail')?.state).toBe('OPEN');
+  });
+
+  it('throws CircuitOpenError when OPEN and within recovery window', async () => {
+    const instance = CircuitBreakerService.getInstance();
+    instance.register('test-open', {
+      failureThreshold: 1,
+      recoveryMs: 60_000,
+      persist: false,
+    });
+
+    await instance.execute('test-open', () => Promise.reject(new Error('err'))).catch(() => {});
+
+    await expect(
+      instance.execute('test-open', () => Promise.resolve('ok')),
+    ).rejects.toBeInstanceOf(CircuitOpenError);
+  });
+
+  it('resets to CLOSED after manual reset', async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const instance = CircuitBreakerService.getInstance();
+    instance.register('test-reset', { failureThreshold: 1, persist: false });
+
+    await instance.execute('test-reset', () => Promise.reject(new Error('err'))).catch(() => {});
+    expect(instance.get('test-reset')?.state).toBe('OPEN');
+
+    await instance.reset('test-reset');
+    expect(instance.get('test-reset')?.state).toBe('CLOSED');
+  });
+});

--- a/backend/src/controllers/circuitBreakerController.ts
+++ b/backend/src/controllers/circuitBreakerController.ts
@@ -1,0 +1,163 @@
+/**
+ * @file src/controllers/circuitBreakerController.ts
+ * @description HTTP handlers for the circuit-breaker management API.
+ *              Part of the API & Database Scaling effort (Issue #256 – Part 11).
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+import { circuitBreakerService } from '../services/circuitBreakerService.js';
+import { getPool } from '../services/dbPoolService.js';
+import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
+import logger from '../utils/logger.js';
+
+export class CircuitBreakerController {
+  /**
+   * GET /api/v1/circuit-breakers
+   * List all registered circuit breakers and their current state.
+   */
+  async listAll(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const circuits = circuitBreakerService.getAll();
+      res.status(200).json({
+        success: true,
+        data: circuits,
+        meta: { count: circuits.length },
+      });
+    } catch (err) {
+      logger.error({ err }, '[CircuitBreakerController] Failed to list circuits');
+      next(err);
+    }
+  }
+
+  /**
+   * GET /api/v1/circuit-breakers/:name
+   * Return the snapshot for a single named circuit.
+   */
+  async getOne(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const { name } = req.params;
+      const snapshot = circuitBreakerService.get(name);
+
+      if (!snapshot) {
+        res.status(404).json(
+          apiErrorResponse(ErrorCodes.NOT_FOUND, `Circuit "${name}" not found`),
+        );
+        return;
+      }
+
+      res.status(200).json({ success: true, data: snapshot });
+    } catch (err) {
+      logger.error({ err }, '[CircuitBreakerController] Failed to get circuit');
+      next(err);
+    }
+  }
+
+  /**
+   * POST /api/v1/circuit-breakers/:name/reset
+   * Manually reset a circuit to CLOSED state.
+   */
+  async reset(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const { name } = req.params;
+
+      const before = circuitBreakerService.get(name);
+      if (!before) {
+        res.status(404).json(
+          apiErrorResponse(ErrorCodes.NOT_FOUND, `Circuit "${name}" not found`),
+        );
+        return;
+      }
+
+      await circuitBreakerService.reset(name);
+      const after = circuitBreakerService.get(name);
+
+      logger.info(
+        `[CircuitBreakerController] Circuit "${name}" reset from ${before.state} to CLOSED`,
+      );
+
+      res.status(200).json({
+        success: true,
+        message: `Circuit "${name}" has been reset to CLOSED.`,
+        data: after,
+      });
+    } catch (err) {
+      logger.error({ err }, '[CircuitBreakerController] Failed to reset circuit');
+      next(err);
+    }
+  }
+
+  /**
+   * GET /api/v1/circuit-breakers/:name/events
+   * Return recent circuit-breaker events for a named circuit.
+   */
+  async getEvents(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const { name } = req.params;
+      const limit = Math.min(Number(req.query.limit ?? 50), 200);
+      const sinceHours = Number(req.query.sinceHours ?? 24);
+
+      if (isNaN(limit) || limit < 1) {
+        res.status(400).json(
+          apiErrorResponse(ErrorCodes.BAD_REQUEST, 'limit must be a positive integer'),
+        );
+        return;
+      }
+
+      const pool = getPool();
+      const { rows } = await pool.query<{
+        id: string;
+        event_type: string;
+        from_state: string | null;
+        to_state: string | null;
+        failure_count: number;
+        message: string | null;
+        recorded_at: Date;
+      }>(
+        `SELECT id, event_type, from_state, to_state, failure_count, message, recorded_at
+           FROM circuit_breaker_events
+          WHERE breaker_name = $1
+            AND recorded_at >= NOW() - ($2 || ' hours')::INTERVAL
+          ORDER BY recorded_at DESC
+          LIMIT $3`,
+        [name, sinceHours, limit],
+      );
+
+      res.status(200).json({
+        success: true,
+        data: rows,
+        meta: { circuit: name, sinceHours, limit, count: rows.length },
+      });
+    } catch (err) {
+      logger.error({ err }, '[CircuitBreakerController] Failed to fetch events');
+      next(err);
+    }
+  }
+
+  /**
+   * GET /api/v1/circuit-breakers/summary
+   * Return a summary of circuit health across all breakers (admin dashboard).
+   */
+  async getSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const circuits = circuitBreakerService.getAll();
+      const open = circuits.filter((c) => c.state === 'OPEN').length;
+      const halfOpen = circuits.filter((c) => c.state === 'HALF_OPEN').length;
+      const closed = circuits.filter((c) => c.state === 'CLOSED').length;
+
+      res.status(200).json({
+        success: true,
+        data: {
+          total: circuits.length,
+          closed,
+          open,
+          halfOpen,
+          healthy: open === 0 && halfOpen === 0,
+          circuits,
+        },
+      });
+    } catch (err) {
+      logger.error({ err }, '[CircuitBreakerController] Failed to get summary');
+      next(err);
+    }
+  }
+}

--- a/backend/src/db/migrations/041_circuit_breaker_part11.sql
+++ b/backend/src/db/migrations/041_circuit_breaker_part11.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- Migration 041: API & Database Scaling – Part 11
+-- Purpose : Introduce circuit-breaker state persistence and event logging to
+--           support the CircuitBreakerService (Issue #256 – Part 11).
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Circuit-breaker state table
+--    Stores the current state of each named circuit (one row per service).
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS circuit_breaker_state (
+  name              TEXT        PRIMARY KEY,
+  state             TEXT        NOT NULL DEFAULT 'CLOSED'
+                                CHECK (state IN ('CLOSED', 'OPEN', 'HALF_OPEN')),
+  failure_count     INTEGER     NOT NULL DEFAULT 0 CHECK (failure_count >= 0),
+  success_count     INTEGER     NOT NULL DEFAULT 0 CHECK (success_count >= 0),
+  last_failure_at   TIMESTAMPTZ,
+  opened_at         TIMESTAMPTZ,
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE  circuit_breaker_state IS
+  'Persisted state for each named circuit breaker (one row per service).';
+COMMENT ON COLUMN circuit_breaker_state.state IS
+  'CLOSED = healthy, OPEN = blocking all requests, HALF_OPEN = probing recovery.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Circuit-breaker event log
+--    Immutable log of every state-transition event for auditing & metrics.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS circuit_breaker_events (
+  id              BIGSERIAL   PRIMARY KEY,
+  breaker_name    TEXT        NOT NULL,
+  event_type      TEXT        NOT NULL
+                              CHECK (event_type IN (
+                                'FAILURE', 'SUCCESS', 'OPENED', 'CLOSED', 'HALF_OPENED', 'RESET'
+                              )),
+  from_state      TEXT,
+  to_state        TEXT,
+  failure_count   INTEGER,
+  message         TEXT,
+  recorded_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cb_events_name_ts
+  ON circuit_breaker_events (breaker_name, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cb_events_type_ts
+  ON circuit_breaker_events (event_type, recorded_at DESC);
+
+COMMENT ON TABLE circuit_breaker_events IS
+  'Immutable audit log of circuit-breaker state transitions and failure events.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Auto-prune old events (retain last 30 days)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION prune_circuit_breaker_events() RETURNS void
+LANGUAGE sql AS $$
+  DELETE FROM circuit_breaker_events
+  WHERE recorded_at < NOW() - INTERVAL '30 days';
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Seed well-known circuit names so health checks can reference them
+-- ---------------------------------------------------------------------------
+
+INSERT INTO circuit_breaker_state (name, state) VALUES
+  ('database',     'CLOSED'),
+  ('redis',        'CLOSED'),
+  ('stellar-api',  'CLOSED'),
+  ('email',        'CLOSED')
+ON CONFLICT (name) DO NOTHING;

--- a/backend/src/middlewares/circuitBreakerMiddleware.ts
+++ b/backend/src/middlewares/circuitBreakerMiddleware.ts
@@ -1,0 +1,85 @@
+/**
+ * @file src/middlewares/circuitBreakerMiddleware.ts
+ * @description Express middleware factory that wraps a named circuit breaker
+ *              around a route handler.  Part of the API & Database Scaling
+ *              effort (Issue #256 – Part 11).
+ *
+ * Usage
+ * ─────
+ *   router.get('/payments', circuitBreakerGuard('stellar-api'), handler);
+ *
+ * When the named circuit is OPEN the middleware responds with 503 and a
+ * Retry-After header so clients can back off gracefully.
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+import {
+  circuitBreakerService,
+  CircuitOpenError,
+  CircuitBreakerOptions,
+} from '../services/circuitBreakerService.js';
+import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
+import logger from '../utils/logger.js';
+
+/**
+ * Returns an Express middleware that guards a route behind the named circuit.
+ *
+ * @param name    Circuit name (must match a registered circuit or will auto-register)
+ * @param opts    Optional configuration override for auto-registration
+ */
+export function circuitBreakerGuard(
+  name: string,
+  opts: CircuitBreakerOptions = {},
+) {
+  circuitBreakerService.register(name, opts);
+
+  return async function circuitBreakerMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    const snapshot = circuitBreakerService.get(name);
+
+    if (snapshot?.state === 'OPEN') {
+      const openedMs = snapshot.openedAt ? snapshot.openedAt.getTime() : Date.now();
+      const recoveryMs = opts.recoveryMs ?? 30_000;
+      const retryAfterSec = Math.ceil(
+        Math.max(0, recoveryMs - (Date.now() - openedMs)) / 1000,
+      );
+
+      logger.warn(
+        `[circuitBreakerMiddleware] Circuit "${name}" is OPEN – rejecting ${req.method} ${req.path}`,
+      );
+
+      res.setHeader('Retry-After', String(retryAfterSec));
+      res.status(503).json({
+        ...apiErrorResponse(
+          ErrorCodes.INTERNAL_ERROR,
+          `Service "${name}" is temporarily unavailable. Please retry after ${retryAfterSec}s.`,
+        ),
+        circuit: name,
+        retryAfterSeconds: retryAfterSec,
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Wraps an async route handler so that any thrown error is recorded as a
+ * circuit-breaker failure for the given circuit name.
+ *
+ * Use this when the circuit-breaker failure tracking should happen inside the
+ * handler rather than at the middleware level (e.g., for database calls).
+ *
+ * @param name    Circuit name
+ * @param fn      Async function to execute through the circuit
+ */
+export async function withCircuitBreaker<T>(
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return circuitBreakerService.execute(name, fn);
+}

--- a/backend/src/routes/circuitBreakerRoutes.ts
+++ b/backend/src/routes/circuitBreakerRoutes.ts
@@ -1,0 +1,140 @@
+/**
+ * @file src/routes/circuitBreakerRoutes.ts
+ * @description REST endpoints for circuit-breaker observability and management.
+ *              Part of the API & Database Scaling effort (Issue #256 – Part 11).
+ *
+ * Routes
+ * ──────
+ *   GET  /api/v1/circuit-breakers              – list all circuits
+ *   GET  /api/v1/circuit-breakers/summary      – health summary (admin dashboard)
+ *   GET  /api/v1/circuit-breakers/:name        – single circuit snapshot
+ *   GET  /api/v1/circuit-breakers/:name/events – recent events for a circuit
+ *   POST /api/v1/circuit-breakers/:name/reset  – manually reset a circuit
+ */
+
+import { Router } from 'express';
+import { CircuitBreakerController } from '../controllers/circuitBreakerController.js';
+
+const router = Router();
+const ctrl = new CircuitBreakerController();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Circuit Breakers
+ *   description: Circuit-breaker state management and observability (Issue #256 Part 11)
+ */
+
+/**
+ * @swagger
+ * /api/v1/circuit-breakers:
+ *   get:
+ *     summary: List all registered circuit breakers and their current state
+ *     tags: [Circuit Breakers]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Array of circuit-breaker snapshots
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/CircuitSnapshot'
+ *                 meta:
+ *                   type: object
+ *                   properties:
+ *                     count: { type: integer }
+ */
+router.get('/', (req, res, next) => ctrl.listAll(req, res, next));
+
+/**
+ * @swagger
+ * /api/v1/circuit-breakers/summary:
+ *   get:
+ *     summary: Aggregated health summary across all circuit breakers
+ *     tags: [Circuit Breakers]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Summary with open/closed/half-open counts
+ */
+router.get('/summary', (req, res, next) => ctrl.getSummary(req, res, next));
+
+/**
+ * @swagger
+ * /api/v1/circuit-breakers/{name}:
+ *   get:
+ *     summary: Get the current snapshot for a named circuit breaker
+ *     tags: [Circuit Breakers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema: { type: string }
+ *         description: Circuit name (e.g. "database", "redis", "stellar-api")
+ *     responses:
+ *       200:
+ *         description: Circuit snapshot
+ *       404:
+ *         description: Circuit not found
+ */
+router.get('/:name', (req, res, next) => ctrl.getOne(req, res, next));
+
+/**
+ * @swagger
+ * /api/v1/circuit-breakers/{name}/events:
+ *   get:
+ *     summary: Return recent state-change and failure events for a circuit
+ *     tags: [Circuit Breakers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema: { type: string }
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, default: 50 }
+ *       - in: query
+ *         name: sinceHours
+ *         schema: { type: integer, default: 24 }
+ *     responses:
+ *       200:
+ *         description: List of events
+ *       400:
+ *         description: Invalid query parameters
+ */
+router.get('/:name/events', (req, res, next) => ctrl.getEvents(req, res, next));
+
+/**
+ * @swagger
+ * /api/v1/circuit-breakers/{name}/reset:
+ *   post:
+ *     summary: Manually reset a circuit breaker to CLOSED state
+ *     tags: [Circuit Breakers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Circuit reset successfully
+ *       404:
+ *         description: Circuit not found
+ */
+router.post('/:name/reset', (req, res, next) => ctrl.reset(req, res, next));
+
+export default router;

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -35,6 +35,7 @@ import stellarThrottlingRoutes from '../stellarThrottlingRoutes.js';
 import organizationRoutes from '../organizationRoutes.js';
 import orgAuditRoutes from '../orgAuditRoutes.js';
 import transactionRoutes from '../transactionRoutes.js';
+import circuitBreakerRoutes from '../circuitBreakerRoutes.js';
 
 const router = Router();
 
@@ -69,5 +70,6 @@ router.use('/stellar-throttling', apiRateLimit(), stellarThrottlingRoutes);
 router.use('/organizations', dataRateLimit(), organizationRoutes);
 router.use('/org-audit', dataRateLimit(), orgAuditRoutes);
 router.use('/transactions', dataRateLimit(), transactionRoutes);
+router.use('/circuit-breakers', apiRateLimit(), circuitBreakerRoutes);
 
 export default router;

--- a/backend/src/services/circuitBreakerService.ts
+++ b/backend/src/services/circuitBreakerService.ts
@@ -1,0 +1,334 @@
+/**
+ * @file src/services/circuitBreakerService.ts
+ * @description Circuit-breaker implementation for resilient API & database
+ *              access.  Part of the API & Database Scaling effort (Issue #256
+ *              – Part 11).
+ *
+ * Pattern overview
+ * ────────────────
+ * CLOSED   → all calls pass through; failure counter increments on errors.
+ * OPEN     → all calls are rejected immediately; re-check after recoveryMs.
+ * HALF_OPEN → a limited probe call is allowed to test recovery; success →
+ *             CLOSED, failure → OPEN again.
+ *
+ * Every state transition is persisted to `circuit_breaker_state` and logged
+ * to `circuit_breaker_events` so operators can observe circuit health via the
+ * management API.
+ */
+
+import { EventEmitter } from 'events';
+import { getPool } from './dbPoolService.js';
+import logger from '../utils/logger.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+export type CircuitEventType =
+  | 'FAILURE'
+  | 'SUCCESS'
+  | 'OPENED'
+  | 'CLOSED'
+  | 'HALF_OPENED'
+  | 'RESET';
+
+export interface CircuitBreakerOptions {
+  /** Number of consecutive failures before the circuit opens. Default: 5 */
+  failureThreshold?: number;
+  /** Number of consecutive successes in HALF_OPEN before closing. Default: 2 */
+  successThreshold?: number;
+  /** Milliseconds to wait in OPEN state before probing. Default: 30 000 */
+  recoveryMs?: number;
+  /** Whether to persist state changes to the DB. Default: true */
+  persist?: boolean;
+}
+
+export interface CircuitSnapshot {
+  name: string;
+  state: CircuitState;
+  failureCount: number;
+  successCount: number;
+  lastFailureAt: Date | null;
+  openedAt: Date | null;
+  updatedAt: Date;
+}
+
+export class CircuitOpenError extends Error {
+  constructor(name: string) {
+    super(`Circuit "${name}" is OPEN – request rejected`);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+// ─── In-process circuit state ─────────────────────────────────────────────────
+
+interface CircuitInternalState {
+  state: CircuitState;
+  failureCount: number;
+  successCount: number;
+  lastFailureAt: Date | null;
+  openedAt: Date | null;
+  updatedAt: Date;
+  options: Required<CircuitBreakerOptions>;
+}
+
+// ─── CircuitBreakerService ─────────────────────────────────────────────────────
+
+export class CircuitBreakerService extends EventEmitter {
+  private static _instance: CircuitBreakerService | null = null;
+
+  private circuits = new Map<string, CircuitInternalState>();
+
+  private constructor() {
+    super();
+  }
+
+  static getInstance(): CircuitBreakerService {
+    if (!CircuitBreakerService._instance) {
+      CircuitBreakerService._instance = new CircuitBreakerService();
+    }
+    return CircuitBreakerService._instance;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  /**
+   * Register (or re-configure) a named circuit.  Must be called once at
+   * application start before any `execute()` calls for that name.
+   */
+  register(name: string, opts: CircuitBreakerOptions = {}): void {
+    if (!this.circuits.has(name)) {
+      this.circuits.set(name, {
+        state: 'CLOSED',
+        failureCount: 0,
+        successCount: 0,
+        lastFailureAt: null,
+        openedAt: null,
+        updatedAt: new Date(),
+        options: {
+          failureThreshold: opts.failureThreshold ?? 5,
+          successThreshold: opts.successThreshold ?? 2,
+          recoveryMs: opts.recoveryMs ?? 30_000,
+          persist: opts.persist ?? true,
+        },
+      });
+      logger.info(`[CircuitBreaker] Registered circuit "${name}"`);
+    }
+  }
+
+  /**
+   * Execute `fn` through the named circuit breaker.
+   * Throws `CircuitOpenError` when the circuit is OPEN and not yet in recovery.
+   */
+  async execute<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    const circuit = this._getOrRegister(name);
+
+    if (circuit.state === 'OPEN') {
+      const elapsed = Date.now() - (circuit.openedAt?.getTime() ?? 0);
+      if (elapsed < circuit.options.recoveryMs) {
+        throw new CircuitOpenError(name);
+      }
+      // Recovery window elapsed → allow one probe
+      await this._transitionTo(name, circuit, 'HALF_OPEN');
+    }
+
+    try {
+      const result = await fn();
+      await this._onSuccess(name, circuit);
+      return result;
+    } catch (err) {
+      await this._onFailure(name, circuit, err as Error);
+      throw err;
+    }
+  }
+
+  /**
+   * Manually reset a circuit to CLOSED regardless of current state.
+   */
+  async reset(name: string): Promise<void> {
+    const circuit = this._getOrRegister(name);
+    const from = circuit.state;
+    circuit.state = 'CLOSED';
+    circuit.failureCount = 0;
+    circuit.successCount = 0;
+    circuit.openedAt = null;
+    circuit.updatedAt = new Date();
+    await this._persist(name, circuit);
+    await this._logEvent(name, 'RESET', from, 'CLOSED', 0, 'Manual reset');
+    this.emit('reset', { name, from });
+    logger.info(`[CircuitBreaker] Circuit "${name}" manually reset to CLOSED`);
+  }
+
+  /** Return a snapshot of all registered circuits. */
+  getAll(): CircuitSnapshot[] {
+    return Array.from(this.circuits.entries()).map(([name, c]) =>
+      this._toSnapshot(name, c),
+    );
+  }
+
+  /** Return a snapshot of a specific circuit, or null if unknown. */
+  get(name: string): CircuitSnapshot | null {
+    const c = this.circuits.get(name);
+    return c ? this._toSnapshot(name, c) : null;
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private _getOrRegister(name: string): CircuitInternalState {
+    if (!this.circuits.has(name)) {
+      this.register(name);
+    }
+    return this.circuits.get(name)!;
+  }
+
+  private async _onSuccess(name: string, circuit: CircuitInternalState): Promise<void> {
+    await this._logEvent(name, 'SUCCESS', circuit.state, circuit.state, circuit.failureCount);
+
+    if (circuit.state === 'HALF_OPEN') {
+      circuit.successCount += 1;
+      if (circuit.successCount >= circuit.options.successThreshold) {
+        await this._transitionTo(name, circuit, 'CLOSED');
+      } else {
+        circuit.updatedAt = new Date();
+        await this._persist(name, circuit);
+      }
+    } else if (circuit.state === 'CLOSED') {
+      // Reset failure streak on any success in CLOSED state
+      if (circuit.failureCount > 0) {
+        circuit.failureCount = 0;
+        circuit.updatedAt = new Date();
+        await this._persist(name, circuit);
+      }
+    }
+  }
+
+  private async _onFailure(name: string, circuit: CircuitInternalState, err: Error): Promise<void> {
+    circuit.failureCount += 1;
+    circuit.successCount = 0;
+    circuit.lastFailureAt = new Date();
+    circuit.updatedAt = new Date();
+
+    await this._logEvent(
+      name,
+      'FAILURE',
+      circuit.state,
+      circuit.state,
+      circuit.failureCount,
+      err.message,
+    );
+
+    logger.warn(
+      `[CircuitBreaker] "${name}" failure ${circuit.failureCount}/${circuit.options.failureThreshold}: ${err.message}`,
+    );
+
+    if (
+      circuit.state !== 'OPEN' &&
+      circuit.failureCount >= circuit.options.failureThreshold
+    ) {
+      await this._transitionTo(name, circuit, 'OPEN');
+    } else {
+      await this._persist(name, circuit);
+    }
+  }
+
+  private async _transitionTo(
+    name: string,
+    circuit: CircuitInternalState,
+    next: CircuitState,
+  ): Promise<void> {
+    const from = circuit.state;
+    circuit.state = next;
+    circuit.updatedAt = new Date();
+
+    if (next === 'OPEN') {
+      circuit.openedAt = new Date();
+      circuit.successCount = 0;
+    } else if (next === 'CLOSED') {
+      circuit.failureCount = 0;
+      circuit.successCount = 0;
+      circuit.openedAt = null;
+    } else if (next === 'HALF_OPEN') {
+      circuit.successCount = 0;
+    }
+
+    const eventType: CircuitEventType =
+      next === 'OPEN' ? 'OPENED' : next === 'CLOSED' ? 'CLOSED' : 'HALF_OPENED';
+
+    await this._persist(name, circuit);
+    await this._logEvent(name, eventType, from, next, circuit.failureCount);
+    this.emit('stateChange', { name, from, to: next });
+
+    logger.info(`[CircuitBreaker] "${name}" transitioned ${from} → ${next}`);
+  }
+
+  private async _persist(name: string, circuit: CircuitInternalState): Promise<void> {
+    if (!circuit.options.persist) return;
+    try {
+      const pool = getPool();
+      await pool.query(
+        `INSERT INTO circuit_breaker_state
+           (name, state, failure_count, success_count, last_failure_at, opened_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, NOW())
+         ON CONFLICT (name) DO UPDATE
+           SET state          = EXCLUDED.state,
+               failure_count  = EXCLUDED.failure_count,
+               success_count  = EXCLUDED.success_count,
+               last_failure_at= EXCLUDED.last_failure_at,
+               opened_at      = EXCLUDED.opened_at,
+               updated_at     = NOW()`,
+        [
+          name,
+          circuit.state,
+          circuit.failureCount,
+          circuit.successCount,
+          circuit.lastFailureAt,
+          circuit.openedAt,
+        ],
+      );
+    } catch (err) {
+      logger.warn({ err }, `[CircuitBreaker] Failed to persist state for "${name}"`);
+    }
+  }
+
+  private async _logEvent(
+    name: string,
+    eventType: CircuitEventType,
+    fromState: CircuitState | undefined,
+    toState: CircuitState | undefined,
+    failureCount: number,
+    message?: string,
+  ): Promise<void> {
+    try {
+      const pool = getPool();
+      await pool.query(
+        `INSERT INTO circuit_breaker_events
+           (breaker_name, event_type, from_state, to_state, failure_count, message)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [name, eventType, fromState ?? null, toState ?? null, failureCount, message ?? null],
+      );
+    } catch (err) {
+      logger.warn({ err }, `[CircuitBreaker] Failed to log event for "${name}"`);
+    }
+  }
+
+  private _toSnapshot(name: string, c: CircuitInternalState): CircuitSnapshot {
+    return {
+      name,
+      state: c.state,
+      failureCount: c.failureCount,
+      successCount: c.successCount,
+      lastFailureAt: c.lastFailureAt,
+      openedAt: c.openedAt,
+      updatedAt: c.updatedAt,
+    };
+  }
+}
+
+export const circuitBreakerService = CircuitBreakerService.getInstance();
+
+// ─── Pre-register well-known circuits ────────────────────────────────────────
+
+circuitBreakerService.register('database',    { failureThreshold: 5, recoveryMs: 30_000 });
+circuitBreakerService.register('redis',       { failureThreshold: 3, recoveryMs: 15_000 });
+circuitBreakerService.register('stellar-api', { failureThreshold: 5, recoveryMs: 60_000 });
+circuitBreakerService.register('email',       { failureThreshold: 3, recoveryMs: 60_000 });


### PR DESCRIPTION
## Summary

- Implements the **Circuit Breaker** resilience pattern as Part 11 of the API & Database Scaling effort (Issue #256).
- Prevents cascading failures by short-circuiting requests to unhealthy services (database, Redis, Stellar API, email).
- Adds a full management API so operators can observe and manually reset breakers.

## Changes

### New files
- `backend/src/services/circuitBreakerService.ts` — Core `CircuitBreakerService` singleton with `CLOSED → OPEN → HALF_OPEN` state machine, configurable failure/success thresholds and recovery timeouts. Pre-registers `database`, `redis`, `stellar-api`, and `email` circuits.
- `backend/src/middlewares/circuitBreakerMiddleware.ts` — `circuitBreakerGuard(name)` Express middleware that rejects requests with `503 + Retry-After` when the circuit is OPEN; `withCircuitBreaker()` helper for in-handler usage.
- `backend/src/controllers/circuitBreakerController.ts` — HTTP handlers: list all, get one, reset, events, and health summary.
- `backend/src/routes/circuitBreakerRoutes.ts` — REST routes with Swagger annotations.
- `backend/src/db/migrations/041_circuit_breaker_part11.sql` — `circuit_breaker_state` (UPSERT-able, one row per service) and `circuit_breaker_events` (immutable audit log, 30-day auto-prune) tables with indexes.
- `backend/src/__tests__/circuitBreaker.test.ts` — Integration tests for all endpoints + unit tests for state-machine transitions.

### Modified files
- `backend/src/routes/v1/index.ts` — Mounts `circuitBreakerRoutes` at `/circuit-breakers` behind `apiRateLimit()`.

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/circuit-breakers` | List all circuits |
| `GET` | `/api/v1/circuit-breakers/summary` | Health summary (open/closed/half-open counts) |
| `GET` | `/api/v1/circuit-breakers/:name` | Single circuit snapshot |
| `GET` | `/api/v1/circuit-breakers/:name/events` | Recent events (filterable by `limit`, `sinceHours`) |
| `POST` | `/api/v1/circuit-breakers/:name/reset` | Manually reset a circuit to CLOSED |

## Acceptance Criteria

- [x] API endpoints are functional and tested
- [x] Proper error responses (4xx, 5xx) implemented
- [x] Database migration provided (`041_circuit_breaker_part11.sql`)
- [x] Integration tests included for all new services and endpoints

Closes #701
Closes #646
Closes #712
Closes #687