### PR TITLE
feat(scaling): table bloat, cache hit rate, long-running transactions, vacuum stats

### DIFF
--- a/backend/src/controllers/dbScalingController.ts
+++ b/backend/src/controllers/dbScalingController.ts
@@ -58,4 +58,49 @@ export class DbScalingController {
     const config = service.getPoolConfig();
     res.json({ success: true, data: config });
   }
+
+  /** #289 */
+  async getTableBloat(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const data = await service.getTableBloat();
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch table bloat stats');
+      next(err);
+    }
+  }
+
+  /** #290 */
+  async getCacheHitRate(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const data = await service.getCacheHitRate();
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch cache hit rate');
+      next(err);
+    }
+  }
+
+  /** #291 */
+  async getLongRunningTransactions(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const minSec = Math.max(0, Number(req.query['minDurationSec'] ?? 10));
+      const data = await service.getLongRunningTransactions(minSec);
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch long-running transactions');
+      next(err);
+    }
+  }
+
+  /** #292 */
+  async getVacuumStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const data = await service.getVacuumStats();
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch vacuum stats');
+      next(err);
+    }
+  }
 }

--- a/backend/src/routes/dbScalingRoutes.ts
+++ b/backend/src/routes/dbScalingRoutes.ts
@@ -94,4 +94,16 @@ router.get('/index-usage', (req, res, next) => ctrl.getIndexUsage(req, res, next
  */
 router.get('/config', (req, res) => ctrl.getPoolConfig(req, res));
 
+// Issue #289 — table bloat
+router.get('/table-bloat', (req, res, next) => ctrl.getTableBloat(req, res, next));
+
+// Issue #290 — cache hit rate
+router.get('/cache-hit-rate', (req, res, next) => ctrl.getCacheHitRate(req, res, next));
+
+// Issue #291 — long-running transactions (?minDurationSec=10)
+router.get('/long-running-transactions', (req, res, next) => ctrl.getLongRunningTransactions(req, res, next));
+
+// Issue #292 — vacuum / analyse stats
+router.get('/vacuum-stats', (req, res, next) => ctrl.getVacuumStats(req, res, next));
+
 export default router;

--- a/backend/src/services/dbScalingService.ts
+++ b/backend/src/services/dbScalingService.ts
@@ -132,4 +132,72 @@ export class DbScalingService {
   getPoolConfig(): { min: number; max: number } {
     return { min: POOL_MIN, max: POOL_MAX };
   }
+
+  /** #289 — Table bloat: dead-tuple ratio per table from pg_stat_user_tables. */
+  async getTableBloat(): Promise<{ table: string; liveRows: number; deadRows: number; bloatRatio: number }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{ relname: string; n_live_tup: bigint; n_dead_tup: bigint }>>`
+      SELECT relname, n_live_tup, n_dead_tup
+      FROM pg_stat_user_tables
+      ORDER BY n_dead_tup DESC
+      LIMIT 20
+    `;
+    return rows.map(r => {
+      const live = Number(r.n_live_tup);
+      const dead = Number(r.n_dead_tup);
+      return { table: r.relname, liveRows: live, deadRows: dead, bloatRatio: live + dead > 0 ? dead / (live + dead) : 0 };
+    });
+  }
+
+  /** #290 — Buffer cache hit rates from pg_statio_user_tables. */
+  async getCacheHitRate(): Promise<{ table: string; heapHitRate: number; idxHitRate: number }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      relname: string; heap_blks_hit: bigint; heap_blks_read: bigint; idx_blks_hit: bigint; idx_blks_read: bigint;
+    }>>`
+      SELECT relname, heap_blks_hit, heap_blks_read, idx_blks_hit, idx_blks_read
+      FROM pg_statio_user_tables
+      ORDER BY relname
+    `;
+    return rows.map(r => {
+      const hh = Number(r.heap_blks_hit), hr = Number(r.heap_blks_read);
+      const ih = Number(r.idx_blks_hit),  ir = Number(r.idx_blks_read);
+      return {
+        table: r.relname,
+        heapHitRate: hh + hr > 0 ? hh / (hh + hr) : 1,
+        idxHitRate:  ih + ir > 0 ? ih / (ih + ir) : 1,
+      };
+    });
+  }
+
+  /** #291 — Long-running transactions from pg_stat_activity. */
+  async getLongRunningTransactions(minDurationSec = 10): Promise<{ pid: number; duration: string; state: string; query: string }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{ pid: number; duration: string; state: string; query: string }>>`
+      SELECT pid,
+             (now() - xact_start)::text AS duration,
+             state,
+             left(query, 120) AS query
+      FROM pg_stat_activity
+      WHERE xact_start IS NOT NULL
+        AND now() - xact_start > (${minDurationSec} || ' seconds')::interval
+        AND state != 'idle'
+      ORDER BY duration DESC
+    `;
+    return rows;
+  }
+
+  /** #292 — Vacuum / analyse timestamps from pg_stat_user_tables. */
+  async getVacuumStats(): Promise<{ table: string; lastVacuum: string | null; lastAutoVacuum: string | null; lastAnalyze: string | null }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      relname: string; last_vacuum: Date | null; last_autovacuum: Date | null; last_analyze: Date | null;
+    }>>`
+      SELECT relname, last_vacuum, last_autovacuum, last_analyze
+      FROM pg_stat_user_tables
+      ORDER BY relname
+    `;
+    return rows.map(r => ({
+      table: r.relname,
+      lastVacuum:     r.last_vacuum    ? r.last_vacuum.toISOString()    : null,
+      lastAutoVacuum: r.last_autovacuum ? r.last_autovacuum.toISOString() : null,
+      lastAnalyze:    r.last_analyze   ? r.last_analyze.toISOString()   : null,
+    }));
+  }
 }


### PR DESCRIPTION
Closes #734
Closes #735
Closes #736
Closes #737

Adds four new DB scaling diagnostic endpoints to `dbScalingRoutes`, `dbScalingController`, and `dbScalingService`, all using `this.prisma.$queryRaw` consistent with existing patterns:

| Issue | Endpoint | Source view |
|-------|----------|-------------|
| #734 (#289) | `GET /api/v1/db-scaling/table-bloat` | `pg_stat_user_tables` — dead-tuple count and bloat ratio per table |
| #735 (#290) | `GET /api/v1/db-scaling/cache-hit-rate` | `pg_statio_user_tables` — heap and index buffer cache hit rates |
| #736 (#291) | `GET /api/v1/db-scaling/long-running-transactions?minDurationSec=10` | `pg_stat_activity` — active transactions exceeding a configurable threshold |
| #737 (#292) | `GET /api/v1/db-scaling/vacuum-stats` | `pg_stat_user_tables` — last vacuum, autovacuum, and analyse timestamps |

All endpoints follow existing auth, error handling, and logging conventions.