### PR TITLE
feat(backend): API & Database Scaling Parts 39 & 40 (#284, #285)

### DIFF
--- a/backend/src/__tests__/dbScalingRoutes.test.ts
+++ b/backend/src/__tests__/dbScalingRoutes.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Integration tests for the DB Scaling endpoints (Parts 39 & 40).
+ *
+ * Issues #284 (Part 39) — lock contention, unused indexes
+ * Issues #285 (Part 40) — replication lag, table sizes
+ *
+ * Strategy
+ * ─────────
+ * DbScalingService is instantiated at module level inside the controller.
+ * We replace it with a Jest mock factory before importing the app so that
+ * every method is a jest.fn() and no real PostgreSQL connection is needed.
+ */
+
+import request from 'supertest';
+import app from '../app.js';
+
+// ─── Mock DbScalingService ────────────────────────────────────────────────────
+
+const mockGetLockContention   = jest.fn();
+const mockGetUnusedIndexes    = jest.fn();
+const mockGetReplicationLag   = jest.fn();
+const mockGetTableSizes       = jest.fn();
+
+// Also stub the methods used by existing controller handlers so the mock
+// implementation is complete (prevents "not a function" errors from other routes
+// if the test runner resolves them).
+const mockGetPoolStats             = jest.fn();
+const mockRunHealthCheck           = jest.fn();
+const mockGetSlowQueries           = jest.fn();
+const mockGetIndexUsage            = jest.fn();
+const mockGetPoolConfig            = jest.fn();
+const mockGetTableBloat            = jest.fn();
+const mockGetCacheHitRate          = jest.fn();
+const mockGetLongRunningTransactions = jest.fn();
+const mockGetVacuumStats           = jest.fn();
+
+jest.mock('../services/dbScalingService.js', () => ({
+  DbScalingService: jest.fn().mockImplementation(() => ({
+    getPoolStats:               mockGetPoolStats,
+    runHealthCheck:             mockRunHealthCheck,
+    getSlowQueries:             mockGetSlowQueries,
+    getIndexUsage:              mockGetIndexUsage,
+    getPoolConfig:              mockGetPoolConfig,
+    getTableBloat:              mockGetTableBloat,
+    getCacheHitRate:            mockGetCacheHitRate,
+    getLongRunningTransactions: mockGetLongRunningTransactions,
+    getVacuumStats:             mockGetVacuumStats,
+    getLockContention:          mockGetLockContention,
+    getUnusedIndexes:           mockGetUnusedIndexes,
+    getReplicationLag:          mockGetReplicationLag,
+    getTableSizes:              mockGetTableSizes,
+  })),
+}));
+
+afterEach(() => jest.clearAllMocks());
+
+// ─── Part 39: GET /api/v1/db-scaling/lock-contention ─────────────────────────
+
+describe('GET /api/v1/db-scaling/lock-contention', () => {
+  it('returns 200 with an array of lock-wait rows', async () => {
+    mockGetLockContention.mockResolvedValue([
+      {
+        waitingPid:   1234,
+        blockingPid:  5678,
+        lockType:     'relation',
+        relation:     'employees',
+        waitingQuery: 'UPDATE employees SET ...',
+        waitDuration: '00:00:05.123',
+      },
+    ]);
+
+    const res = await request(app).get('/api/v1/db-scaling/lock-contention');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data[0]).toMatchObject({
+      waitingPid:  1234,
+      blockingPid: 5678,
+      lockType:    'relation',
+      relation:    'employees',
+    });
+  });
+
+  it('returns 200 with an empty array when no lock waits exist', async () => {
+    mockGetLockContention.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/v1/db-scaling/lock-contention');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetLockContention.mockRejectedValue(new Error('pg error'));
+
+    const res = await request(app).get('/api/v1/db-scaling/lock-contention');
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Part 39: GET /api/v1/db-scaling/unused-indexes ─────────────────────────
+
+describe('GET /api/v1/db-scaling/unused-indexes', () => {
+  it('returns 200 with a list of unused indexes', async () => {
+    mockGetUnusedIndexes.mockResolvedValue([
+      { table: 'transactions', index: 'idx_tx_ref_old', indexSizeBytes: 8192 },
+      { table: 'employees',    index: 'idx_emp_dept',   indexSizeBytes: 4096 },
+    ]);
+
+    const res = await request(app).get('/api/v1/db-scaling/unused-indexes');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0]).toMatchObject({
+      table:          'transactions',
+      index:          'idx_tx_ref_old',
+      indexSizeBytes: 8192,
+    });
+  });
+
+  it('returns 200 with empty array when all indexes are used', async () => {
+    mockGetUnusedIndexes.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/v1/db-scaling/unused-indexes');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetUnusedIndexes.mockRejectedValue(new Error('pg error'));
+
+    const res = await request(app).get('/api/v1/db-scaling/unused-indexes');
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Part 40: GET /api/v1/db-scaling/replication-lag ────────────────────────
+
+describe('GET /api/v1/db-scaling/replication-lag', () => {
+  it('returns 200 with replication lag rows for each replica', async () => {
+    mockGetReplicationLag.mockResolvedValue([
+      {
+        clientAddr:     '10.0.0.2',
+        state:          'streaming',
+        sentLsn:        '0/5000000',
+        writeLsn:       '0/4FFF000',
+        flushLsn:       '0/4FFE000',
+        replayLsn:      '0/4FFD000',
+        writeLagBytes:  4096,
+        flushLagBytes:  8192,
+        replayLagBytes: 12288,
+      },
+    ]);
+
+    const res = await request(app).get('/api/v1/db-scaling/replication-lag');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data[0]).toMatchObject({
+      clientAddr:     '10.0.0.2',
+      state:          'streaming',
+      replayLagBytes: 12288,
+    });
+  });
+
+  it('returns 200 with empty array when no replicas are configured', async () => {
+    mockGetReplicationLag.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/v1/db-scaling/replication-lag');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetReplicationLag.mockRejectedValue(new Error('pg error'));
+
+    const res = await request(app).get('/api/v1/db-scaling/replication-lag');
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Part 40: GET /api/v1/db-scaling/table-sizes ────────────────────────────
+
+describe('GET /api/v1/db-scaling/table-sizes', () => {
+  const fakeTables = [
+    {
+      table:       'transactions',
+      totalBytes:  1073741824,
+      tableBytes:  536870912,
+      indexBytes:  268435456,
+      toastBytes:  268435456,
+      totalPretty: '1024 MB',
+    },
+    {
+      table:       'employees',
+      totalBytes:  52428800,
+      tableBytes:  26214400,
+      indexBytes:  16777216,
+      toastBytes:  9437184,
+      totalPretty: '50 MB',
+    },
+  ];
+
+  it('returns 200 with table size breakdown', async () => {
+    mockGetTableSizes.mockResolvedValue(fakeTables);
+
+    const res = await request(app).get('/api/v1/db-scaling/table-sizes');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0]).toMatchObject({
+      table:       'transactions',
+      totalBytes:  1073741824,
+      totalPretty: '1024 MB',
+    });
+  });
+
+  it('respects the ?limit query parameter', async () => {
+    mockGetTableSizes.mockResolvedValue(fakeTables.slice(0, 1));
+
+    const res = await request(app).get('/api/v1/db-scaling/table-sizes?limit=1');
+
+    expect(res.status).toBe(200);
+    expect(mockGetTableSizes).toHaveBeenCalledWith(1);
+  });
+
+  it('caps limit at 100', async () => {
+    mockGetTableSizes.mockResolvedValue([]);
+
+    await request(app).get('/api/v1/db-scaling/table-sizes?limit=999');
+
+    expect(mockGetTableSizes).toHaveBeenCalledWith(100);
+  });
+
+  it('returns 400 for a non-numeric limit', async () => {
+    const res = await request(app).get('/api/v1/db-scaling/table-sizes?limit=abc');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetTableSizes.mockRejectedValue(new Error('pg error'));
+
+    const res = await request(app).get('/api/v1/db-scaling/table-sizes');
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/backend/src/controllers/dbScalingController.ts
+++ b/backend/src/controllers/dbScalingController.ts
@@ -103,4 +103,57 @@ export class DbScalingController {
       next(err);
     }
   }
+
+  // ── Part 39 (#284) ─────────────────────────────────────────────────────
+
+  /** #284a — Lock contention between concurrent backends. */
+  async getLockContention(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const data = await service.getLockContention();
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch lock contention');
+      next(err);
+    }
+  }
+
+  /** #284b — Unused indexes (zero scans since last stats reset). */
+  async getUnusedIndexes(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const data = await service.getUnusedIndexes();
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch unused indexes');
+      next(err);
+    }
+  }
+
+  // ── Part 40 (#285) ─────────────────────────────────────────────────────
+
+  /** #285a — Streaming replication lag per standby replica. */
+  async getReplicationLag(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const data = await service.getReplicationLag();
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch replication lag');
+      next(err);
+    }
+  }
+
+  /** #285b — Per-table disk usage (table + indexes + TOAST). */
+  async getTableSizes(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const limit = Math.min(Number(req.query['limit'] ?? 30), 100);
+      if (isNaN(limit) || limit < 1) {
+        res.status(400).json({ success: false, error: 'limit must be a positive integer' });
+        return;
+      }
+      const data = await service.getTableSizes(limit);
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch table sizes');
+      next(err);
+    }
+  }
 }

--- a/backend/src/routes/dbScalingRoutes.ts
+++ b/backend/src/routes/dbScalingRoutes.ts
@@ -106,4 +106,94 @@ router.get('/long-running-transactions', (req, res, next) => ctrl.getLongRunning
 // Issue #292 — vacuum / analyse stats
 router.get('/vacuum-stats', (req, res, next) => ctrl.getVacuumStats(req, res, next));
 
+// ── Part 39 (#284) ──────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /api/v1/db-scaling/lock-contention:
+ *   get:
+ *     summary: Active lock-wait chains between database backends (Part 39)
+ *     description: >
+ *       Returns rows from pg_locks + pg_stat_activity where one backend is
+ *       blocking another. An empty array means no lock waits are active.
+ *     tags: [DB Scaling]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lock contention rows (may be empty)
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/lock-contention', (req, res, next) => ctrl.getLockContention(req, res, next));
+
+/**
+ * @swagger
+ * /api/v1/db-scaling/unused-indexes:
+ *   get:
+ *     summary: Indexes with zero scans since last statistics reset (Part 39)
+ *     description: >
+ *       Lists non-primary, non-unique indexes never used by the query planner.
+ *       These are candidates for removal to reduce write overhead and storage.
+ *     tags: [DB Scaling]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Unused index list
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/unused-indexes', (req, res, next) => ctrl.getUnusedIndexes(req, res, next));
+
+// ── Part 40 (#285) ──────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /api/v1/db-scaling/replication-lag:
+ *   get:
+ *     summary: Streaming replication lag per standby replica (Part 40)
+ *     description: >
+ *       Queries pg_stat_replication for LSN distances between primary and each
+ *       connected standby. Returns an empty array when no replicas are configured.
+ *     tags: [DB Scaling]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Replication lag per replica (may be empty)
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/replication-lag', (req, res, next) => ctrl.getReplicationLag(req, res, next));
+
+/**
+ * @swagger
+ * /api/v1/db-scaling/table-sizes:
+ *   get:
+ *     summary: Per-table disk usage including indexes and TOAST (Part 40)
+ *     description: >
+ *       Returns total on-disk size for each public-schema table broken down into
+ *       heap, index, and TOAST segments. Ordered by total size descending.
+ *     tags: [DB Scaling]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 30
+ *           maximum: 100
+ *         description: Maximum number of tables to return
+ *     responses:
+ *       200:
+ *         description: Table size breakdown
+ *       400:
+ *         description: Invalid limit parameter
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/table-sizes', (req, res, next) => ctrl.getTableSizes(req, res, next));
+
 export default router;

--- a/backend/src/services/dbScalingService.ts
+++ b/backend/src/services/dbScalingService.ts
@@ -200,4 +200,195 @@ export class DbScalingService {
       lastAnalyze:    r.last_analyze   ? r.last_analyze.toISOString()   : null,
     }));
   }
+
+  // ── Part 39 (#284) ───────────────────────────────────────────────────────
+
+  /**
+   * #284a — Lock contention: active waits from pg_locks joined to pg_stat_activity.
+   * Returns rows where one backend is blocking another, showing both PIDs,
+   * the lock type, and the waiting query (truncated to 120 chars).
+   */
+  async getLockContention(): Promise<{
+    waitingPid: number;
+    blockingPid: number;
+    lockType: string;
+    relation: string | null;
+    waitingQuery: string;
+    waitDuration: string | null;
+  }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      waiting_pid: number;
+      blocking_pid: number;
+      locktype: string;
+      relation: string | null;
+      waiting_query: string;
+      wait_duration: string | null;
+    }>>`
+      SELECT
+        blocked.pid                          AS waiting_pid,
+        blocking.pid                         AS blocking_pid,
+        blocked_locks.locktype,
+        blocked_locks.relation::regclass::text AS relation,
+        left(blocked_activity.query, 120)    AS waiting_query,
+        (now() - blocked_activity.query_start)::text AS wait_duration
+      FROM pg_locks AS blocked_locks
+      JOIN pg_stat_activity AS blocked_activity
+        ON blocked_activity.pid = blocked_locks.pid
+      JOIN pg_locks AS blocking_locks
+        ON  blocking_locks.locktype  = blocked_locks.locktype
+        AND blocking_locks.database  IS NOT DISTINCT FROM blocked_locks.database
+        AND blocking_locks.relation  IS NOT DISTINCT FROM blocked_locks.relation
+        AND blocking_locks.page      IS NOT DISTINCT FROM blocked_locks.page
+        AND blocking_locks.tuple     IS NOT DISTINCT FROM blocked_locks.tuple
+        AND blocking_locks.classid   IS NOT DISTINCT FROM blocked_locks.classid
+        AND blocking_locks.objid     IS NOT DISTINCT FROM blocked_locks.objid
+        AND blocking_locks.objsubid  IS NOT DISTINCT FROM blocked_locks.objsubid
+        AND blocking_locks.pid != blocked_locks.pid
+      JOIN pg_stat_activity AS blocking
+        ON blocking.pid = blocking_locks.pid
+      WHERE NOT blocked_locks.granted
+      ORDER BY wait_duration DESC NULLS LAST
+    `;
+    return rows.map(r => ({
+      waitingPid:   r.waiting_pid,
+      blockingPid:  r.blocking_pid,
+      lockType:     r.locktype,
+      relation:     r.relation,
+      waitingQuery: r.waiting_query,
+      waitDuration: r.wait_duration,
+    }));
+  }
+
+  /**
+   * #284b — Unused indexes: user indexes with zero scans since last stats reset.
+   * Useful for identifying bloat from indexes that are never hit by queries.
+   */
+  async getUnusedIndexes(): Promise<{
+    table: string;
+    index: string;
+    indexSizeBytes: number;
+  }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      relname: string;
+      indexrelname: string;
+      index_size: bigint;
+    }>>`
+      SELECT
+        t.relname,
+        i.relname AS indexrelname,
+        pg_relation_size(i.oid) AS index_size
+      FROM pg_index AS ix
+      JOIN pg_class AS t ON t.oid = ix.indrelid
+      JOIN pg_class AS i ON i.oid = ix.indexrelid
+      JOIN pg_stat_user_indexes AS s
+        ON s.indexrelid = ix.indexrelid
+      WHERE s.idx_scan = 0
+        AND NOT ix.indisprimary
+        AND NOT ix.indisunique
+      ORDER BY index_size DESC
+      LIMIT 50
+    `;
+    return rows.map(r => ({
+      table:          r.relname,
+      index:          r.indexrelname,
+      indexSizeBytes: Number(r.index_size),
+    }));
+  }
+
+  // ── Part 40 (#285) ───────────────────────────────────────────────────────
+
+  /**
+   * #285a — Replication lag: bytes behind primary for each standby replica.
+   * Returns an empty array when no replicas are configured (not an error).
+   */
+  async getReplicationLag(): Promise<{
+    clientAddr: string | null;
+    state: string;
+    sentLsn: string;
+    writeLsn: string;
+    flushLsn: string;
+    replayLsn: string;
+    writeLagBytes: number;
+    flushLagBytes: number;
+    replayLagBytes: number;
+  }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      client_addr: string | null;
+      state: string;
+      sent_lsn: string;
+      write_lsn: string;
+      flush_lsn: string;
+      replay_lsn: string;
+      write_lag_bytes: bigint;
+      flush_lag_bytes: bigint;
+      replay_lag_bytes: bigint;
+    }>>`
+      SELECT
+        client_addr::text,
+        state,
+        sent_lsn::text,
+        write_lsn::text,
+        flush_lsn::text,
+        replay_lsn::text,
+        (sent_lsn - write_lsn)  AS write_lag_bytes,
+        (sent_lsn - flush_lsn)  AS flush_lag_bytes,
+        (sent_lsn - replay_lsn) AS replay_lag_bytes
+      FROM pg_stat_replication
+      ORDER BY replay_lag_bytes DESC
+    `;
+    return rows.map(r => ({
+      clientAddr:      r.client_addr,
+      state:           r.state,
+      sentLsn:         r.sent_lsn,
+      writeLsn:        r.write_lsn,
+      flushLsn:        r.flush_lsn,
+      replayLsn:       r.replay_lsn,
+      writeLagBytes:   Number(r.write_lag_bytes),
+      flushLagBytes:   Number(r.flush_lag_bytes),
+      replayLagBytes:  Number(r.replay_lag_bytes),
+    }));
+  }
+
+  /**
+   * #285b — Table sizes: total on-disk size (table + indexes + TOAST) per table,
+   * ordered largest first.  Useful for capacity planning and spotting unexpected growth.
+   */
+  async getTableSizes(limit = 30): Promise<{
+    table: string;
+    totalBytes: number;
+    tableBytes: number;
+    indexBytes: number;
+    toastBytes: number;
+    totalPretty: string;
+  }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      relname: string;
+      total_bytes: bigint;
+      table_bytes: bigint;
+      index_bytes: bigint;
+      toast_bytes: bigint;
+      total_pretty: string;
+    }>>`
+      SELECT
+        relname,
+        pg_total_relation_size(oid)                    AS total_bytes,
+        pg_relation_size(oid)                          AS table_bytes,
+        pg_indexes_size(oid)                           AS index_bytes,
+        COALESCE(pg_total_relation_size(reltoastrelid), 0) AS toast_bytes,
+        pg_size_pretty(pg_total_relation_size(oid))    AS total_pretty
+      FROM pg_class
+      WHERE relkind = 'r'
+        AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+      ORDER BY total_bytes DESC
+      LIMIT ${limit}
+    `;
+    return rows.map(r => ({
+      table:       r.relname,
+      totalBytes:  Number(r.total_bytes),
+      tableBytes:  Number(r.table_bytes),
+      indexBytes:  Number(r.index_bytes),
+      toastBytes:  Number(r.toast_bytes),
+      totalPretty: r.total_pretty,
+    }));
+  }
 }


### PR DESCRIPTION
Closes #729
Closes #730

## Summary

Implements two backend scaling increments continuing the DB observability series:

### Part 39 — Issue #284 (`/api/v1/db-scaling/lock-contention` + `/unused-indexes`)

**Lock contention** (`getLockContention`)
- Queries `pg_locks` joined to `pg_stat_activity` to surface active wait chains
- Returns: `waitingPid`, `blockingPid`, `lockType`, `relation`, `waitingQuery` (truncated to 120 chars), `waitDuration`
- Empty array when no lock waits are active — not an error

**Unused indexes** (`getUnusedIndexes`)
- Queries `pg_stat_user_indexes` for non-primary, non-unique indexes with `idx_scan = 0`
- Returns: `table`, `index`, `indexSizeBytes` — ordered by size descending, limit 50
- Candidates for removal to reduce write amplification and storage overhead

### Part 40 — Issue #285 (`/api/v1/db-scaling/replication-lag` + `/table-sizes`)

**Replication lag** (`getReplicationLag`)
- Queries `pg_stat_replication` for write/flush/replay LSN distances per standby
- Returns: `clientAddr`, `state`, `sentLsn`, `writeLsn`, `flushLsn`, `replayLsn`, `writeLagBytes`, `flushLagBytes`, `replayLagBytes`
- Returns empty array gracefully when no replicas are configured

**Table sizes** (`getTableSizes`)
- Uses `pg_total_relation_size`, `pg_relation_size`, `pg_indexes_size`, and TOAST size for each public-schema table
- Returns: `table`, `totalBytes`, `tableBytes`, `indexBytes`, `toastBytes`, `totalPretty`
- Accepts `?limit` (default 30, max 100); returns 400 on invalid input
- All `bigint` values wrapped with `Number()` for JSON serialisation safety

## Files changed

| File | Change |
|---|---|
| `backend/src/services/dbScalingService.ts` | 4 new async methods |
| `backend/src/controllers/dbScalingController.ts` | 4 new handler methods with error logging |
| `backend/src/routes/dbScalingRoutes.ts` | 4 new routes with Swagger/OpenAPI annotations |
| `backend/src/__tests__/dbScalingRoutes.test.ts` | New test file — 15 test cases |

## Tests

`dbScalingRoutes.test.ts` covers all four endpoints:
- ✅ 200 with data
- ✅ 200 with empty array (lock contention, replication lag — no-replica/no-wait cases)
- ✅ 400 for invalid `?limit` on table-sizes
- ✅ 500 when service throws
- ✅ `?limit` parameter is respected and capped at 100