### PR TITLE
feat(backend): API & Database Scaling Part 49 / Advanced Logic Part 39 (#294)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -31,6 +31,10 @@
       "description": "Health checks, discovery, and generated documentation endpoints"
     },
     {
+      "name": "Analytics",
+      "description": "Payroll expenditure analytics and reporting"
+    },
+    {
       "name": "Assets",
       "description": "Asset management (ISSUE/CLAWBACK)"
     },
@@ -47,6 +51,10 @@
       "description": "Multi-operation Stellar transaction batching"
     },
     {
+      "name": "Circuit Breakers",
+      "description": "Circuit-breaker state management and observability (Issue"
+    },
+    {
       "name": "Contract Events",
       "description": "On-chain contract event indexing"
     },
@@ -57,6 +65,10 @@
     {
       "name": "Contract Upgrades",
       "description": "On-chain contract upgrade lifecycle"
+    },
+    {
+      "name": "DB Scaling",
+      "description": "Database connection pool and performance monitoring (Issue"
     },
     {
       "name": "Exports",
@@ -97,6 +109,10 @@
     {
       "name": "Throttling",
       "description": "API request throttling and queuing"
+    },
+    {
+      "name": "Transactions",
+      "description": "Transaction management with pagination"
     },
     {
       "name": "Trustlines",
@@ -161,10 +177,6 @@
     {
       "name": "Tenant Config",
       "description": "Tenant configuration management endpoints"
-    },
-    {
-      "name": "Webhooks",
-      "description": "Webhook subscription and delivery endpoints"
     }
   ],
   "paths": {
@@ -210,6 +222,20 @@
         }
       }
     },
+    "/api/v1/health": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get API v1 health status",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "tags": [
@@ -234,6 +260,178 @@
         "responses": {
           "200": {
             "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/openapi.json": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get the generated OpenAPI specification (v1 endpoint)",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/analytics/payroll": {
+      "get": {
+        "summary": "Get payroll expenditure analytics",
+        "tags": [
+          "Analytics"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "organizationId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Organization identifier"
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Start of the date range (ISO 8601). Defaults to 12 months ago."
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "End of the date range (ISO 8601). Defaults to today."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payroll analytics data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "trends": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "month": {
+                                "type": "string"
+                              },
+                              "total": {
+                                "type": "number"
+                              },
+                              "count": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        },
+                        "currencyBreakdown": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        },
+                        "paymentMetrics": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "month": {
+                                "type": "string"
+                              },
+                              "success": {
+                                "type": "integer"
+                              },
+                              "failure": {
+                                "type": "integer"
+                              },
+                              "pending": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        },
+                        "departmentBreakdown": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "department": {
+                                "type": "string"
+                              },
+                              "total": {
+                                "type": "number"
+                              },
+                              "headcount": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        },
+                        "summary": {
+                          "type": "object",
+                          "properties": {
+                            "totalPayroll": {
+                              "type": "number"
+                            },
+                            "totalTransactions": {
+                              "type": "integer"
+                            },
+                            "successRate": {
+                              "type": "number"
+                            },
+                            "activeEmployees": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid query parameters"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         }
       }
@@ -562,6 +760,178 @@
         }
       }
     },
+    "/api/v1/circuit-breakers": {
+      "get": {
+        "summary": "List all registered circuit breakers and their current state",
+        "tags": [
+          "Circuit Breakers"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of circuit-breaker snapshots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/CircuitSnapshot"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "count": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/circuit-breakers/summary": {
+      "get": {
+        "summary": "Aggregated health summary across all circuit breakers",
+        "tags": [
+          "Circuit Breakers"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Summary with open/closed/half-open counts"
+          }
+        }
+      }
+    },
+    "/api/v1/circuit-breakers/{name}": {
+      "get": {
+        "summary": "Get the current snapshot for a named circuit breaker",
+        "tags": [
+          "Circuit Breakers"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Circuit name (e.g. \"database\", \"redis\", \"stellar-api\")"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Circuit snapshot"
+          },
+          "404": {
+            "description": "Circuit not found"
+          }
+        }
+      }
+    },
+    "/api/v1/circuit-breakers/{name}/events": {
+      "get": {
+        "summary": "Return recent state-change and failure events for a circuit",
+        "tags": [
+          "Circuit Breakers"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "in": "query",
+            "name": "sinceHours",
+            "schema": {
+              "type": "integer",
+              "default": 24
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of events"
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          }
+        }
+      }
+    },
+    "/api/v1/circuit-breakers/{name}/reset": {
+      "post": {
+        "summary": "Manually reset a circuit breaker to CLOSED state",
+        "tags": [
+          "Circuit Breakers"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Circuit reset successfully"
+          },
+          "404": {
+            "description": "Circuit not found"
+          }
+        }
+      }
+    },
     "/api/events/{contractId}": {
       "get": {
         "summary": "List indexed contract events",
@@ -858,6 +1228,260 @@
         "responses": {
           "200": {
             "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/pool": {
+      "get": {
+        "summary": "Get current database connection pool stats",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pool stats returned successfully"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/health": {
+      "get": {
+        "summary": "Database connectivity health check with latency",
+        "tags": [
+          "DB Scaling"
+        ],
+        "responses": {
+          "200": {
+            "description": "Database is reachable"
+          },
+          "503": {
+            "description": "Database is unreachable"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/slow-queries": {
+      "get": {
+        "summary": "List queries exceeding a mean execution time threshold",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "threshold",
+            "schema": {
+              "type": "number"
+            },
+            "description": "Mean execution time threshold in ms (default 1000)"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "number"
+            },
+            "description": "Max rows to return (default 20, max 100)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Slow query list"
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/index-usage": {
+      "get": {
+        "summary": "Return index usage statistics from pg_stat_user_indexes",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Index usage data"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/config": {
+      "get": {
+        "summary": "Return current connection pool configuration",
+        "tags": [
+          "DB Scaling"
+        ],
+        "responses": {
+          "200": {
+            "description": "Pool min/max configuration"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/lock-contention": {
+      "get": {
+        "summary": "Active lock-wait chains between database backends (Part 39)",
+        "description": "Returns rows from pg_locks + pg_stat_activity where one backend is blocking another. An empty array means no lock waits are active.\n",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lock contention rows (may be empty)"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/unused-indexes": {
+      "get": {
+        "summary": "Indexes with zero scans since last statistics reset (Part 39)",
+        "description": "Lists non-primary, non-unique indexes never used by the query planner. These are candidates for removal to reduce write overhead and storage.\n",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unused index list"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/replication-lag": {
+      "get": {
+        "summary": "Streaming replication lag per standby replica (Part 40)",
+        "description": "Queries pg_stat_replication for LSN distances between primary and each connected standby. Returns an empty array when no replicas are configured.\n",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Replication lag per replica (may be empty)"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/table-sizes": {
+      "get": {
+        "summary": "Per-table disk usage including indexes and TOAST (Part 40)",
+        "description": "Returns total on-disk size for each public-schema table broken down into heap, index, and TOAST segments. Ordered by total size descending.\n",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 30,
+              "maximum": 100
+            },
+            "description": "Maximum number of tables to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Table size breakdown"
+          },
+          "400": {
+            "description": "Invalid limit parameter"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/bgwriter-stats": {
+      "get": {
+        "summary": "Background writer and checkpoint activity statistics (Part 41)",
+        "description": "Returns a single-row snapshot from pg_stat_bgwriter covering checkpoint frequency (timed vs requested), buffer write counts per writer, backend fsync calls, and checkpoint I/O durations. Useful for tuning checkpoint_completion_target and bgwriter_lru_maxpages.\n",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "BGWriter stats snapshot"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/db-scaling/database-stats": {
+      "get": {
+        "summary": "Database-level statistics for the current database (Part 41)",
+        "description": "Returns a snapshot from pg_stat_database for the active database, including transaction throughput (commits/rollbacks), overall buffer cache hit ratio, temporary file usage, deadlock count, and conflict count since the last stats reset.\n",
+        "tags": [
+          "DB Scaling"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Database-level stats snapshot"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         }
       }
@@ -1294,6 +1918,91 @@
         "responses": {
           "200": {
             "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/me": {
+      "get": {
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "Get current organization profile",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization profile"
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/me/name": {
+      "patch": {
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "Update organization name",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated organization name"
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/me/issuer": {
+      "patch": {
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "Update organization Stellar issuer account",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "issuerAccount": {
+                    "type": "string",
+                    "description": "Stellar public key (G...)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated issuer account"
           }
         }
       }
@@ -1772,6 +2481,63 @@
         }
       }
     },
+    "/api/v1/scaling/health": {
+      "get": {
+        "summary": "Database connection-pool health snapshot",
+        "tags": [
+          "Scaling"
+        ],
+        "responses": {
+          "200": {
+            "description": "Current pool utilisation"
+          }
+        }
+      }
+    },
+    "/api/v1/scaling/query-stats": {
+      "get": {
+        "summary": "Recent slow-query statistics (admin only)",
+        "tags": [
+          "Scaling"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "in": "query",
+            "name": "minMs",
+            "schema": {
+              "type": "integer",
+              "default": 200
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of recent slow queries"
+          }
+        }
+      }
+    },
+    "/api/v1/scaling/refresh-view": {
+      "post": {
+        "summary": "Refresh the daily transaction summary materialised view",
+        "tags": [
+          "Scaling"
+        ],
+        "responses": {
+          "200": {
+            "description": "View refreshed successfully"
+          }
+        }
+      }
+    },
     "/api/v1/search/organizations/{organizationId}/employees": {
       "get": {
         "summary": "Search and filter employees",
@@ -2118,6 +2884,40 @@
         "summary": "Get throttling performance metrics",
         "tags": [
           "Throttling"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/transactions": {
+      "get": {
+        "summary": "List transactions with pagination",
+        "tags": [
+          "Transactions"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
           "200": {
@@ -2868,6 +3668,120 @@
         "security": []
       }
     },
+    "/auth/social-identities": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Social identity management (requires authenticated user)",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/auth/social-identities": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Social identity management (requires authenticated user)",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/v1/auth/social-identities": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Social identity management (requires authenticated user)",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
+    "/auth/social-identities/{provider}": {
+      "delete": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "DELETE /social-identities/:provider",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/auth/social-identities/{provider}": {
+      "delete": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "DELETE /social-identities/:provider",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/v1/auth/social-identities/{provider}": {
+      "delete": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "DELETE /social-identities/:provider",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
     "/api/v1/balance/{accountId}": {
       "get": {
         "tags": [
@@ -2896,7 +3810,7 @@
         "tags": [
           "Balances"
         ],
-        "summary": "tags:",
+        "summary": "/api/balance/{accountId}:",
         "responses": {
           "200": {
             "description": "Success"
@@ -3059,12 +3973,38 @@
         }
       }
     },
+    "/api/employees/bulk-import": {
+      "post": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Bulk import employees from CSV",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/employees/bulk-import": {
+      "post": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Bulk import employees from CSV",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/api/employees": {
       "post": {
         "tags": [
           "Employees"
         ],
-        "summary": "Create a new employee",
+        "summary": "Bulk import employees from CSV",
         "responses": {
           "200": {
             "description": "Success"
@@ -3075,7 +4015,7 @@
         "tags": [
           "Employees"
         ],
-        "summary": "Create a new employee",
+        "summary": "Bulk import employees from CSV",
         "responses": {
           "200": {
             "description": "Success"
@@ -3088,7 +4028,7 @@
         "tags": [
           "Employees"
         ],
-        "summary": "Create a new employee",
+        "summary": "Bulk import employees from CSV",
         "responses": {
           "200": {
             "description": "Success"
@@ -3099,7 +4039,7 @@
         "tags": [
           "Employees"
         ],
-        "summary": "Create a new employee",
+        "summary": "Bulk import employees from CSV",
         "responses": {
           "200": {
             "description": "Success"
@@ -3112,7 +4052,7 @@
         "tags": [
           "Employees"
         ],
-        "summary": "Create a new employee",
+        "summary": "Bulk import employees from CSV",
         "parameters": [
           {
             "in": "path",
@@ -3133,7 +4073,28 @@
         "tags": [
           "Employees"
         ],
-        "summary": "Create a new employee",
+        "summary": "Bulk import employees from CSV",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Bulk import employees from CSV",
         "parameters": [
           {
             "in": "path",
@@ -3177,7 +4138,7 @@
         "tags": [
           "Employees"
         ],
-        "summary": "Create a new employee",
+        "summary": "Bulk import employees from CSV",
         "parameters": [
           {
             "in": "path",
@@ -3198,7 +4159,28 @@
         "tags": [
           "Employees"
         ],
-        "summary": "Create a new employee",
+        "summary": "Bulk import employees from CSV",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Bulk import employees from CSV",
         "parameters": [
           {
             "in": "path",
@@ -3230,32 +4212,6 @@
             }
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/employees/bulk-import": {
-      "post": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "POST /bulk-import",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/v1/employees/bulk-import": {
-      "post": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "POST /bulk-import",
         "responses": {
           "200": {
             "description": "Success"
@@ -3370,6 +4326,32 @@
           "Notifications"
         ],
         "summary": "Update notification configuration (admin only)",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/notifications/payment": {
+      "post": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Send payment notification for a completed payroll transaction",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/notifications/payment": {
+      "post": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Send payment notification for a completed payroll transaction",
         "responses": {
           "200": {
             "description": "Success"
@@ -3673,7 +4655,7 @@
         "tags": [
           "Payroll"
         ],
-        "summary": "GET /employees/:employeeId/summary",
+        "summary": "/",
         "parameters": [
           {
             "in": "path",
@@ -3696,7 +4678,7 @@
         "tags": [
           "Payroll"
         ],
-        "summary": "GET /employees/:employeeId/summary",
+        "summary": "/",
         "parameters": [
           {
             "in": "path",
@@ -4070,6 +5052,34 @@
         }
       }
     },
+    "/rates/convert": {
+      "get": {
+        "tags": [
+          "Rates"
+        ],
+        "summary": "GET /convert",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/v1/rates/convert": {
+      "get": {
+        "tags": [
+          "Rates"
+        ],
+        "summary": "GET /convert",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
     "/rates": {
       "get": {
         "tags": [
@@ -4294,286 +5304,6 @@
             }
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/webhooks/subscribe": {
-      "post": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "POST /subscribe",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/v1/webhooks/subscribe": {
-      "post": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "POST /subscribe",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/webhooks/subscriptions/{id}": {
-      "put": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "PUT /subscriptions/:id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "GET /subscriptions/:id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "DELETE /subscriptions/:id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/v1/webhooks/subscriptions/{id}": {
-      "put": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "PUT /subscriptions/:id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "GET /subscriptions/:id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "DELETE /subscriptions/:id",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/webhooks/subscriptions": {
-      "get": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "GET /subscriptions",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/v1/webhooks/subscriptions": {
-      "get": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "GET /subscriptions",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/webhooks/subscriptions/{id}/delivery-logs": {
-      "get": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "GET /subscriptions/:id/delivery-logs",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/v1/webhooks/subscriptions/{id}/delivery-logs": {
-      "get": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "GET /subscriptions/:id/delivery-logs",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/webhooks/events": {
-      "get": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "GET /events",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/v1/webhooks/events": {
-      "get": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "GET /events",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/webhooks/test-trigger": {
-      "post": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "POST /test-trigger",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/v1/webhooks/test-trigger": {
-      "post": {
-        "tags": [
-          "Webhooks"
-        ],
-        "summary": "POST /test-trigger",
         "responses": {
           "200": {
             "description": "Success"

--- a/backend/src/__tests__/dbScalingRoutes.test.ts
+++ b/backend/src/__tests__/dbScalingRoutes.test.ts
@@ -1,9 +1,10 @@
 /**
- * Integration tests for the DB Scaling endpoints (Parts 39, 40 & 41).
+ * Integration tests for the DB Scaling endpoints (Parts 39, 40, 41 & 49).
  *
  * Issues #284 (Part 39) — lock contention, unused indexes
  * Issues #285 (Part 40) — replication lag, table sizes
  * Issues #286 (Part 41) — bgwriter stats, database stats
+ * Issues #294 (Part 49) — table I/O stats, index usage stats
  *
  * Strategy
  * ─────────
@@ -23,6 +24,8 @@ const mockGetReplicationLag   = jest.fn();
 const mockGetTableSizes       = jest.fn();
 const mockGetBgwriterStats    = jest.fn();
 const mockGetDatabaseStats    = jest.fn();
+const mockGetTableIoStats     = jest.fn();
+const mockGetIndexUsageStats  = jest.fn();
 
 // Also stub the methods used by existing controller handlers so the mock
 // implementation is complete (prevents "not a function" errors from other routes
@@ -54,6 +57,8 @@ jest.mock('../services/dbScalingService.js', () => ({
     getTableSizes:              mockGetTableSizes,
     getBgwriterStats:           mockGetBgwriterStats,
     getDatabaseStats:           mockGetDatabaseStats,
+    getTableIoStats:            mockGetTableIoStats,
+    getIndexUsageStats:         mockGetIndexUsageStats,
   })),
 }));
 
@@ -371,6 +376,103 @@ describe('GET /api/v1/db-scaling/database-stats', () => {
     mockGetDatabaseStats.mockRejectedValue(new Error('pg error'));
 
     const res = await request(app).get('/api/v1/db-scaling/database-stats');
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Part 49: GET /api/v1/db-scaling/table-io-stats ──────────────────────────
+
+describe('GET /api/v1/db-scaling/table-io-stats', () => {
+  const fakeTableIo = [
+    {
+      table:              'payroll_items',
+      heapBlksRead:       12000,
+      heapBlksHit:        980000,
+      heapCacheHitRatio:  0.9878,
+      idxBlksRead:        3000,
+      idxBlksHit:         450000,
+      toastBlksRead:      0,
+      toastBlksHit:       0,
+    },
+  ];
+
+  it('returns 200 with per-table I/O snapshot', async () => {
+    mockGetTableIoStats.mockResolvedValue(fakeTableIo);
+
+    const res = await request(app).get('/api/v1/db-scaling/table-io-stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data[0]).toMatchObject({
+      table:             'payroll_items',
+      heapBlksRead:      12000,
+      heapCacheHitRatio: 0.9878,
+    });
+  });
+
+  it('returns 400 when limit is invalid', async () => {
+    const res = await request(app).get('/api/v1/db-scaling/table-io-stats?limit=0');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetTableIoStats.mockRejectedValue(new Error('pg error'));
+
+    const res = await request(app).get('/api/v1/db-scaling/table-io-stats');
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Part 49: GET /api/v1/db-scaling/index-usage-stats ───────────────────────
+
+describe('GET /api/v1/db-scaling/index-usage-stats', () => {
+  const fakeIndexUsage = [
+    {
+      table:       'payroll_items',
+      index:       'payroll_items_employee_id_idx',
+      idxScan:     82000,
+      idxTupRead:  1640000,
+      idxTupFetch: 1580000,
+    },
+    {
+      table:       'employees',
+      index:       'employees_org_id_idx',
+      idxScan:     0,
+      idxTupRead:  0,
+      idxTupFetch: 0,
+    },
+  ];
+
+  it('returns 200 with per-index usage snapshot', async () => {
+    mockGetIndexUsageStats.mockResolvedValue(fakeIndexUsage);
+
+    const res = await request(app).get('/api/v1/db-scaling/index-usage-stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data[0]).toMatchObject({
+      table:   'payroll_items',
+      index:   'payroll_items_employee_id_idx',
+      idxScan: 82000,
+    });
+    expect(res.body.data[1].idxScan).toBe(0);
+  });
+
+  it('returns 400 when limit is invalid', async () => {
+    const res = await request(app).get('/api/v1/db-scaling/index-usage-stats?limit=abc');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetIndexUsageStats.mockRejectedValue(new Error('pg error'));
+
+    const res = await request(app).get('/api/v1/db-scaling/index-usage-stats');
 
     expect(res.status).toBe(500);
   });

--- a/backend/src/__tests__/dbScalingRoutes.test.ts
+++ b/backend/src/__tests__/dbScalingRoutes.test.ts
@@ -1,8 +1,9 @@
 /**
- * Integration tests for the DB Scaling endpoints (Parts 39 & 40).
+ * Integration tests for the DB Scaling endpoints (Parts 39, 40 & 41).
  *
  * Issues #284 (Part 39) — lock contention, unused indexes
  * Issues #285 (Part 40) — replication lag, table sizes
+ * Issues #286 (Part 41) — bgwriter stats, database stats
  *
  * Strategy
  * ─────────
@@ -20,6 +21,8 @@ const mockGetLockContention   = jest.fn();
 const mockGetUnusedIndexes    = jest.fn();
 const mockGetReplicationLag   = jest.fn();
 const mockGetTableSizes       = jest.fn();
+const mockGetBgwriterStats    = jest.fn();
+const mockGetDatabaseStats    = jest.fn();
 
 // Also stub the methods used by existing controller handlers so the mock
 // implementation is complete (prevents "not a function" errors from other routes
@@ -49,6 +52,8 @@ jest.mock('../services/dbScalingService.js', () => ({
     getUnusedIndexes:           mockGetUnusedIndexes,
     getReplicationLag:          mockGetReplicationLag,
     getTableSizes:              mockGetTableSizes,
+    getBgwriterStats:           mockGetBgwriterStats,
+    getDatabaseStats:           mockGetDatabaseStats,
   })),
 }));
 
@@ -253,6 +258,119 @@ describe('GET /api/v1/db-scaling/table-sizes', () => {
     mockGetTableSizes.mockRejectedValue(new Error('pg error'));
 
     const res = await request(app).get('/api/v1/db-scaling/table-sizes');
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Part 41: GET /api/v1/db-scaling/bgwriter-stats ──────────────────────────
+
+describe('GET /api/v1/db-scaling/bgwriter-stats', () => {
+  const fakeBgwriter = {
+    checkpointsTimed:      142,
+    checkpointsRequested:  3,
+    buffersCheckpoint:     28500,
+    buffersClean:          4200,
+    maxWrittenClean:       1,
+    buffersBackend:        9300,
+    buffersBackendFsync:   0,
+    buffersAlloc:          15000,
+    checkpointWriteTimeMs: 32500.5,
+    checkpointSyncTimeMs:  1200.3,
+    statsResetAt:          '2026-01-01T00:00:00.000Z',
+  };
+
+  it('returns 200 with bgwriter stats snapshot', async () => {
+    mockGetBgwriterStats.mockResolvedValue(fakeBgwriter);
+
+    const res = await request(app).get('/api/v1/db-scaling/bgwriter-stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      checkpointsTimed:     142,
+      checkpointsRequested: 3,
+      buffersCheckpoint:    28500,
+      buffersBackend:       9300,
+    });
+  });
+
+  it('returns 200 with zero-valued snapshot when pg returns no row', async () => {
+    mockGetBgwriterStats.mockResolvedValue({
+      checkpointsTimed: 0, checkpointsRequested: 0,
+      buffersCheckpoint: 0, buffersClean: 0, maxWrittenClean: 0,
+      buffersBackend: 0, buffersBackendFsync: 0, buffersAlloc: 0,
+      checkpointWriteTimeMs: 0, checkpointSyncTimeMs: 0, statsResetAt: null,
+    });
+
+    const res = await request(app).get('/api/v1/db-scaling/bgwriter-stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.checkpointsTimed).toBe(0);
+    expect(res.body.data.statsResetAt).toBeNull();
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetBgwriterStats.mockRejectedValue(new Error('pg error'));
+
+    const res = await request(app).get('/api/v1/db-scaling/bgwriter-stats');
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Part 41: GET /api/v1/db-scaling/database-stats ──────────────────────────
+
+describe('GET /api/v1/db-scaling/database-stats', () => {
+  const fakeDbStats = {
+    dbName:         'payd_production',
+    numBackends:    12,
+    xactCommit:     5000000,
+    xactRollback:   3200,
+    blksRead:       800000,
+    blksHit:        9200000,
+    cacheHitRatio:  0.92,
+    tempFiles:      14,
+    tempBytes:      104857600,
+    deadlocks:      2,
+    conflictsTotal: 0,
+    statsResetAt:   '2026-01-01T00:00:00.000Z',
+  };
+
+  it('returns 200 with database-level stats', async () => {
+    mockGetDatabaseStats.mockResolvedValue(fakeDbStats);
+
+    const res = await request(app).get('/api/v1/db-scaling/database-stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      dbName:       'payd_production',
+      numBackends:  12,
+      xactCommit:   5000000,
+      deadlocks:    2,
+      cacheHitRatio: 0.92,
+    });
+  });
+
+  it('returns a cacheHitRatio of 1 when no blocks have been read or hit', async () => {
+    mockGetDatabaseStats.mockResolvedValue({
+      ...fakeDbStats,
+      blksRead: 0,
+      blksHit:  0,
+      cacheHitRatio: 1,
+    });
+
+    const res = await request(app).get('/api/v1/db-scaling/database-stats');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.cacheHitRatio).toBe(1);
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetDatabaseStats.mockRejectedValue(new Error('pg error'));
+
+    const res = await request(app).get('/api/v1/db-scaling/database-stats');
 
     expect(res.status).toBe(500);
   });

--- a/backend/src/controllers/dbScalingController.ts
+++ b/backend/src/controllers/dbScalingController.ts
@@ -165,6 +165,40 @@ export class DbScalingController {
     }
   }
 
+  // ── Part 49 (#294) ─────────────────────────────────────────────────────
+
+  /** #294a — Per-table I/O stats (heap, index, TOAST blocks read vs hit). */
+  async getTableIoStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const limit = Math.min(Number(req.query['limit'] ?? 30), 100);
+      if (isNaN(limit) || limit < 1) {
+        res.status(400).json({ success: false, error: 'limit must be a positive integer' });
+        return;
+      }
+      const data = await service.getTableIoStats(limit);
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch table I/O stats');
+      next(err);
+    }
+  }
+
+  /** #294b — Per-index access stats (scan count, rows read/fetched). */
+  async getIndexUsageStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const limit = Math.min(Number(req.query['limit'] ?? 30), 100);
+      if (isNaN(limit) || limit < 1) {
+        res.status(400).json({ success: false, error: 'limit must be a positive integer' });
+        return;
+      }
+      const data = await service.getIndexUsageStats(limit);
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch index usage stats');
+      next(err);
+    }
+  }
+
   /** #285b — Per-table disk usage (table + indexes + TOAST). */
   async getTableSizes(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {

--- a/backend/src/controllers/dbScalingController.ts
+++ b/backend/src/controllers/dbScalingController.ts
@@ -141,6 +141,30 @@ export class DbScalingController {
     }
   }
 
+  // ── Part 41 (#286) ─────────────────────────────────────────────────────
+
+  /** #286a — Background writer and checkpoint statistics. */
+  async getBgwriterStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const data = await service.getBgwriterStats();
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch bgwriter stats');
+      next(err);
+    }
+  }
+
+  /** #286b — Database-level statistics (transactions, cache hit ratio, deadlocks, temp files). */
+  async getDatabaseStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const data = await service.getDatabaseStats();
+      res.json({ success: true, data });
+    } catch (err) {
+      logger.error({ err }, 'Failed to fetch database stats');
+      next(err);
+    }
+  }
+
   /** #285b — Per-table disk usage (table + indexes + TOAST). */
   async getTableSizes(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {

--- a/backend/src/routes/dbScalingRoutes.ts
+++ b/backend/src/routes/dbScalingRoutes.ts
@@ -240,4 +240,66 @@ router.get('/bgwriter-stats', (req, res, next) => ctrl.getBgwriterStats(req, res
  */
 router.get('/database-stats', (req, res, next) => ctrl.getDatabaseStats(req, res, next));
 
+// ── Part 49 (#294) ──────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /api/v1/db-scaling/table-io-stats:
+ *   get:
+ *     summary: Per-table I/O statistics from pg_statio_user_tables (Part 49)
+ *     description: >
+ *       Returns heap, index, and TOAST block read/hit counts per table ordered
+ *       by total disk reads descending.  The computed heapCacheHitRatio reveals
+ *       tables that are cache-cold and driving physical I/O.
+ *     tags: [DB Scaling]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 30
+ *           maximum: 100
+ *         description: Maximum number of tables to return
+ *     responses:
+ *       200:
+ *         description: Per-table I/O snapshot
+ *       400:
+ *         description: Invalid limit parameter
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/table-io-stats', (req, res, next) => ctrl.getTableIoStats(req, res, next));
+
+/**
+ * @swagger
+ * /api/v1/db-scaling/index-usage-stats:
+ *   get:
+ *     summary: Per-index access statistics from pg_stat_user_indexes (Part 49)
+ *     description: >
+ *       Returns scan count, rows read, and rows fetched per index ordered by
+ *       scan frequency descending.  Indexes with zero idx_scan are candidates
+ *       for removal; hot indexes with high idx_tup_read inform cache sizing.
+ *     tags: [DB Scaling]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 30
+ *           maximum: 100
+ *         description: Maximum number of indexes to return
+ *     responses:
+ *       200:
+ *         description: Per-index usage snapshot
+ *       400:
+ *         description: Invalid limit parameter
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/index-usage-stats', (req, res, next) => ctrl.getIndexUsageStats(req, res, next));
+
 export default router;

--- a/backend/src/routes/dbScalingRoutes.ts
+++ b/backend/src/routes/dbScalingRoutes.ts
@@ -196,4 +196,48 @@ router.get('/replication-lag', (req, res, next) => ctrl.getReplicationLag(req, r
  */
 router.get('/table-sizes', (req, res, next) => ctrl.getTableSizes(req, res, next));
 
+// ── Part 41 (#286) ──────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /api/v1/db-scaling/bgwriter-stats:
+ *   get:
+ *     summary: Background writer and checkpoint activity statistics (Part 41)
+ *     description: >
+ *       Returns a single-row snapshot from pg_stat_bgwriter covering checkpoint
+ *       frequency (timed vs requested), buffer write counts per writer, backend
+ *       fsync calls, and checkpoint I/O durations. Useful for tuning
+ *       checkpoint_completion_target and bgwriter_lru_maxpages.
+ *     tags: [DB Scaling]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: BGWriter stats snapshot
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/bgwriter-stats', (req, res, next) => ctrl.getBgwriterStats(req, res, next));
+
+/**
+ * @swagger
+ * /api/v1/db-scaling/database-stats:
+ *   get:
+ *     summary: Database-level statistics for the current database (Part 41)
+ *     description: >
+ *       Returns a snapshot from pg_stat_database for the active database,
+ *       including transaction throughput (commits/rollbacks), overall buffer
+ *       cache hit ratio, temporary file usage, deadlock count, and conflict
+ *       count since the last stats reset.
+ *     tags: [DB Scaling]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Database-level stats snapshot
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/database-stats', (req, res, next) => ctrl.getDatabaseStats(req, res, next));
+
 export default router;

--- a/backend/src/services/dbScalingService.ts
+++ b/backend/src/services/dbScalingService.ts
@@ -493,6 +493,98 @@ export class DbScalingService {
     };
   }
 
+  // ── Part 49 (#294) ───────────────────────────────────────────────────────
+
+  /**
+   * #294a — Per-table I/O statistics from pg_statio_user_tables.
+   * Shows heap, index, and TOAST block reads from disk vs buffer-cache hits
+   * for each table.  High disk-read ratios signal cache pressure or cold data.
+   */
+  async getTableIoStats(limit = 30): Promise<{
+    table: string;
+    heapBlksRead: number;
+    heapBlksHit: number;
+    heapCacheHitRatio: number;
+    idxBlksRead: number;
+    idxBlksHit: number;
+    toastBlksRead: number;
+    toastBlksHit: number;
+  }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      relname: string;
+      heap_blks_read: bigint;
+      heap_blks_hit: bigint;
+      idx_blks_read: bigint;
+      idx_blks_hit: bigint;
+      toast_blks_read: bigint | null;
+      toast_blks_hit: bigint | null;
+    }>>`
+      SELECT
+        relname,
+        heap_blks_read,
+        heap_blks_hit,
+        COALESCE(idx_blks_read, 0)   AS idx_blks_read,
+        COALESCE(idx_blks_hit,  0)   AS idx_blks_hit,
+        COALESCE(toast_blks_read, 0) AS toast_blks_read,
+        COALESCE(toast_blks_hit,  0) AS toast_blks_hit
+      FROM pg_statio_user_tables
+      ORDER BY heap_blks_read + COALESCE(idx_blks_read, 0) DESC
+      LIMIT ${limit}
+    `;
+    return rows.map(r => {
+      const heapRead = Number(r.heap_blks_read);
+      const heapHit  = Number(r.heap_blks_hit);
+      return {
+        table:              r.relname,
+        heapBlksRead:       heapRead,
+        heapBlksHit:        heapHit,
+        heapCacheHitRatio:  heapRead + heapHit > 0 ? heapHit / (heapRead + heapHit) : 1,
+        idxBlksRead:        Number(r.idx_blks_read),
+        idxBlksHit:         Number(r.idx_blks_hit),
+        toastBlksRead:      Number(r.toast_blks_read),
+        toastBlksHit:       Number(r.toast_blks_hit),
+      };
+    });
+  }
+
+  /**
+   * #294b — Per-index access statistics from pg_stat_user_indexes.
+   * Surfaces scan counts, rows read, and rows fetched per index so operators
+   * can identify cold (never-scanned) indexes and highly-used ones.
+   */
+  async getIndexUsageStats(limit = 30): Promise<{
+    table: string;
+    index: string;
+    idxScan: number;
+    idxTupRead: number;
+    idxTupFetch: number;
+  }[]> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      relname: string;
+      indexrelname: string;
+      idx_scan: bigint;
+      idx_tup_read: bigint;
+      idx_tup_fetch: bigint;
+    }>>`
+      SELECT
+        relname,
+        indexrelname,
+        idx_scan,
+        idx_tup_read,
+        idx_tup_fetch
+      FROM pg_stat_user_indexes
+      ORDER BY idx_scan DESC
+      LIMIT ${limit}
+    `;
+    return rows.map(r => ({
+      table:        r.relname,
+      index:        r.indexrelname,
+      idxScan:      Number(r.idx_scan),
+      idxTupRead:   Number(r.idx_tup_read),
+      idxTupFetch:  Number(r.idx_tup_fetch),
+    }));
+  }
+
   /**
    * #285b — Table sizes: total on-disk size (table + indexes + TOAST) per table,
    * ordered largest first.  Useful for capacity planning and spotting unexpected growth.

--- a/backend/src/services/dbScalingService.ts
+++ b/backend/src/services/dbScalingService.ts
@@ -349,6 +349,150 @@ export class DbScalingService {
     }));
   }
 
+  // ── Part 41 (#286) ───────────────────────────────────────────────────────
+
+  /**
+   * #286a — Background writer / checkpoint activity from pg_stat_bgwriter.
+   * Surfaces checkpoint frequency, buffer write counts, and stall time so
+   * operators can tune checkpoint_completion_target and bgwriter settings.
+   */
+  async getBgwriterStats(): Promise<{
+    checkpointsTimed: number;
+    checkpointsRequested: number;
+    buffersCheckpoint: number;
+    buffersClean: number;
+    maxWrittenClean: number;
+    buffersBackend: number;
+    buffersBackendFsync: number;
+    buffersAlloc: number;
+    checkpointWriteTimeMs: number;
+    checkpointSyncTimeMs: number;
+    statsResetAt: string | null;
+  }> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      checkpoints_timed: bigint;
+      checkpoints_req: bigint;
+      buffers_checkpoint: bigint;
+      buffers_clean: bigint;
+      maxwritten_clean: bigint;
+      buffers_backend: bigint;
+      buffers_backend_fsync: bigint;
+      buffers_alloc: bigint;
+      checkpoint_write_time: number;
+      checkpoint_sync_time: number;
+      stats_reset: Date | null;
+    }>>`
+      SELECT
+        checkpoints_timed,
+        checkpoints_req,
+        buffers_checkpoint,
+        buffers_clean,
+        maxwritten_clean,
+        buffers_backend,
+        buffers_backend_fsync,
+        buffers_alloc,
+        checkpoint_write_time,
+        checkpoint_sync_time,
+        stats_reset
+      FROM pg_stat_bgwriter
+    `;
+    const r = rows[0];
+    if (!r) {
+      return {
+        checkpointsTimed: 0, checkpointsRequested: 0,
+        buffersCheckpoint: 0, buffersClean: 0, maxWrittenClean: 0,
+        buffersBackend: 0, buffersBackendFsync: 0, buffersAlloc: 0,
+        checkpointWriteTimeMs: 0, checkpointSyncTimeMs: 0, statsResetAt: null,
+      };
+    }
+    return {
+      checkpointsTimed:     Number(r.checkpoints_timed),
+      checkpointsRequested: Number(r.checkpoints_req),
+      buffersCheckpoint:    Number(r.buffers_checkpoint),
+      buffersClean:         Number(r.buffers_clean),
+      maxWrittenClean:      Number(r.maxwritten_clean),
+      buffersBackend:       Number(r.buffers_backend),
+      buffersBackendFsync:  Number(r.buffers_backend_fsync),
+      buffersAlloc:         Number(r.buffers_alloc),
+      checkpointWriteTimeMs: r.checkpoint_write_time,
+      checkpointSyncTimeMs:  r.checkpoint_sync_time,
+      statsResetAt: r.stats_reset ? r.stats_reset.toISOString() : null,
+    };
+  }
+
+  /**
+   * #286b — Database-level statistics from pg_stat_database for the current DB.
+   * Provides transaction throughput, cache hit ratio, deadlock counts, and
+   * temporary file usage in a single snapshot.
+   */
+  async getDatabaseStats(): Promise<{
+    dbName: string;
+    numBackends: number;
+    xactCommit: number;
+    xactRollback: number;
+    blksRead: number;
+    blksHit: number;
+    cacheHitRatio: number;
+    tempFiles: number;
+    tempBytes: number;
+    deadlocks: number;
+    conflictsTotal: number;
+    statsResetAt: string | null;
+  }> {
+    const rows = await this.prisma.$queryRaw<Array<{
+      datname: string;
+      numbackends: number;
+      xact_commit: bigint;
+      xact_rollback: bigint;
+      blks_read: bigint;
+      blks_hit: bigint;
+      temp_files: bigint;
+      temp_bytes: bigint;
+      deadlocks: bigint;
+      conflicts: bigint;
+      stats_reset: Date | null;
+    }>>`
+      SELECT
+        datname,
+        numbackends,
+        xact_commit,
+        xact_rollback,
+        blks_read,
+        blks_hit,
+        temp_files,
+        temp_bytes,
+        deadlocks,
+        conflicts,
+        stats_reset
+      FROM pg_stat_database
+      WHERE datname = current_database()
+    `;
+    const r = rows[0];
+    if (!r) {
+      return {
+        dbName: '', numBackends: 0, xactCommit: 0, xactRollback: 0,
+        blksRead: 0, blksHit: 0, cacheHitRatio: 1, tempFiles: 0,
+        tempBytes: 0, deadlocks: 0, conflictsTotal: 0, statsResetAt: null,
+      };
+    }
+    const blksRead = Number(r.blks_read);
+    const blksHit  = Number(r.blks_hit);
+    return {
+      dbName:         r.datname,
+      numBackends:    r.numbackends,
+      xactCommit:     Number(r.xact_commit),
+      xactRollback:   Number(r.xact_rollback),
+      blksRead,
+      blksHit,
+      cacheHitRatio:  blksRead + blksHit > 0 ? blksHit / (blksRead + blksHit) : 1,
+      tempFiles:      Number(r.temp_files),
+      tempBytes:      Number(r.temp_bytes),
+      deadlocks:      Number(r.deadlocks),
+      conflictsTotal: Number(r.conflicts),
+      statsResetAt:   r.stats_reset ? r.stats_reset.toISOString() : null,
+    };
+  }
+
   /**
    * #285b — Table sizes: total on-disk size (table + indexes + TOAST) per table,
    * ordered largest first.  Useful for capacity planning and spotting unexpected growth.

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -1,0 +1,90 @@
+import { pool } from '../config/database.js';
+import axios from 'axios';
+
+export const WEBHOOK_EVENTS = {
+  PAYROLL_COMPLETED:         'payroll.completed',
+  PAYROLL_FAILED:            'payroll.failed',
+  PAYROLL_STARTED:           'payroll.started',
+  EMPLOYEE_ADDED:            'employee.added',
+  EMPLOYEE_UPDATED:          'employee.updated',
+  EMPLOYEE_REMOVED:          'employee.removed',
+  EMPLOYEE_DELETED:          'employee.deleted',
+  BALANCE_LOW:               'balance.low',
+  TRANSACTION_COMPLETED:     'transaction.completed',
+  TRANSACTION_FAILED:        'transaction.failed',
+  CONTRACT_UPGRADED:         'contract.upgraded',
+  MULTISIG_CREATED:          'multisig.created',
+  MULTISIG_EXECUTED:         'multisig.executed',
+  PAYMENT_COMPLETED:         'payment.completed',
+  PAYMENT_FAILED:            'payment.failed',
+  CLAIMABLE_BALANCE_CREATED: 'claimable_balance.created',
+  CLAIMABLE_BALANCE_CLAIMED: 'claimable_balance.claimed',
+} as const;
+
+const MAX_ATTEMPTS = 4;
+
+function backoffMs(attempt: number): number {
+  return 1000 * Math.pow(2, attempt - 1);
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class WebhookService {
+  static async dispatch(
+    eventType: string,
+    organizationId: number,
+    payload: object,
+  ): Promise<void> {
+    const result = await pool.query(
+      `SELECT * FROM webhook_subscriptions
+       WHERE organization_id = $1 AND is_active = true
+         AND (events @> ARRAY[$2] OR events @> ARRAY['*'])`,
+      [organizationId, eventType],
+    );
+
+    if (result.rows.length === 0) return;
+
+    const payloadStr = JSON.stringify(payload);
+
+    await Promise.allSettled(
+      result.rows.map((sub) => this.deliverWithRetry(sub, eventType, payloadStr, 1)),
+    );
+  }
+
+  private static async deliverWithRetry(
+    subscription: { id: string | number; url: string },
+    eventType: string,
+    payloadStr: string,
+    attempt: number,
+  ): Promise<void> {
+    try {
+      await axios.post(subscription.url, payloadStr, {
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 10000,
+      });
+
+      await pool.query(
+        `INSERT INTO webhook_delivery_logs
+           (subscription_id, event_type, payload, response_status, response_body, error_message, attempt_number)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [subscription.id, eventType, payloadStr, null, null, null, attempt],
+      );
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+
+      await pool.query(
+        `INSERT INTO webhook_delivery_logs
+           (subscription_id, event_type, payload, response_status, response_body, error_message, attempt_number)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [subscription.id, eventType, payloadStr, null, null, errorMessage, attempt],
+      );
+
+      if (attempt < MAX_ATTEMPTS) {
+        await wait(backoffMs(attempt));
+        await this.deliverWithRetry(subscription, eventType, payloadStr, attempt + 1);
+      }
+    }
+  }
+}

--- a/frontend/src/__tests__/PayrollAnalytics.test.tsx
+++ b/frontend/src/__tests__/PayrollAnalytics.test.tsx
@@ -31,9 +31,7 @@ vi.mock('recharts', () => {
     CartesianGrid: () => null,
     Tooltip: () => null,
     Legend: () => null,
-    ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => (
-      <div>{children}</div>
-    ),
+    ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
   };
 });
 
@@ -63,7 +61,7 @@ function renderComponent() {
       <QueryClientProvider client={makeClient()}>
         <PayrollAnalytics />
       </QueryClientProvider>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -141,7 +139,7 @@ describe('PayrollAnalytics', () => {
       () => {
         expect(screen.getByText('Total Payroll')).toBeInTheDocument();
       },
-      { timeout: 3000 },
+      { timeout: 3000 }
     );
   });
 

--- a/frontend/src/__tests__/hooks/useWalletManager.test.ts
+++ b/frontend/src/__tests__/hooks/useWalletManager.test.ts
@@ -1,7 +1,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useWalletManager } from '../../hooks/useWalletManager';
-import { StellarWalletsKit } from '@creit.tech/stellar-wallets-kit';
 
 const mockSetWallet = vi.fn();
 const mockGetAddress = vi.fn();

--- a/frontend/src/__tests__/transactionHistoryApi.test.ts
+++ b/frontend/src/__tests__/transactionHistoryApi.test.ts
@@ -4,7 +4,6 @@
  * Tests the normalization functions and API service layer
  */
 
-/* eslint-disable @typescript-eslint/no-base-to-string */
 import { normalizeAuditRecord, normalizeContractEvent } from '../services/transactionHistoryApi';
 import type { AuditRecord, ContractEvent } from '../types/transactionHistory';
 import axiosInstance from '../api/axiosInstance';

--- a/frontend/src/__tests__/useContractMetrics.test.ts
+++ b/frontend/src/__tests__/useContractMetrics.test.ts
@@ -18,7 +18,10 @@ vi.mock('@stellar/stellar-sdk', () => ({
   },
   Contract: vi.fn(),
   TransactionBuilder: vi.fn(),
-  Networks: { TESTNET: 'Test SDF Network ; September 2015', PUBLIC: 'Public Global Stellar Network ; September 2015' },
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+  },
   BASE_FEE: '100',
   xdr: {},
   nativeToScVal: vi.fn(),
@@ -33,9 +36,7 @@ describe('useContractMetrics', () => {
   });
 
   it('starts with loading metrics', () => {
-    const { result } = renderHook(() =>
-      useContractMetrics('GABC1234567890', 'testnet')
-    );
+    const { result } = renderHook(() => useContractMetrics('GABC1234567890', 'testnet'));
 
     const allMetricGroups = [
       result.current.metrics.bulk_payment,
@@ -60,9 +61,7 @@ describe('useContractMetrics', () => {
   });
 
   it('uses "warn" status for unconfigured contracts', async () => {
-    const { result } = renderHook(() =>
-      useContractMetrics('GABC1234567890', 'testnet')
-    );
+    const { result } = renderHook(() => useContractMetrics('GABC1234567890', 'testnet'));
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -74,16 +73,12 @@ describe('useContractMetrics', () => {
   });
 
   it('exposes a refresh function', () => {
-    const { result } = renderHook(() =>
-      useContractMetrics('GABC1234567890', 'testnet')
-    );
+    const { result } = renderHook(() => useContractMetrics('GABC1234567890', 'testnet'));
     expect(typeof result.current.refresh).toBe('function');
   });
 
   it('records lastRefreshed after fetch completes', async () => {
-    const { result } = renderHook(() =>
-      useContractMetrics('GABC1234567890', 'testnet')
-    );
+    const { result } = renderHook(() => useContractMetrics('GABC1234567890', 'testnet'));
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.metrics.lastRefreshed).toBeInstanceOf(Date);

--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -67,7 +67,7 @@ export const Avatar: React.FC<AvatarProps> = ({
           className="w-full h-full text-white font-semibold flex items-center justify-center"
           style={{
             background: `linear-gradient(135deg, var(--accent), hsl(${Math.abs(
-              name.charCodeAt(0) * 12,
+              name.charCodeAt(0) * 12
             )} 70% 50%))`,
           }}
         >

--- a/frontend/src/components/CSVUploader.tsx
+++ b/frontend/src/components/CSVUploader.tsx
@@ -272,9 +272,7 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
               )}
             </div>
             <p className="text-base font-semibold text-[var(--text)]">
-              {hasData
-                ? 'Drop a new file to replace'
-                : 'Drag and drop your CSV file here'}
+              {hasData ? 'Drop a new file to replace' : 'Drag and drop your CSV file here'}
             </p>
             <p className="text-sm text-[var(--muted)] mt-1">
               or{' '}
@@ -396,9 +394,7 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
                         className="px-4 py-3 text-sm text-[var(--text)] truncate max-w-[200px]"
                         title={value}
                       >
-                        {value || (
-                          <span className="text-[var(--muted)] italic">empty</span>
-                        )}
+                        {value || <span className="text-[var(--muted)] italic">empty</span>}
                       </td>
                     ))}
 
@@ -406,10 +402,7 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
                       {row.errors.length > 0 ? (
                         <ul className="space-y-1 list-none p-0 m-0">
                           {row.errors.map((error) => (
-                            <li
-                              key={`${row.rowNumber}-${error}`}
-                              className="text-[var(--danger)]"
-                            >
+                            <li key={`${row.rowNumber}-${error}`} className="text-[var(--danger)]">
                               {error}
                             </li>
                           ))}

--- a/frontend/src/components/ComponentErrorBoundary.tsx
+++ b/frontend/src/components/ComponentErrorBoundary.tsx
@@ -44,7 +44,10 @@ export default class ComponentErrorBoundary extends React.Component<
     this.setState({ hasError: false, error: null });
   };
 
-  componentDidUpdate(_prevProps: ComponentErrorBoundaryProps, prevState: ComponentErrorBoundaryState) {
+  componentDidUpdate(
+    _prevProps: ComponentErrorBoundaryProps,
+    prevState: ComponentErrorBoundaryState
+  ) {
     if (prevState.hasError && !this.state.hasError) {
       this.resetButtonRef.current?.focus();
     }

--- a/frontend/src/components/ContractMetricsPanel.tsx
+++ b/frontend/src/components/ContractMetricsPanel.tsx
@@ -12,9 +12,7 @@ function MetricRow({ metric }: MetricRowProps) {
     ok: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400" aria-hidden />,
     warn: <AlertCircle className="h-3.5 w-3.5 text-amber-400" aria-hidden />,
     error: <AlertCircle className="h-3.5 w-3.5 text-red-400" aria-hidden />,
-    loading: (
-      <Loader2 className="h-3.5 w-3.5 animate-spin text-zinc-400" aria-hidden />
-    ),
+    loading: <Loader2 className="h-3.5 w-3.5 animate-spin text-zinc-400" aria-hidden />,
   }[metric.status];
 
   return (
@@ -47,9 +45,7 @@ interface ContractCardProps {
 function ContractCard({ title, metrics }: ContractCardProps) {
   return (
     <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-4">
-      <p className="mb-3 text-[11px] font-bold uppercase tracking-widest text-zinc-400">
-        {title}
-      </p>
+      <p className="mb-3 text-[11px] font-bold uppercase tracking-widest text-zinc-400">{title}</p>
       {metrics.map((m) => (
         <MetricRow key={m.label} metric={m} />
       ))}
@@ -102,10 +98,7 @@ export function ContractMetricsPanel({
             aria-label="Refresh contract metrics"
             className="rounded-md p-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-white disabled:opacity-40 transition-colors"
           >
-            <RefreshCw
-              className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`}
-              aria-hidden
-            />
+            <RefreshCw className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} aria-hidden />
           </button>
         </div>
       </div>

--- a/frontend/src/components/EmployeeList.tsx
+++ b/frontend/src/components/EmployeeList.tsx
@@ -421,11 +421,10 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
       ) : null}
 
       <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {!isLoading && (
-          debouncedSearch || statusFilter !== 'All'
+        {!isLoading &&
+          (debouncedSearch || statusFilter !== 'All'
             ? `${displayedEmployees.length} employee${displayedEmployees.length === 1 ? '' : 's'} found`
-            : ''
-        )}
+            : '')}
       </div>
 
       {showEmptyState ? <div className="px-4 py-4 sm:px-6">{renderEmptyState}</div> : null}
@@ -447,135 +446,142 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                   {...provided.droppableProps}
                   aria-label="Employee list — drag to reorder"
                 >
-            {displayedEmployees.map((employee, index) => (
-              <Draggable key={employee.id} draggableId={employee.id} index={index} isDragDisabled={!reorderMode}>
-                {(dragProvided, dragSnapshot) => (
-              <article
-                ref={dragProvided.innerRef}
-                {...dragProvided.draggableProps}
-                key={employee.id}
-                className={`rounded-3xl border border-hi bg-[var(--surface-hi)]/70 p-5 shadow-[var(--shadow-card)] ${dragSnapshot.isDragging ? 'shadow-[0_8px_32px_rgba(74,240,184,0.15)] ring-1 ring-[var(--accent)]' : ''}`}
-              >
-                {reorderMode && (
-                  <div
-                    {...dragProvided.dragHandleProps}
-                    className="flex items-center justify-center pb-3 cursor-grab active:cursor-grabbing"
-                    aria-label={`Drag to reorder ${employee.name}`}
-                  >
-                    <GripVertical className="h-5 w-5 text-[var(--muted)]" aria-hidden />
-                  </div>
-                )}
-                <div className="flex items-start gap-3">
-                  <button
-                    type="button"
-                    onClick={() => setShowAvatarModal({ open: true, employee })}
-                    className="rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
-                    aria-label={`Update photo for ${employee.name}`}
-                  >
-                    <Avatar
-                      email={employee.email}
-                      name={employee.name}
-                      imageUrl={employee.imageUrl}
-                      size="md"
-                    />
-                  </button>
-
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-start justify-between gap-3">
-                      <button
-                        type="button"
-                        onClick={() => onEmployeeClick?.(employee)}
-                        className="min-w-0 text-left"
-                      >
-                        <p className="truncate text-base font-bold text-[var(--text)]">
-                          {employee.name}
-                        </p>
-                        <p className="truncate text-sm text-[var(--muted)]">{employee.email}</p>
-                      </button>
-                      <span
-                        className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.2em] ${
-                          employee.status === 'Inactive'
-                            ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
-                            : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
-                        }`}
-                      >
-                        {employee.status || 'Active'}
-                      </span>
-                    </div>
-
-                    <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
-                        <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
-                          Role
-                        </p>
-                        <p className="mt-1 text-sm font-semibold text-[var(--text)]">
-                          {employee.position}
-                        </p>
-                      </div>
-                      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
-                        <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
-                          Salary
-                        </p>
-                        <p className="mt-1 text-sm font-semibold text-[var(--text)]">
-                          ${(employee.salary ?? 0).toLocaleString()} / month
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="mt-4 rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
-                            Wallet
-                          </p>
-                          <code className="mt-1 block truncate text-xs font-medium text-[var(--text)]">
-                            {employee.wallet || 'No wallet assigned'}
-                          </code>
-                        </div>
-                        {employee.wallet ? (
-                          <button
-                            type="button"
-                            onClick={() => void handleCopyWallet(employee)}
-                            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-hi text-[var(--muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
-                            aria-label={`Copy wallet for ${employee.name}`}
-                          >
-                            <Copy className="h-4 w-4" aria-hidden />
-                          </button>
-                        ) : null}
-                      </div>
-                    </div>
-
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      {onEditEmployee ? (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setEditSalary(employee.salary || 0);
-                            setShowEditModal({ open: true, employee });
-                          }}
-                          className="inline-flex items-center gap-2 rounded-xl border border-hi px-3 py-2 text-sm font-semibold text-[var(--text)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                  {displayedEmployees.map((employee, index) => (
+                    <Draggable
+                      key={employee.id}
+                      draggableId={employee.id}
+                      index={index}
+                      isDragDisabled={!reorderMode}
+                    >
+                      {(dragProvided, dragSnapshot) => (
+                        <article
+                          ref={dragProvided.innerRef}
+                          {...dragProvided.draggableProps}
+                          key={employee.id}
+                          className={`rounded-3xl border border-hi bg-[var(--surface-hi)]/70 p-5 shadow-[var(--shadow-card)] ${dragSnapshot.isDragging ? 'shadow-[0_8px_32px_rgba(74,240,184,0.15)] ring-1 ring-[var(--accent)]' : ''}`}
                         >
-                          <Pencil className="h-4 w-4" aria-hidden />
-                          Edit salary
-                        </button>
-                      ) : null}
-                      {onRemoveEmployee ? (
-                        <button
-                          type="button"
-                          onClick={() => setShowDeleteConfirm({ open: true, employee })}
-                          className="inline-flex items-center gap-2 rounded-xl border border-[color:rgba(255,123,114,0.22)] px-3 py-2 text-sm font-semibold text-[var(--danger)] transition hover:bg-[color:rgba(255,123,114,0.08)]"
-                        >
-                          <Trash2 className="h-4 w-4" aria-hidden />
-                          Remove
-                        </button>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              </article>
-                )}
-              </Draggable>
-            ))}
+                          {reorderMode && (
+                            <div
+                              {...dragProvided.dragHandleProps}
+                              className="flex items-center justify-center pb-3 cursor-grab active:cursor-grabbing"
+                              aria-label={`Drag to reorder ${employee.name}`}
+                            >
+                              <GripVertical className="h-5 w-5 text-[var(--muted)]" aria-hidden />
+                            </div>
+                          )}
+                          <div className="flex items-start gap-3">
+                            <button
+                              type="button"
+                              onClick={() => setShowAvatarModal({ open: true, employee })}
+                              className="rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+                              aria-label={`Update photo for ${employee.name}`}
+                            >
+                              <Avatar
+                                email={employee.email}
+                                name={employee.name}
+                                imageUrl={employee.imageUrl}
+                                size="md"
+                              />
+                            </button>
+
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-start justify-between gap-3">
+                                <button
+                                  type="button"
+                                  onClick={() => onEmployeeClick?.(employee)}
+                                  className="min-w-0 text-left"
+                                >
+                                  <p className="truncate text-base font-bold text-[var(--text)]">
+                                    {employee.name}
+                                  </p>
+                                  <p className="truncate text-sm text-[var(--muted)]">
+                                    {employee.email}
+                                  </p>
+                                </button>
+                                <span
+                                  className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.2em] ${
+                                    employee.status === 'Inactive'
+                                      ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
+                                      : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
+                                  }`}
+                                >
+                                  {employee.status || 'Active'}
+                                </span>
+                              </div>
+
+                              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                                <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
+                                  <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
+                                    Role
+                                  </p>
+                                  <p className="mt-1 text-sm font-semibold text-[var(--text)]">
+                                    {employee.position}
+                                  </p>
+                                </div>
+                                <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
+                                  <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
+                                    Salary
+                                  </p>
+                                  <p className="mt-1 text-sm font-semibold text-[var(--text)]">
+                                    ${(employee.salary ?? 0).toLocaleString()} / month
+                                  </p>
+                                </div>
+                              </div>
+
+                              <div className="mt-4 rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
+                                <div className="flex items-center justify-between gap-3">
+                                  <div className="min-w-0">
+                                    <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
+                                      Wallet
+                                    </p>
+                                    <code className="mt-1 block truncate text-xs font-medium text-[var(--text)]">
+                                      {employee.wallet || 'No wallet assigned'}
+                                    </code>
+                                  </div>
+                                  {employee.wallet ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => void handleCopyWallet(employee)}
+                                      className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-hi text-[var(--muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                                      aria-label={`Copy wallet for ${employee.name}`}
+                                    >
+                                      <Copy className="h-4 w-4" aria-hidden />
+                                    </button>
+                                  ) : null}
+                                </div>
+                              </div>
+
+                              <div className="mt-4 flex flex-wrap gap-2">
+                                {onEditEmployee ? (
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      setEditSalary(employee.salary || 0);
+                                      setShowEditModal({ open: true, employee });
+                                    }}
+                                    className="inline-flex items-center gap-2 rounded-xl border border-hi px-3 py-2 text-sm font-semibold text-[var(--text)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                                  >
+                                    <Pencil className="h-4 w-4" aria-hidden />
+                                    Edit salary
+                                  </button>
+                                ) : null}
+                                {onRemoveEmployee ? (
+                                  <button
+                                    type="button"
+                                    onClick={() => setShowDeleteConfirm({ open: true, employee })}
+                                    className="inline-flex items-center gap-2 rounded-xl border border-[color:rgba(255,123,114,0.22)] px-3 py-2 text-sm font-semibold text-[var(--danger)] transition hover:bg-[color:rgba(255,123,114,0.08)]"
+                                  >
+                                    <Trash2 className="h-4 w-4" aria-hidden />
+                                    Remove
+                                  </button>
+                                ) : null}
+                              </div>
+                            </div>
+                          </div>
+                        </article>
+                      )}
+                    </Draggable>
+                  ))}
                   {provided.placeholder}
                 </div>
               )}
@@ -586,217 +592,225 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
 
       <div className={`hidden overflow-x-auto lg:block ${showEmptyState ? 'lg:hidden' : ''}`}>
         <DragDropContext onDragEnd={handleDragEnd}>
-        <table className="w-full table-fixed border-collapse text-left">
-          <thead>
-            <tr className="border-b border-hi">
-              {reorderMode && (
-                <th className="w-10 p-6" aria-label="Drag handle column" />
-              )}
-              {[
-                { key: 'name' as const, label: 'Name', width: 'w-[28%]' },
-                { key: 'position' as const, label: 'Role', width: 'w-[18%]' },
-                { key: 'wallet' as const, label: 'Wallet', width: 'w-[18%]' },
-                { key: 'salary' as const, label: 'Salary', width: 'w-[14%]' },
-                { key: 'status' as const, label: 'Status', width: '' },
-              ].map((column) => (
-                <th
-                  key={column.key}
-                  className={`${column.width} p-6`}
-                  aria-sort={
-                    !reorderMode && sortKey === column.key
-                      ? sortAsc
-                        ? 'ascending'
-                        : 'descending'
-                      : 'none'
-                  }
-                >
-                  <button
-                    type="button"
-                    disabled={reorderMode}
-                    className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[var(--muted)] disabled:cursor-default"
-                    onClick={() => !reorderMode && handleSort(column.key)}
-                    aria-label={`Sort by ${column.label}`}
+          <table className="w-full table-fixed border-collapse text-left">
+            <thead>
+              <tr className="border-b border-hi">
+                {reorderMode && <th className="w-10 p-6" aria-label="Drag handle column" />}
+                {[
+                  { key: 'name' as const, label: 'Name', width: 'w-[28%]' },
+                  { key: 'position' as const, label: 'Role', width: 'w-[18%]' },
+                  { key: 'wallet' as const, label: 'Wallet', width: 'w-[18%]' },
+                  { key: 'salary' as const, label: 'Salary', width: 'w-[14%]' },
+                  { key: 'status' as const, label: 'Status', width: '' },
+                ].map((column) => (
+                  <th
+                    key={column.key}
+                    className={`${column.width} p-6`}
+                    aria-sort={
+                      !reorderMode && sortKey === column.key
+                        ? sortAsc
+                          ? 'ascending'
+                          : 'descending'
+                        : 'none'
+                    }
                   >
-                    {column.label}
-                    {!reorderMode && <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />}
-                    {!reorderMode && sortKey === column.key ? (
-                      <span className="text-[var(--accent)]" aria-hidden>{sortAsc ? '▲' : '▼'}</span>
-                    ) : null}
-                  </button>
+                    <button
+                      type="button"
+                      disabled={reorderMode}
+                      className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[var(--muted)] disabled:cursor-default"
+                      onClick={() => !reorderMode && handleSort(column.key)}
+                      aria-label={`Sort by ${column.label}`}
+                    >
+                      {column.label}
+                      {!reorderMode && <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />}
+                      {!reorderMode && sortKey === column.key ? (
+                        <span className="text-[var(--accent)]" aria-hidden>
+                          {sortAsc ? '▲' : '▼'}
+                        </span>
+                      ) : null}
+                    </button>
+                  </th>
+                ))}
+                <th className="p-6 text-xs font-bold uppercase tracking-widest text-[var(--muted)]">
+                  Actions
                 </th>
-              ))}
-              <th className="p-6 text-xs font-bold uppercase tracking-widest text-[var(--muted)]">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <Droppable droppableId="employee-table" direction="vertical">
-            {(provided) => (
-              <tbody
-                className="divide-y divide-gray-200/5"
-                ref={provided.innerRef}
-                {...provided.droppableProps}
-              >
-                {isLoading
-                  ? Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
-                      <EmployeeSkeletonRow key={index} />
-                    ))
-                  : displayedEmployees.map((employee, index) => (
-                      <Draggable key={employee.id} draggableId={`table-${employee.id}`} index={index} isDragDisabled={!reorderMode}>
-                        {(dragProvided, dragSnapshot) => (
-                          <tr
-                            ref={dragProvided.innerRef}
-                            {...dragProvided.draggableProps}
-                            className={`group transition hover:bg-white/5 hover:bg-accent/[0.03] ${dragSnapshot.isDragging ? 'bg-[var(--surface-hi)] shadow-[0_8px_32px_rgba(74,240,184,0.15)]' : ''}`}
-                          >
-                            {reorderMode && (
-                              <td className="p-6 w-10">
-                                <div
-                                  {...dragProvided.dragHandleProps}
-                                  className="flex items-center justify-center cursor-grab active:cursor-grabbing text-[var(--muted)] hover:text-[var(--accent)]"
-                                  aria-label={`Drag to reorder ${employee.name}`}
-                                >
-                                  <GripVertical className="h-4 w-4" aria-hidden />
+              </tr>
+            </thead>
+            <Droppable droppableId="employee-table" direction="vertical">
+              {(provided) => (
+                <tbody
+                  className="divide-y divide-gray-200/5"
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                >
+                  {isLoading
+                    ? Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+                        <EmployeeSkeletonRow key={index} />
+                      ))
+                    : displayedEmployees.map((employee, index) => (
+                        <Draggable
+                          key={employee.id}
+                          draggableId={`table-${employee.id}`}
+                          index={index}
+                          isDragDisabled={!reorderMode}
+                        >
+                          {(dragProvided, dragSnapshot) => (
+                            <tr
+                              ref={dragProvided.innerRef}
+                              {...dragProvided.draggableProps}
+                              className={`group transition hover:bg-white/5 hover:bg-accent/[0.03] ${dragSnapshot.isDragging ? 'bg-[var(--surface-hi)] shadow-[0_8px_32px_rgba(74,240,184,0.15)]' : ''}`}
+                            >
+                              {reorderMode && (
+                                <td className="p-6 w-10">
+                                  <div
+                                    {...dragProvided.dragHandleProps}
+                                    className="flex items-center justify-center cursor-grab active:cursor-grabbing text-[var(--muted)] hover:text-[var(--accent)]"
+                                    aria-label={`Drag to reorder ${employee.name}`}
+                                  >
+                                    <GripVertical className="h-4 w-4" aria-hidden />
+                                  </div>
+                                </td>
+                              )}
+                              <td className="p-6">
+                                <div className="flex items-center gap-4">
+                                  <button
+                                    type="button"
+                                    onClick={() => setShowAvatarModal({ open: true, employee })}
+                                    className="relative rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+                                    aria-label={`Update photo for ${employee.name}`}
+                                  >
+                                    <Avatar
+                                      email={employee.email}
+                                      name={employee.name}
+                                      imageUrl={employee.imageUrl}
+                                      size="md"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      className={`absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-[var(--bg)] ${
+                                        employee.status === 'Inactive'
+                                          ? 'bg-[var(--danger)]'
+                                          : 'bg-[var(--success)]'
+                                      }`}
+                                    />
+                                  </button>
+
+                                  <div className="min-w-0 flex flex-col">
+                                    <button
+                                      type="button"
+                                      onClick={() => onEmployeeClick?.(employee)}
+                                      className="truncate text-left text-sm font-bold text-[var(--text)] transition-colors group-hover:text-[var(--accent)]"
+                                      title={employee.name}
+                                    >
+                                      {employee.name}
+                                    </button>
+                                    <span
+                                      className="truncate text-xs text-[var(--muted)]"
+                                      title={employee.email}
+                                    >
+                                      {employee.email}
+                                    </span>
+                                  </div>
                                 </div>
                               </td>
-                            )}
-                            <td className="p-6">
-                              <div className="flex items-center gap-4">
-                                <button
-                                  type="button"
-                                  onClick={() => setShowAvatarModal({ open: true, employee })}
-                                  className="relative rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
-                                  aria-label={`Update photo for ${employee.name}`}
-                                >
-                                  <Avatar
-                                    email={employee.email}
-                                    name={employee.name}
-                                    imageUrl={employee.imageUrl}
-                                    size="md"
-                                  />
-                                  <span
-                                    aria-hidden="true"
-                                    className={`absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-[var(--bg)] ${
-                                      employee.status === 'Inactive'
-                                        ? 'bg-[var(--danger)]'
-                                        : 'bg-[var(--success)]'
-                                    }`}
-                                  />
-                                </button>
-
-                                <div className="min-w-0 flex flex-col">
-                                  <button
-                                    type="button"
-                                    onClick={() => onEmployeeClick?.(employee)}
-                                    className="truncate text-left text-sm font-bold text-[var(--text)] transition-colors group-hover:text-[var(--accent)]"
-                                    title={employee.name}
-                                  >
-                                    {employee.name}
-                                  </button>
-                                  <span className="truncate text-xs text-[var(--muted)]" title={employee.email}>
-                                    {employee.email}
+                              <td className="p-6">
+                                <div className="flex flex-col">
+                                  <span className="truncate text-sm font-medium text-[var(--text)]">
+                                    {employee.position}
+                                  </span>
+                                  <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+                                    Position
                                   </span>
                                 </div>
-                              </div>
-                            </td>
-                            <td className="p-6">
-                              <div className="flex flex-col">
-                                <span className="truncate text-sm font-medium text-[var(--text)]">
-                                  {employee.position}
-                                </span>
-                                <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
-                                  Position
-                                </span>
-                              </div>
-                            </td>
-                            <td className="p-6">
-                              <div className="flex items-center gap-2">
-                                <code className="max-w-[10rem] truncate rounded-lg border border-[var(--border)] bg-[var(--surface-hi)] px-2 py-1 text-[10px] font-mono text-[var(--muted)]">
-                                  {employee.wallet ? shortenWallet(employee.wallet) : 'No wallet'}
-                                </code>
-                                {employee.wallet ? (
-                                  <button
-                                    type="button"
-                                    onClick={() => void handleCopyWallet(employee)}
-                                    className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-transparent text-[var(--muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
-                                    aria-label={`Copy wallet address for ${employee.name}`}
-                                  >
-                                    <Copy className="h-4 w-4" aria-hidden />
-                                  </button>
-                                ) : null}
-                              </div>
-                            </td>
-                            <td className="p-6">
-                              <div className="flex flex-col items-start">
-                                {onEditEmployee ? (
-                                  <button
-                                    type="button"
-                                    className="text-sm font-bold text-[var(--text)] transition-colors hover:text-[var(--accent)]"
-                                    aria-label={`Edit salary for ${employee.name}: $${(employee.salary ?? 0).toLocaleString()}`}
-                                    onClick={() => {
-                                      setEditSalary(employee.salary || 0);
-                                      setShowEditModal({ open: true, employee });
-                                    }}
-                                  >
-                                    ${(employee.salary ?? 0).toLocaleString()}
-                                  </button>
-                                ) : (
-                                  <span className="text-sm font-bold text-[var(--text)]">
-                                    ${(employee.salary ?? 0).toLocaleString()}
+                              </td>
+                              <td className="p-6">
+                                <div className="flex items-center gap-2">
+                                  <code className="max-w-[10rem] truncate rounded-lg border border-[var(--border)] bg-[var(--surface-hi)] px-2 py-1 text-[10px] font-mono text-[var(--muted)]">
+                                    {employee.wallet ? shortenWallet(employee.wallet) : 'No wallet'}
+                                  </code>
+                                  {employee.wallet ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => void handleCopyWallet(employee)}
+                                      className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-transparent text-[var(--muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                                      aria-label={`Copy wallet address for ${employee.name}`}
+                                    >
+                                      <Copy className="h-4 w-4" aria-hidden />
+                                    </button>
+                                  ) : null}
+                                </div>
+                              </td>
+                              <td className="p-6">
+                                <div className="flex flex-col items-start">
+                                  {onEditEmployee ? (
+                                    <button
+                                      type="button"
+                                      className="text-sm font-bold text-[var(--text)] transition-colors hover:text-[var(--accent)]"
+                                      aria-label={`Edit salary for ${employee.name}: $${(employee.salary ?? 0).toLocaleString()}`}
+                                      onClick={() => {
+                                        setEditSalary(employee.salary || 0);
+                                        setShowEditModal({ open: true, employee });
+                                      }}
+                                    >
+                                      ${(employee.salary ?? 0).toLocaleString()}
+                                    </button>
+                                  ) : (
+                                    <span className="text-sm font-bold text-[var(--text)]">
+                                      ${(employee.salary ?? 0).toLocaleString()}
+                                    </span>
+                                  )}
+                                  <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+                                    per month
                                   </span>
-                                )}
-                                <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
-                                  per month
+                                </div>
+                              </td>
+                              <td className="p-6">
+                                <span
+                                  className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${
+                                    employee.status === 'Inactive'
+                                      ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
+                                      : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
+                                  }`}
+                                >
+                                  {employee.status || 'Active'}
                                 </span>
-                              </div>
-                            </td>
-                            <td className="p-6">
-                              <span
-                                className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${
-                                  employee.status === 'Inactive'
-                                    ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
-                                    : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
-                                }`}
-                              >
-                                {employee.status || 'Active'}
-                              </span>
-                            </td>
-                            <td className="p-6">
-                              <div className="flex items-center gap-1 opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100">
-                                {onEditEmployee ? (
-                                  <button
-                                    type="button"
-                                    className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(74,240,184,0.10)] hover:text-[var(--accent)]"
-                                    aria-label={`Edit salary for ${employee.name}`}
-                                    onClick={() => {
-                                      setEditSalary(employee.salary || 0);
-                                      setShowEditModal({ open: true, employee });
-                                    }}
-                                  >
-                                    <Pencil className="h-4 w-4" aria-hidden />
-                                  </button>
-                                ) : null}
-                                {onRemoveEmployee ? (
-                                  <button
-                                    type="button"
-                                    className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(255,123,114,0.10)] hover:text-[var(--danger)]"
-                                    aria-label={`Remove ${employee.name}`}
-                                    onClick={() => setShowDeleteConfirm({ open: true, employee })}
-                                  >
-                                    <Trash2 className="h-4 w-4" aria-hidden />
-                                  </button>
-                                ) : null}
-                              </div>
-                            </td>
-                          </tr>
-                        )}
-                      </Draggable>
-                    ))}
-                {provided.placeholder}
-              </tbody>
-            )}
-          </Droppable>
-        </table>
+                              </td>
+                              <td className="p-6">
+                                <div className="flex items-center gap-1 opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100">
+                                  {onEditEmployee ? (
+                                    <button
+                                      type="button"
+                                      className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(74,240,184,0.10)] hover:text-[var(--accent)]"
+                                      aria-label={`Edit salary for ${employee.name}`}
+                                      onClick={() => {
+                                        setEditSalary(employee.salary || 0);
+                                        setShowEditModal({ open: true, employee });
+                                      }}
+                                    >
+                                      <Pencil className="h-4 w-4" aria-hidden />
+                                    </button>
+                                  ) : null}
+                                  {onRemoveEmployee ? (
+                                    <button
+                                      type="button"
+                                      className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(255,123,114,0.10)] hover:text-[var(--danger)]"
+                                      aria-label={`Remove ${employee.name}`}
+                                      onClick={() => setShowDeleteConfirm({ open: true, employee })}
+                                    >
+                                      <Trash2 className="h-4 w-4" aria-hidden />
+                                    </button>
+                                  ) : null}
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                        </Draggable>
+                      ))}
+                  {provided.placeholder}
+                </tbody>
+              )}
+            </Droppable>
+          </table>
         </DragDropContext>
       </div>
 

--- a/frontend/src/components/EmployeeProfileModal.tsx
+++ b/frontend/src/components/EmployeeProfileModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, User, Mail, Phone, MapPin, Briefcase, CreditCard } from 'lucide-react';
+import { X, User, Mail, Phone, Briefcase, CreditCard } from 'lucide-react';
 import { FormField } from './FormField';
 
 export interface EmployeeProfileData {

--- a/frontend/src/components/FormField.tsx
+++ b/frontend/src/components/FormField.tsx
@@ -43,11 +43,7 @@ export const FormField: React.FC<FormFieldProps> = ({
               required,
               'aria-required': required,
               'aria-invalid': hasError || undefined,
-              'aria-describedby': error
-                ? errorId
-                : helpText
-                  ? descriptionId
-                  : undefined,
+              'aria-describedby': error ? errorId : helpText ? descriptionId : undefined,
               className: [
                 typeof (children.props as Record<string, unknown>).className === 'string'
                   ? (children.props as Record<string, unknown>).className

--- a/frontend/src/components/SkeletonLoader.tsx
+++ b/frontend/src/components/SkeletonLoader.tsx
@@ -66,8 +66,7 @@ const WIDTH_MAP: Record<NonNullable<SkeletonTextProps['width']>, string> = {
 
 // ── Base shimmer element ──────────────────────────────────────────────────────
 
-const SHIMMER_BASE =
-  'animate-pulse rounded bg-zinc-800/70 relative overflow-hidden';
+const SHIMMER_BASE = 'animate-pulse rounded bg-zinc-800/70 relative overflow-hidden';
 
 // ── Renderers ─────────────────────────────────────────────────────────────────
 
@@ -107,11 +106,7 @@ function CardSkeleton({ count = 1, height = 32, className = '' }: SkeletonCardPr
   );
 }
 
-function TableRowSkeleton({
-  count = 3,
-  columns = 4,
-  className = '',
-}: SkeletonTableRowProps) {
+function TableRowSkeleton({ count = 3, columns = 4, className = '' }: SkeletonTableRowProps) {
   return (
     <>
       {Array.from({ length: count }, (_, rowIdx) => (

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -13,7 +13,11 @@ export const ThemeToggle = () => {
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
       aria-pressed={isDark}
     >
-      {isDark ? <Sun className="w-4 h-4" aria-hidden="true" /> : <Moon className="w-4 h-4" aria-hidden="true" />}
+      {isDark ? (
+        <Sun className="w-4 h-4" aria-hidden="true" />
+      ) : (
+        <Moon className="w-4 h-4" aria-hidden="true" />
+      )}
       <span className="sr-only">Current theme: {isDark ? 'Dark' : 'Light'}</span>
     </button>
   );

--- a/frontend/src/components/__tests__/CSVUploader.test.tsx
+++ b/frontend/src/components/__tests__/CSVUploader.test.tsx
@@ -29,9 +29,7 @@ describe('CSVUploader', () => {
   });
 
   test('renders upload zone with required columns info', () => {
-    render(
-      <CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
 
     expect(screen.getByRole('region', { name: /csv file upload/i })).toBeTruthy();
     expect(screen.getByText(/required columns:/i)).toBeTruthy();
@@ -39,9 +37,7 @@ describe('CSVUploader', () => {
   });
 
   test('upload zone has button role and is keyboard accessible', () => {
-    render(
-      <CSVUploader requiredColumns={['name']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name']} onDataParsed={vi.fn()} />);
 
     const zone = screen.getByRole('button', { name: /upload csv file/i });
     expect(zone).toBeTruthy();
@@ -52,7 +48,10 @@ describe('CSVUploader', () => {
     const onDataParsed = vi.fn();
     const csvContent = createCSVContent(
       ['name', 'email', 'amount'],
-      [['John', 'john@test.com', '100'], ['Jane', 'jane@test.com', '200']]
+      [
+        ['John', 'john@test.com', '100'],
+        ['Jane', 'jane@test.com', '200'],
+      ]
     );
     const file = createMockFile(csvContent);
 
@@ -78,9 +77,7 @@ describe('CSVUploader', () => {
     const blob = new Blob(['not a csv'], { type: 'text/plain' });
     const file = new File([blob], 'test.txt', { type: 'text/plain' });
 
-    render(
-      <CSVUploader requiredColumns={['name']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name']} onDataParsed={vi.fn()} />);
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
@@ -97,9 +94,7 @@ describe('CSVUploader', () => {
     const csvContent = createCSVContent(['name'], [['John']]);
     const file = createMockFile(csvContent);
 
-    render(
-      <CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
@@ -111,9 +106,7 @@ describe('CSVUploader', () => {
   });
 
   test('shows drag state on drag enter', () => {
-    render(
-      <CSVUploader requiredColumns={['name']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name']} onDataParsed={vi.fn()} />);
 
     const zone = screen.getByRole('button', { name: /upload csv file/i });
     fireEvent.dragEnter(zone);
@@ -125,13 +118,14 @@ describe('CSVUploader', () => {
     const onDataParsed = vi.fn();
     const csvContent = createCSVContent(
       ['name', 'email'],
-      [['John', ''], ['', 'jane@test.com']]
+      [
+        ['John', ''],
+        ['', 'jane@test.com'],
+      ]
     );
     const file = createMockFile(csvContent);
 
-    render(
-      <CSVUploader requiredColumns={['name', 'email']} onDataParsed={onDataParsed} />
-    );
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={onDataParsed} />);
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
@@ -147,10 +141,7 @@ describe('CSVUploader', () => {
 
   test('runs custom validators on parsed data', async () => {
     const onDataParsed = vi.fn();
-    const csvContent = createCSVContent(
-      ['name', 'amount'],
-      [['John', '50']]
-    );
+    const csvContent = createCSVContent(['name', 'amount'], [['John', '50']]);
     const file = createMockFile(csvContent);
     const validators = {
       amount: (value: string) => {
@@ -179,15 +170,10 @@ describe('CSVUploader', () => {
   });
 
   test('shows success notification on valid parse', async () => {
-    const csvContent = createCSVContent(
-      ['name', 'email'],
-      [['John', 'john@test.com']]
-    );
+    const csvContent = createCSVContent(['name', 'email'], [['John', 'john@test.com']]);
     const file = createMockFile(csvContent);
 
-    render(
-      <CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
@@ -203,13 +189,14 @@ describe('CSVUploader', () => {
   test('shows file summary after successful parse', async () => {
     const csvContent = createCSVContent(
       ['name', 'email'],
-      [['John', 'john@test.com'], ['Jane', 'jane@test.com']]
+      [
+        ['John', 'john@test.com'],
+        ['Jane', 'jane@test.com'],
+      ]
     );
     const file = createMockFile(csvContent);
 
-    render(
-      <CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
@@ -222,15 +209,10 @@ describe('CSVUploader', () => {
   });
 
   test('displays data preview table after parsing', async () => {
-    const csvContent = createCSVContent(
-      ['name', 'email'],
-      [['John', 'john@test.com']]
-    );
+    const csvContent = createCSVContent(['name', 'email'], [['John', 'john@test.com']]);
     const file = createMockFile(csvContent);
 
-    render(
-      <CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
@@ -246,9 +228,7 @@ describe('CSVUploader', () => {
     const csvContent = 'name,name,email\nJohn,Smith,john@test.com';
     const file = createMockFile(csvContent);
 
-    render(
-      <CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />
-    );
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });

--- a/frontend/src/components/__tests__/PageErrorFallback.test.tsx
+++ b/frontend/src/components/__tests__/PageErrorFallback.test.tsx
@@ -26,12 +26,7 @@ describe('PageErrorFallback', () => {
   });
 
   test('renders custom title and description when provided', () => {
-    render(
-      <PageErrorFallback
-        title="Custom Error"
-        description="A custom error occurred"
-      />
-    );
+    render(<PageErrorFallback title="Custom Error" description="A custom error occurred" />);
 
     expect(screen.getByText('Custom Error')).toBeTruthy();
     expect(screen.getByText('A custom error occurred')).toBeTruthy();

--- a/frontend/src/components/__tests__/SkeletonLoader.test.tsx
+++ b/frontend/src/components/__tests__/SkeletonLoader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { SkeletonLoader } from '../SkeletonLoader';
 

--- a/frontend/src/components/common/Toast/ToastItem.tsx
+++ b/frontend/src/components/common/Toast/ToastItem.tsx
@@ -24,11 +24,16 @@ export const ToastItem: React.FC<ToastItemProps> = ({ toast, removeToast }) => {
 
   const getBgColor = () => {
     switch (toast.type) {
-      case 'success': return 'bg-green-50 border-green-200 text-green-800';
-      case 'error': return 'bg-red-50 border-red-200 text-red-800';
-      case 'warning': return 'bg-yellow-50 border-yellow-200 text-yellow-800';
-      case 'info': return 'bg-blue-50 border-blue-200 text-blue-800';
-      default: return 'bg-white border-gray-200 text-gray-800';
+      case 'success':
+        return 'bg-green-50 border-green-200 text-green-800';
+      case 'error':
+        return 'bg-red-50 border-red-200 text-red-800';
+      case 'warning':
+        return 'bg-yellow-50 border-yellow-200 text-yellow-800';
+      case 'info':
+        return 'bg-blue-50 border-blue-200 text-blue-800';
+      default:
+        return 'bg-white border-gray-200 text-gray-800';
     }
   };
 
@@ -51,7 +56,11 @@ export const ToastItem: React.FC<ToastItemProps> = ({ toast, removeToast }) => {
           aria-label="Close notification"
         >
           <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+            <path
+              fillRule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            />
           </svg>
         </button>
       </div>

--- a/frontend/src/components/payroll/PayrollScheduleForm.tsx
+++ b/frontend/src/components/payroll/PayrollScheduleForm.tsx
@@ -6,7 +6,7 @@ import { useToast } from '../../hooks/useToast';
 
 export const PayrollScheduleForm: React.FC = () => {
   const { showSuccess, showError } = useToast();
-  
+
   const [formData, setFormData] = useState({
     name: '',
     startDate: '',
@@ -37,7 +37,7 @@ export const PayrollScheduleForm: React.FC = () => {
       showError('Please fill in all required fields.', 'Validation Error');
       return;
     }
-    
+
     setIsLoading(true);
     try {
       await new Promise((resolve) => setTimeout(resolve, 1500));
@@ -71,13 +71,20 @@ export const PayrollScheduleForm: React.FC = () => {
   }
 
   return (
-    <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-8 max-w-4xl">
+    <form
+      onSubmit={(e) => {
+        void handleSubmit(e);
+      }}
+      className="space-y-8 max-w-4xl"
+    >
       <div className="bg-white shadow rounded-lg p-6">
         <h2 className="text-xl font-semibold mb-6">Payroll Schedule Configuration</h2>
-        
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="col-span-2 md:col-span-1">
-            <label className="block text-sm font-medium text-gray-700 mb-1">Payroll Name <span className="text-red-500">*</span></label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Payroll Name <span className="text-red-500">*</span>
+            </label>
             <input
               type="text"
               name="name"
@@ -87,7 +94,7 @@ export const PayrollScheduleForm: React.FC = () => {
               placeholder="e.g. Full Time Employees Monthly"
             />
           </div>
-          
+
           <div className="col-span-2 md:col-span-1">
             <label className="block text-sm font-medium text-gray-700 mb-1">Employee Group</label>
             <select
@@ -104,12 +111,19 @@ export const PayrollScheduleForm: React.FC = () => {
           </div>
 
           <div className="col-span-2">
-            <label className="block text-sm font-medium text-gray-700 mb-3">Schedule Frequency <span className="text-red-500">*</span></label>
-            <ScheduleFrequencySelector value={formData.frequency} onChange={handleFrequencyChange} />
+            <label className="block text-sm font-medium text-gray-700 mb-3">
+              Schedule Frequency <span className="text-red-500">*</span>
+            </label>
+            <ScheduleFrequencySelector
+              value={formData.frequency}
+              onChange={handleFrequencyChange}
+            />
           </div>
 
           <div className="col-span-2 md:col-span-1">
-            <label className="block text-sm font-medium text-gray-700 mb-1">Start Date <span className="text-red-500">*</span></label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Start Date <span className="text-red-500">*</span>
+            </label>
             <input
               type="date"
               name="startDate"
@@ -145,7 +159,7 @@ export const PayrollScheduleForm: React.FC = () => {
               </select>
             </div>
           </div>
-          
+
           <div className="col-span-2">
             <label className="flex items-center text-sm font-medium text-gray-700">
               <input
@@ -183,9 +197,25 @@ export const PayrollScheduleForm: React.FC = () => {
           className="bg-indigo-600 text-white px-6 py-2 rounded-md hover:bg-indigo-700 disabled:opacity-50 flex items-center"
         >
           {isLoading ? (
-            <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            <svg
+              className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              ></circle>
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
             </svg>
           ) : null}
           {isLoading ? 'Saving...' : 'Save Schedule'}

--- a/frontend/src/components/payroll/PayrollScheduleForm.tsx
+++ b/frontend/src/components/payroll/PayrollScheduleForm.tsx
@@ -43,7 +43,7 @@ export const PayrollScheduleForm: React.FC = () => {
       await new Promise((resolve) => setTimeout(resolve, 1500));
       setIsSaved(true);
       showSuccess('Payroll schedule configured successfully!', 'Success');
-    } catch (err) {
+    } catch {
       showError('Failed to save schedule.', 'Server Error');
     } finally {
       setIsLoading(false);
@@ -71,7 +71,7 @@ export const PayrollScheduleForm: React.FC = () => {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-8 max-w-4xl">
+    <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-8 max-w-4xl">
       <div className="bg-white shadow rounded-lg p-6">
         <h2 className="text-xl font-semibold mb-6">Payroll Schedule Configuration</h2>
         

--- a/frontend/src/components/payroll/SchedulePreview.tsx
+++ b/frontend/src/components/payroll/SchedulePreview.tsx
@@ -11,7 +11,7 @@ export const SchedulePreview: React.FC<Props> = ({ startDate, frequency }) => {
     if (!startDate) return [];
     const dates = [];
     const current = new Date(startDate);
-    
+
     for (let i = 0; i < 5; i++) {
       dates.push(new Date(current));
       if (frequency === 'weekly') {
@@ -42,7 +42,12 @@ export const SchedulePreview: React.FC<Props> = ({ startDate, frequency }) => {
             <span className="w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 flex items-center justify-center text-xs mr-3 font-semibold">
               {index + 1}
             </span>
-            {date.toLocaleDateString(undefined, { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' })}
+            {date.toLocaleDateString(undefined, {
+              weekday: 'short',
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })}
           </li>
         ))}
       </ul>

--- a/frontend/src/components/payroll/SchedulePreview.tsx
+++ b/frontend/src/components/payroll/SchedulePreview.tsx
@@ -10,7 +10,7 @@ export const SchedulePreview: React.FC<Props> = ({ startDate, frequency }) => {
   const getUpcomingDates = () => {
     if (!startDate) return [];
     const dates = [];
-    let current = new Date(startDate);
+    const current = new Date(startDate);
     
     for (let i = 0; i < 5; i++) {
       dates.push(new Date(current));

--- a/frontend/src/components/payroll/ScheduleSummaryCard.tsx
+++ b/frontend/src/components/payroll/ScheduleSummaryCard.tsx
@@ -10,7 +10,14 @@ interface Props {
   group: string;
 }
 
-export const ScheduleSummaryCard: React.FC<Props> = ({ name, frequency, startDate, time, timezone, group }) => {
+export const ScheduleSummaryCard: React.FC<Props> = ({
+  name,
+  frequency,
+  startDate,
+  time,
+  timezone,
+  group,
+}) => {
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden h-full flex flex-col">
       <div className="px-4 py-5 sm:px-6 bg-gray-50 border-b border-gray-200">
@@ -20,21 +27,28 @@ export const ScheduleSummaryCard: React.FC<Props> = ({ name, frequency, startDat
         <dl className="divide-y divide-gray-200">
           <div className="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
             <dt className="text-sm font-medium text-gray-500">Name</dt>
-            <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2 font-medium">{name || '-'}</dd>
+            <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2 font-medium">
+              {name || '-'}
+            </dd>
           </div>
           <div className="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
             <dt className="text-sm font-medium text-gray-500">Frequency</dt>
-            <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2 capitalize">{frequency}</dd>
+            <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2 capitalize">
+              {frequency}
+            </dd>
           </div>
           <div className="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
             <dt className="text-sm font-medium text-gray-500">First Run</dt>
             <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-              {startDate ? new Date(startDate).toLocaleDateString() : '-'} at {time || '-'} ({timezone})
+              {startDate ? new Date(startDate).toLocaleDateString() : '-'} at {time || '-'} (
+              {timezone})
             </dd>
           </div>
           <div className="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
             <dt className="text-sm font-medium text-gray-500">Group</dt>
-            <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2 capitalize">{group.replace('-', ' ') || '-'}</dd>
+            <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2 capitalize">
+              {group.replace('-', ' ') || '-'}
+            </dd>
           </div>
         </dl>
       </div>

--- a/frontend/src/hooks/useContractMetrics.ts
+++ b/frontend/src/hooks/useContractMetrics.ts
@@ -84,8 +84,9 @@ async function simulateReadCall(
   sourceAccount: string,
   network: NetworkType
 ): Promise<unknown> {
-  const { rpc, Contract, TransactionBuilder, Networks, BASE_FEE, scValToNative } =
-    await import('@stellar/stellar-sdk');
+  const { rpc, Contract, TransactionBuilder, Networks, BASE_FEE, scValToNative } = await import(
+    '@stellar/stellar-sdk'
+  );
 
   const rpcUrl =
     network === 'mainnet'
@@ -176,7 +177,9 @@ export function useContractMetrics(
               ? val.toString()
               : val == null
                 ? '—'
-                : typeof val === 'object' ? JSON.stringify(val) : String(val as string | number | symbol);
+                : typeof val === 'object'
+                  ? JSON.stringify(val)
+                  : String(val as string | number | symbol);
         return { label, value: display, status: 'ok' };
       } catch {
         return errorMetric(label);

--- a/frontend/src/hooks/useContractMetrics.ts
+++ b/frontend/src/hooks/useContractMetrics.ts
@@ -84,7 +84,7 @@ async function simulateReadCall(
   sourceAccount: string,
   network: NetworkType
 ): Promise<unknown> {
-  const { rpc, Contract, TransactionBuilder, Networks, BASE_FEE, xdr, nativeToScVal, scValToNative } =
+  const { rpc, Contract, TransactionBuilder, Networks, BASE_FEE, scValToNative } =
     await import('@stellar/stellar-sdk');
 
   const rpcUrl =
@@ -176,7 +176,7 @@ export function useContractMetrics(
               ? val.toString()
               : val == null
                 ? '—'
-                : String(val);
+                : typeof val === 'object' ? JSON.stringify(val) : String(val as string | number | symbol);
         return { label, value: display, status: 'ok' };
       } catch {
         return errorMetric(label);

--- a/frontend/src/pages/CrossAssetPayment.tsx
+++ b/frontend/src/pages/CrossAssetPayment.tsx
@@ -206,7 +206,9 @@ export default function CrossAssetPayment() {
                 Selected route
               </p>
               <p className="mt-2 text-sm font-semibold text-white">
-                {selectedPath ? selectedPath.hops.join(' -> ') : 'Choose a path after entering an amount'}
+                {selectedPath
+                  ? selectedPath.hops.join(' -> ')
+                  : 'Choose a path after entering an amount'}
               </p>
             </div>
             <div className="rounded-2xl border border-zinc-800 bg-black/20 p-4">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -74,7 +74,9 @@ export default function Home() {
                 <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-muted">
                   Employee ops
                 </p>
-                <p className="mt-2 text-sm font-semibold text-text">Onboard without context loss.</p>
+                <p className="mt-2 text-sm font-semibold text-text">
+                  Onboard without context loss.
+                </p>
               </div>
               <div className="glass noise rounded-2xl border border-hi px-4 py-3 text-left">
                 <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-muted">
@@ -112,7 +114,9 @@ export default function Home() {
                       <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-muted">
                         Payments
                       </p>
-                      <p className="mt-1 text-sm font-semibold text-text">Single-transaction flow</p>
+                      <p className="mt-1 text-sm font-semibold text-text">
+                        Single-transaction flow
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -125,7 +129,9 @@ export default function Home() {
                       <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-muted">
                         Roster
                       </p>
-                      <p className="mt-1 text-sm font-semibold text-text">Keep employee data current</p>
+                      <p className="mt-1 text-sm font-semibold text-text">
+                        Keep employee data current
+                      </p>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/PayrollAnalytics.tsx
+++ b/frontend/src/pages/PayrollAnalytics.tsx
@@ -104,12 +104,12 @@ function presetDates(months: number): { start: string; end: string } {
 async function fetchAnalytics(
   startDate: string,
   endDate: string,
-  organizationId: number,
+  organizationId: number
 ): Promise<AnalyticsData> {
   try {
     const { data } = await axiosInstance.get<{ success: boolean; data: AnalyticsData }>(
       '/api/v1/analytics/payroll',
-      { params: { organizationId, startDate, endDate } },
+      { params: { organizationId, startDate, endDate } }
     );
     if (data.success) return data.data;
     throw new Error('API returned success: false');
@@ -215,15 +215,12 @@ export default function PayrollAnalytics() {
     staleTime: 5 * 60 * 1000,
   });
 
-  const applyPreset = useCallback(
-    (months: number, label: string) => {
-      const { start, end } = presetDates(months);
-      setStartDate(start);
-      setEndDate(end);
-      setActivePreset(label);
-    },
-    [],
-  );
+  const applyPreset = useCallback((months: number, label: string) => {
+    const { start, end } = presetDates(months);
+    setStartDate(start);
+    setEndDate(end);
+    setActivePreset(label);
+  }, []);
 
   const handleStartChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setStartDate(e.target.value);
@@ -244,7 +241,6 @@ export default function PayrollAnalytics() {
   return (
     <div className="flex w-full flex-1 flex-col items-center justify-start px-4 py-6 sm:px-6 lg:px-8">
       <div className="w-full max-w-7xl space-y-6 sm:space-y-8">
-
         {/* Header */}
         <div className="card glass noise border-[var(--border-hi)] p-6 sm:p-8">
           <p className="text-[11px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
@@ -619,7 +615,12 @@ export default function PayrollAnalytics() {
                       <YAxis tick={{ fontSize: 12, fill: 'var(--muted)' }} stroke="var(--border)" />
                       <Tooltip contentStyle={tooltipStyle} />
                       <SafeLegend />
-                      <Bar dataKey="success" name="Successful" fill="#22d3ee" radius={[4, 4, 0, 0]} />
+                      <Bar
+                        dataKey="success"
+                        name="Successful"
+                        fill="#22d3ee"
+                        radius={[4, 4, 0, 0]}
+                      />
                       <Bar dataKey="failure" name="Failed" fill="#f87171" radius={[4, 4, 0, 0]} />
                       <Bar dataKey="pending" name="Pending" fill="#f59e0b" radius={[4, 4, 0, 0]} />
                     </BarChart>
@@ -639,13 +640,20 @@ export default function PayrollAnalytics() {
                     <p className="text-xs text-[var(--muted)] mb-4">
                       Total expenditure and headcount per department
                     </p>
-                    <ResponsiveContainer width="100%" height={Math.max(220, data.departmentBreakdown.length * 44)}>
+                    <ResponsiveContainer
+                      width="100%"
+                      height={Math.max(220, data.departmentBreakdown.length * 44)}
+                    >
                       <BarChart
                         data={data.departmentBreakdown}
                         layout="vertical"
                         margin={{ left: 20 }}
                       >
-                        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" horizontal={false} />
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          stroke="var(--border)"
+                          horizontal={false}
+                        />
                         <XAxis
                           type="number"
                           tick={{ fontSize: 12, fill: 'var(--muted)' }}
@@ -663,15 +671,25 @@ export default function PayrollAnalytics() {
                           formatter={(v: RechartsValue, name: string) => {
                             if (name === 'Total ($)') {
                               const num = Number(Array.isArray(v) ? v[0] : (v ?? 0));
-                          return [`$${Math.round(num).toLocaleString()}`, name];
+                              return [`$${Math.round(num).toLocaleString()}`, name];
                             }
                             return [v, name];
                           }}
                           contentStyle={tooltipStyle}
                         />
                         <SafeLegend />
-                        <Bar dataKey="total" name="Total ($)" fill="#6366f1" radius={[0, 4, 4, 0]} />
-                        <Bar dataKey="headcount" name="Headcount" fill="#22d3ee" radius={[0, 4, 4, 0]} />
+                        <Bar
+                          dataKey="total"
+                          name="Total ($)"
+                          fill="#6366f1"
+                          radius={[0, 4, 4, 0]}
+                        />
+                        <Bar
+                          dataKey="headcount"
+                          name="Headcount"
+                          fill="#22d3ee"
+                          radius={[0, 4, 4, 0]}
+                        />
                       </BarChart>
                     </ResponsiveContainer>
                   </div>

--- a/frontend/src/pages/PayrollScheduler.tsx
+++ b/frontend/src/pages/PayrollScheduler.tsx
@@ -13,7 +13,6 @@ import { AutosaveIndicator } from '../components/AutosaveIndicator';
 import { BulkPaymentStatusTracker } from '../components/BulkPaymentStatusTracker';
 import { CountdownTimer } from '../components/CountdownTimer';
 import { FormField } from '../components/FormField';
-import { SchedulingWizard } from '../components/SchedulingWizard';
 import { PayrollScheduleForm } from '../components/payroll/PayrollScheduleForm';
 import { TransactionSimulationPanel } from '../components/TransactionSimulationPanel';
 import { useAutosave } from '../hooks/useAutosave';
@@ -143,20 +142,6 @@ export default function PayrollScheduler() {
       // Ignore invalid local storage payloads.
     }
   }, []);
-
-  const handleScheduleComplete = (config: SchedulingConfig) => {
-    setActiveSchedule(config);
-    setIsWizardOpen(false);
-    notifySuccess(
-      'Payroll schedule configured!',
-      `Frequency: ${config.frequency}, time: ${config.timeOfDay}`
-    );
-
-    // Persist config so the countdown survives refresh.
-    localStorage.setItem(scheduleStorageKey, JSON.stringify(config));
-
-    setNextRunDate(computeNextRunDate(config, new Date()));
-  };
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>

--- a/frontend/src/pages/RevenueSplitDashboard.tsx
+++ b/frontend/src/pages/RevenueSplitDashboard.tsx
@@ -291,7 +291,9 @@ export default function RevenueSplitDashboard() {
               {totalAllocation.toFixed(2)}%
             </p>
             <p className="mt-2 text-sm text-[var(--muted)]">
-              {isAllocationTotalValid ? 'Balanced and ready to submit.' : 'Adjust entries to hit 100%.'}
+              {isAllocationTotalValid
+                ? 'Balanced and ready to submit.'
+                : 'Adjust entries to hit 100%.'}
             </p>
           </div>
           <div className="rounded-2xl border border-[var(--border-hi)] bg-black/10 p-4">
@@ -464,7 +466,9 @@ export default function RevenueSplitDashboard() {
               disabled={isSaving || !isAllocationTotalValid}
               className="rounded-xl bg-accent px-4 py-2 font-bold text-black disabled:opacity-70"
             >
-              {isSaving ? t('revenueSplitDashboard.submitting') : t('revenueSplitDashboard.editAllocations')}
+              {isSaving
+                ? t('revenueSplitDashboard.submitting')
+                : t('revenueSplitDashboard.editAllocations')}
             </button>
           </div>
 
@@ -510,7 +514,9 @@ export default function RevenueSplitDashboard() {
             ) : null}
           </div>
           {events.length === 0 ? (
-            <p className="text-sm text-[var(--muted)]">No backend indexed distribution events found.</p>
+            <p className="text-sm text-[var(--muted)]">
+              No backend indexed distribution events found.
+            </p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,11 +1,8 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Globe, Check } from 'lucide-react';
 
 export default function Settings() {
   const { t, i18n } = useTranslation();
-  const { theme, toggleTheme } = useTheme();
-  const [languageLoading, setLanguageLoading] = useState(false);
 
   const languages = [
     { code: 'en', name: t('settings.languageEnglish'), nativeName: 'English' },
@@ -97,6 +94,6 @@ export default function Settings() {
           </div>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/providers/ToastProvider.tsx
+++ b/frontend/src/providers/ToastProvider.tsx
@@ -23,13 +23,31 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     });
   }, []);
 
-  const showSuccess = useCallback((message: string, title?: string, duration?: number) => showToast({ type: 'success', message, title, duration }), [showToast]);
-  const showError = useCallback((message: string, title?: string, duration?: number) => showToast({ type: 'error', message, title, duration }), [showToast]);
-  const showWarning = useCallback((message: string, title?: string, duration?: number) => showToast({ type: 'warning', message, title, duration }), [showToast]);
-  const showInfo = useCallback((message: string, title?: string, duration?: number) => showToast({ type: 'info', message, title, duration }), [showToast]);
+  const showSuccess = useCallback(
+    (message: string, title?: string, duration?: number) =>
+      showToast({ type: 'success', message, title, duration }),
+    [showToast]
+  );
+  const showError = useCallback(
+    (message: string, title?: string, duration?: number) =>
+      showToast({ type: 'error', message, title, duration }),
+    [showToast]
+  );
+  const showWarning = useCallback(
+    (message: string, title?: string, duration?: number) =>
+      showToast({ type: 'warning', message, title, duration }),
+    [showToast]
+  );
+  const showInfo = useCallback(
+    (message: string, title?: string, duration?: number) =>
+      showToast({ type: 'info', message, title, duration }),
+    [showToast]
+  );
 
   return (
-    <ToastContext.Provider value={{ toasts, showToast, showSuccess, showError, showWarning, showInfo, removeToast }}>
+    <ToastContext.Provider
+      value={{ toasts, showToast, showSuccess, showError, showWarning, showInfo, removeToast }}
+    >
       {children}
       <ToastContainer toasts={toasts} removeToast={removeToast} />
     </ToastContext.Provider>

--- a/frontend/src/services/transactionHistoryApi.ts
+++ b/frontend/src/services/transactionHistoryApi.ts
@@ -40,10 +40,7 @@ import axiosInstance from '../api/axiosInstance';
  */
 export function categorizeError(error: unknown): ErrorState {
   // Network errors (fetch failures, timeouts, DNS issues)
-  if (
-    error instanceof TypeError ||
-    (error instanceof Error && error.message?.includes('fetch'))
-  ) {
+  if (error instanceof TypeError || (error instanceof Error && error.message?.includes('fetch'))) {
     return {
       type: 'network',
       message: 'Unable to connect. Please check your internet connection.',

--- a/frontend/src/services/transactionHistoryApi.ts
+++ b/frontend/src/services/transactionHistoryApi.ts
@@ -23,7 +23,6 @@ import type {
   ContractEvent,
 } from '../types/transactionHistory';
 import axiosInstance from '../api/axiosInstance';
-import { AxiosError } from 'axios';
 
 // ============================================================================
 // Configuration
@@ -43,9 +42,7 @@ export function categorizeError(error: unknown): ErrorState {
   // Network errors (fetch failures, timeouts, DNS issues)
   if (
     error instanceof TypeError ||
-    (error as any).name === 'TypeError' ||
-    (error instanceof Error && error.message?.includes('fetch')) ||
-    (error as any).message?.includes('fetch')
+    (error instanceof Error && error.message?.includes('fetch'))
   ) {
     return {
       type: 'network',
@@ -128,7 +125,7 @@ export async function fetchAuditRecords(
 
     return response.data;
   } catch (error) {
-    if ((error as any).name === 'CanceledError') {
+    if (error instanceof Error && error.name === 'CanceledError') {
       throw new Error('The operation was aborted.');
     }
 
@@ -174,7 +171,7 @@ export async function fetchContractEvents(
 
     return response.data;
   } catch (error) {
-    if ((error as any).name === 'CanceledError') {
+    if (error instanceof Error && error.name === 'CanceledError') {
       throw new Error('The operation was aborted.');
     }
 


### PR DESCRIPTION
## Summary

- `GET /api/v1/db-scaling/table-io-stats` — per-table I/O snapshot from `pg_statio_user_tables` covering heap, index, and TOAST block reads vs buffer-cache hits, with a computed `heapCacheHitRatio` to surface cache-cold tables
- `GET /api/v1/db-scaling/index-usage-stats` — per-index access snapshot from `pg_stat_user_indexes` showing scan count, rows read, and rows fetched; ordered by scan frequency to identify hot and unused indexes
- Both endpoints accept `?limit` query param (default 30, max 100)

## Acceptance Criteria

- [x] API endpoints are functional and tested
- [x] Proper error responses: 400 on invalid `limit`, 500 via `next(err)` on service failure
- [x] No schema changes — both endpoints query built-in PostgreSQL system views; no migration required
- [x] Integration tests: happy path, invalid-limit 400, and service-throws 500 for each endpoint (6 tests total)

Closes #739