### PR TITLE
feat(frontend,backend): skeleton table loaders and admin 2FA enforcement

### DIFF
--- a/backend/src/controllers/__tests__/organizationController.test.ts
+++ b/backend/src/controllers/__tests__/organizationController.test.ts
@@ -25,6 +25,14 @@ jest.mock('../../middlewares/rbac.js', () => ({
   isolateOrganization: (_req: any, _res: any, next: any) => next(),
 }));
 
+// Pass-through the admin 2FA gate here so these tests stay focused on the
+// controller. The gate itself is covered in require2faForAdmin.test.ts.
+jest.mock('../../middlewares/require2faForAdmin.js', () => ({
+  __esModule: true,
+  require2FAForAdmin: (_req: any, _res: any, next: any) => next(),
+  default: (_req: any, _res: any, next: any) => next(),
+}));
+
 // ── Database mock ─────────────────────────────────────────────────────────────
 const mockQuery = jest.fn();
 jest.mock('../../config/database.js', () => ({

--- a/backend/src/db/migrations/052_api_database_scaling_part23.sql
+++ b/backend/src/db/migrations/052_api_database_scaling_part23.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- Migration 052: API & Database Scaling – Part 23
+-- Purpose : Add composite / partial indexes that accelerate the highest-traffic
+--           dashboard query paths:
+--             * Payroll run lists filtered by organization + status, newest-first
+--               (BulkPaymentStatusTracker, payroll dashboards).
+--             * Fast lookup of failed payroll items for the retry flow.
+--           These are read-path optimizations only — no schema or data changes.
+--           Closes Issue #713 – API & Database Scaling Part 23 (ref #268).
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Payroll runs: org + status + recency
+--    Backs the default "runs for my org, newest first, filtered by status"
+--    query used by the bulk-payment status tracker and payroll dashboards.
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_payroll_runs_org_status_created
+  ON payroll_runs (organization_id, status, created_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- 2. Payroll items: failed-item fast path
+--    Partial index so the "retry failed payments" flow can locate failed items
+--    for a run without scanning completed/pending rows.
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_payroll_items_failed
+  ON payroll_items (payroll_run_id)
+  WHERE status = 'failed';
+
+-- ---------------------------------------------------------------------------
+-- 3. Comments
+-- ---------------------------------------------------------------------------
+
+COMMENT ON INDEX idx_payroll_runs_org_status_created IS
+  'Covers org-scoped, status-filtered, newest-first payroll run listings.';
+COMMENT ON INDEX idx_payroll_items_failed IS
+  'Partial index over failed payroll items, used by the payment retry flow.';

--- a/backend/src/db/rollbacks/052_api_database_scaling_part23.sql
+++ b/backend/src/db/rollbacks/052_api_database_scaling_part23.sql
@@ -1,0 +1,4 @@
+-- Rollback for Migration 052: API & Database Scaling – Part 23
+
+DROP INDEX IF EXISTS idx_payroll_items_failed;
+DROP INDEX IF EXISTS idx_payroll_runs_org_status_created;

--- a/backend/src/middlewares/__tests__/require2faForAdmin.test.ts
+++ b/backend/src/middlewares/__tests__/require2faForAdmin.test.ts
@@ -1,0 +1,142 @@
+import { Request, Response, NextFunction } from 'express';
+
+// ── Database mock ─────────────────────────────────────────────────────────────
+const mockQuery = jest.fn();
+jest.mock('../../config/database.js', () => ({
+  pool: { query: (...args: unknown[]) => mockQuery(...args) },
+}));
+
+// ── otplib mock ───────────────────────────────────────────────────────────────
+const mockCheck = jest.fn();
+jest.mock('@otplib/preset-default', () => ({
+  authenticator: { check: (...args: unknown[]) => mockCheck(...args) },
+}));
+
+import { require2FAForAdmin } from '../require2faForAdmin.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function mockRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return {
+    user: { id: 1, organizationId: 42, role: 'EMPLOYER', email: 'admin@acme.com' },
+    headers: {},
+    body: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+describe('require2FAForAdmin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when no authenticated user is present', async () => {
+    const req = mockReq({ user: undefined });
+    const res = mockRes();
+    const next = jest.fn() as NextFunction;
+
+    await require2FAForAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the admin has not enabled 2FA', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ is_2fa_enabled: false, totp_secret: null, recovery_codes: null }],
+    });
+    const req = mockReq({ headers: { 'x-2fa-token': '123456' } });
+    const res = mockRes();
+    const next = jest.fn() as NextFunction;
+
+    await require2FAForAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when 2FA is enabled but no token is supplied', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ is_2fa_enabled: true, totp_secret: 'SECRET', recovery_codes: [] }],
+    });
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn() as NextFunction;
+
+    await require2FAForAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next() for a valid TOTP token', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ is_2fa_enabled: true, totp_secret: 'SECRET', recovery_codes: [] }],
+    });
+    mockCheck.mockReturnValue(true);
+    const req = mockReq({ headers: { 'x-2fa-token': '123456' } });
+    const res = mockRes();
+    const next = jest.fn() as NextFunction;
+
+    await require2FAForAdmin(req, res, next);
+
+    expect(mockCheck).toHaveBeenCalledWith('123456', 'SECRET');
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for an invalid TOTP token', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ is_2fa_enabled: true, totp_secret: 'SECRET', recovery_codes: [] }],
+    });
+    mockCheck.mockReturnValue(false);
+    const req = mockReq({ body: { twoFactorToken: '000000' } });
+    const res = mockRes();
+    const next = jest.fn() as NextFunction;
+
+    await require2FAForAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('accepts a recovery code and consumes it (single-use)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ is_2fa_enabled: true, totp_secret: 'SECRET', recovery_codes: ['ABC123', 'XYZ789'] }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // UPDATE consuming the code
+    const req = mockReq({ headers: { 'x-2fa-token': 'abc123' } });
+    const res = mockRes();
+    const next = jest.fn() as NextFunction;
+
+    await require2FAForAdmin(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    // The consumed code is removed, leaving only the unused one.
+    expect(mockQuery).toHaveBeenLastCalledWith(
+      'UPDATE users SET recovery_codes = $1 WHERE id = $2',
+      [['XYZ789'], 1]
+    );
+    // TOTP check should not run when a recovery code matched.
+    expect(mockCheck).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the database lookup fails', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('db down'));
+    const req = mockReq({ headers: { 'x-2fa-token': '123456' } });
+    const res = mockRes();
+    const next = jest.fn() as NextFunction;
+
+    await require2FAForAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middlewares/require2faForAdmin.ts
+++ b/backend/src/middlewares/require2faForAdmin.ts
@@ -1,0 +1,101 @@
+/**
+ * require2FAForAdmin
+ *
+ * Enforces verified TOTP / recovery-code two-factor authentication on sensitive
+ * admin organization-management endpoints (e.g. renaming an organization or
+ * rotating its Stellar issuer account).
+ *
+ * Unlike `require2FA`, which is a *soft* gate that lets a request through when
+ * the user has not enabled 2FA, this middleware is a *hard* gate:
+ *
+ *   1. The request must carry an authenticated user (JWT) — run after
+ *      `authenticateJWT`.
+ *   2. The user MUST have 2FA enabled. Admins managing an organization are
+ *      required to protect their account, so a missing/disabled 2FA setup is
+ *      rejected with `403 FORBIDDEN`.
+ *   3. A valid TOTP token (or single-use recovery code) MUST be supplied via the
+ *      `x-2fa-token` header or the `twoFactorToken` body field.
+ *
+ * Recovery codes are single-use and consumed on a successful match.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { authenticator } from '@otplib/preset-default';
+import { pool } from '../config/database.js';
+import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
+
+interface UserTwoFactorRow {
+  is_2fa_enabled: boolean;
+  totp_secret: string | null;
+  recovery_codes: string[] | null;
+}
+
+export const require2FAForAdmin = async (req: Request, res: Response, next: NextFunction) => {
+  const userId = req.user?.id;
+
+  if (!userId) {
+    return res
+      .status(401)
+      .json(apiErrorResponse(ErrorCodes.UNAUTHORIZED, 'Authentication required for admin actions'));
+  }
+
+  const token = ((req.headers['x-2fa-token'] as string) || req.body?.twoFactorToken || '').trim();
+
+  try {
+    const result = await pool.query<UserTwoFactorRow>(
+      'SELECT is_2fa_enabled, totp_secret, recovery_codes FROM users WHERE id = $1',
+      [userId]
+    );
+
+    const user = result.rows[0];
+
+    // Hard gate: 2FA must be set up before performing admin org operations.
+    if (!user || !user.is_2fa_enabled || !user.totp_secret) {
+      return res
+        .status(403)
+        .json(
+          apiErrorResponse(
+            ErrorCodes.FORBIDDEN,
+            'Two-factor authentication must be enabled to manage organization settings'
+          )
+        );
+    }
+
+    if (!token) {
+      return res
+        .status(401)
+        .json(
+          apiErrorResponse(
+            ErrorCodes.UNAUTHORIZED,
+            'A 2FA token or recovery code is required for this action'
+          )
+        );
+    }
+
+    // 1. Try single-use recovery codes (case-insensitive match).
+    const codes: string[] = Array.isArray(user.recovery_codes) ? user.recovery_codes : [];
+    const codeIdx = codes.findIndex((c) => String(c).toLowerCase() === token.toLowerCase());
+
+    if (codeIdx >= 0) {
+      const remaining = codes.filter((_, i) => i !== codeIdx);
+      await pool.query('UPDATE users SET recovery_codes = $1 WHERE id = $2', [remaining, userId]);
+      return next();
+    }
+
+    // 2. Fall back to a time-based one-time password.
+    if (authenticator.check(token, user.totp_secret)) {
+      return next();
+    }
+
+    return res
+      .status(401)
+      .json(apiErrorResponse(ErrorCodes.UNAUTHORIZED, 'Invalid 2FA token or recovery code'));
+  } catch (err) {
+    console.error('[require2FAForAdmin]', err);
+    return res
+      .status(500)
+      .json(apiErrorResponse(ErrorCodes.INTERNAL_ERROR, 'Failed to verify two-factor authentication'));
+  }
+};
+
+export default require2FAForAdmin;

--- a/backend/src/routes/organizationRoutes.ts
+++ b/backend/src/routes/organizationRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import authenticateJWT from '../middlewares/auth.js';
 import { authorizeRoles, isolateOrganization } from '../middlewares/rbac.js';
+import { require2FAForAdmin } from '../middlewares/require2faForAdmin.js';
 import { OrganizationController } from '../controllers/organizationController.js';
 
 const router = Router();
@@ -30,8 +31,16 @@ router.get('/me', OrganizationController.getMe);
  *   patch:
  *     tags: [Organizations]
  *     summary: Update organization name
+ *     description: Requires a valid 2FA token (TOTP or recovery code) supplied via the `x-2fa-token` header or `twoFactorToken` body field.
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - in: header
+ *         name: x-2fa-token
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: TOTP token or single-use recovery code for the authenticated admin.
  *     requestBody:
  *       required: true
  *       content:
@@ -41,11 +50,18 @@ router.get('/me', OrganizationController.getMe);
  *             properties:
  *               name:
  *                 type: string
+ *               twoFactorToken:
+ *                 type: string
+ *                 description: Alternative to the x-2fa-token header.
  *     responses:
  *       200:
  *         description: Updated organization name
+ *       401:
+ *         description: Missing or invalid 2FA token
+ *       403:
+ *         description: 2FA is not enabled for the admin account
  */
-router.patch('/me/name', OrganizationController.updateName);
+router.patch('/me/name', require2FAForAdmin, OrganizationController.updateName);
 
 /**
  * @openapi
@@ -53,8 +69,16 @@ router.patch('/me/name', OrganizationController.updateName);
  *   patch:
  *     tags: [Organizations]
  *     summary: Update organization Stellar issuer account
+ *     description: Requires a valid 2FA token (TOTP or recovery code) supplied via the `x-2fa-token` header or `twoFactorToken` body field.
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - in: header
+ *         name: x-2fa-token
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: TOTP token or single-use recovery code for the authenticated admin.
  *     requestBody:
  *       required: true
  *       content:
@@ -65,10 +89,17 @@ router.patch('/me/name', OrganizationController.updateName);
  *               issuerAccount:
  *                 type: string
  *                 description: Stellar public key (G...)
+ *               twoFactorToken:
+ *                 type: string
+ *                 description: Alternative to the x-2fa-token header.
  *     responses:
  *       200:
  *         description: Updated issuer account
+ *       401:
+ *         description: Missing or invalid 2FA token
+ *       403:
+ *         description: 2FA is not enabled for the admin account
  */
-router.patch('/me/issuer', OrganizationController.updateIssuer);
+router.patch('/me/issuer', require2FAForAdmin, OrganizationController.updateIssuer);
 
 export default router;

--- a/frontend/src/components/BulkPaymentStatusTracker.tsx
+++ b/frontend/src/components/BulkPaymentStatusTracker.tsx
@@ -5,6 +5,7 @@ import { useSocket } from '../hooks/useSocket';
 import { useWallet } from '../hooks/useWallet';
 import { useWalletSigning } from '../hooks/useWalletSigning';
 import { contractService } from '../services/contracts';
+import { SkeletonLoader } from './SkeletonLoader';
 import {
   fetchPayrollRunOnChainState,
   fetchPayrollRuns,
@@ -289,8 +290,11 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
         </div>
       </div>
 
-      {isLoading ? <p className="text-sm text-muted">Loading bulk payroll runs...</p> : null}
       {error ? <p className="text-sm text-danger">{error}</p> : null}
+
+      <span className="sr-only" role="status" aria-live="polite">
+        {isLoading ? 'Loading bulk payroll runs…' : ''}
+      </span>
 
       {!isLoading && rows.length === 0 ? (
         <p className="text-sm text-muted">No payroll batch runs found.</p>
@@ -309,7 +313,10 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
                 <th className="py-2 pr-4">Actions</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody aria-busy={isLoading}>
+              {isLoading && rows.length === 0 ? (
+                <SkeletonLoader variant="table-row" count={5} columns={8} />
+              ) : null}
               {rows.map(
                 ({
                   run,

--- a/frontend/src/components/__tests__/SkeletonLoader.test.tsx
+++ b/frontend/src/components/__tests__/SkeletonLoader.test.tsx
@@ -82,6 +82,34 @@ describe('SkeletonLoader', () => {
       const cells = container.querySelectorAll('td');
       expect(cells).toHaveLength(5);
     });
+
+    it('renders the total cell count across multiple rows (data-table layout)', () => {
+      // Mirrors the 8-column bulk-payment / 6-column freeze-log tables that now
+      // render skeleton rows while loading.
+      const { container } = render(
+        <table>
+          <tbody>
+            <SkeletonLoader variant="table-row" count={5} columns={8} />
+          </tbody>
+        </table>
+      );
+      expect(container.querySelectorAll('tr[aria-hidden="true"]')).toHaveLength(5);
+      expect(container.querySelectorAll('td')).toHaveLength(40);
+    });
+
+    it('keeps placeholder rows hidden from assistive tech', () => {
+      const { container } = render(
+        <table>
+          <tbody>
+            <SkeletonLoader variant="table-row" count={3} columns={4} />
+          </tbody>
+        </table>
+      );
+      container.querySelectorAll('tr').forEach((row) => {
+        expect(row.getAttribute('aria-hidden')).toBe('true');
+        expect(row.textContent).toBe('');
+      });
+    });
   });
 
   describe('avatar variant', () => {

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -14,6 +14,7 @@ import { useWallet } from '../hooks/useWallet';
 import ContractUpgradeTab from '../components/ContractUpgradeTab';
 import MultisigDetector from '../components/MultisigDetector';
 import { FormField } from '../components/FormField';
+import { SkeletonLoader } from '../components/SkeletonLoader';
 import { Button, Input, Heading, Text, Card } from '@stellar/design-system';
 
 const InputComponent = Input as unknown as React.FC<Record<string, unknown>>;
@@ -581,11 +582,13 @@ export default function AdminPanel() {
                     <th className="p-3">Reason</th>
                   </tr>
                 </thead>
-                <tbody>
-                  {logs.length === 0 ? (
+                <tbody aria-busy={logsLoading}>
+                  {logsLoading && logs.length === 0 ? (
+                    <SkeletonLoader variant="table-row" count={5} columns={6} />
+                  ) : logs.length === 0 ? (
                     <tr>
                       <td colSpan={6} className="p-8 text-center text-muted">
-                        {logsLoading ? 'Loading…' : 'No freeze logs found.'}
+                        No freeze logs found.
                       </td>
                     </tr>
                   ) : (

--- a/frontend/src/pages/CustomReportBuilder.tsx
+++ b/frontend/src/pages/CustomReportBuilder.tsx
@@ -13,6 +13,7 @@ import {
   Search,
 } from 'lucide-react';
 import { useNotification } from '../hooks/useNotification';
+import { SkeletonLoader } from '../components/SkeletonLoader';
 import { getTxExplorerUrl } from '../utils/stellarExpert';
 import {
   PAYROLL_EXPORT_COLUMNS,
@@ -571,9 +572,39 @@ export default function CustomReportBuilder() {
                     </p>
                   </div>
                 ) : isPreviewing ? (
-                  <div className="rounded-2xl border border-white/10 bg-black/20 px-6 py-16 text-center">
-                    <div className="mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-2 border-white/15 border-t-(--accent)" />
-                    <p className="text-sm text-(--muted)">Loading payroll preview...</p>
+                  <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/20">
+                    <span className="sr-only" role="status" aria-live="polite">
+                      Loading payroll preview…
+                    </span>
+                    <div className="overflow-x-auto">
+                      <table className="min-w-full border-separate border-spacing-0">
+                        <thead className="sticky top-0 bg-[#111827]">
+                          <tr>
+                            {(selectedColumnMeta.length > 0
+                              ? selectedColumnMeta
+                              : DEFAULT_SELECTED_COLUMNS.map((id) => ({ id, label: id }))
+                            ).map((column) => (
+                              <th
+                                key={column.id}
+                                className="border-b border-white/10 px-4 py-3 text-left text-[11px] font-bold uppercase tracking-[0.22em] text-(--muted)"
+                              >
+                                {column.label}
+                              </th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody aria-busy="true">
+                          <SkeletonLoader
+                            variant="table-row"
+                            count={6}
+                            columns={Math.max(
+                              selectedColumnMeta.length,
+                              DEFAULT_SELECTED_COLUMNS.length
+                            )}
+                          />
+                        </tbody>
+                      </table>
+                    </div>
                   </div>
                 ) : selectedColumnMeta.length === 0 ? (
                   <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 px-6 py-16 text-center">


### PR DESCRIPTION
## Summary

This PR resolves four Stellar Wave issues with focused, pattern-following changes across the frontend and backend.

Closes #647
Closes #680
Closes #692
Closes #713

## What Changed

### Frontend — Skeleton loading for data tables (#647, #680)
- Reused the existing shared `SkeletonLoader` (`table-row` variant) to replace plain-text/spinner loading states in the remaining data tables that lacked a proper skeleton:
  - **AdminPanel** freeze-logs table — was showing a `Loading…` text cell.
  - **BulkPaymentStatusTracker** — was showing a `Loading bulk payroll runs...` paragraph.
  - **CustomReportBuilder** preview table — was showing a spinner; now renders a column-accurate skeleton table that mirrors the real layout.
- Added `sr-only` `aria-live="polite"` status announcements and `aria-busy` on the loading `tbody` so screen-reader users are informed while tables load (WCAG 2.1).
- Extended `SkeletonLoader.test.tsx` with cases covering the multi-row/multi-column data-table layouts and verifying placeholder rows stay hidden from assistive tech.

### Backend — Admin 2FA enforcement (#692)
- Added `require2FAForAdmin` middleware that **enforces** verified TOTP / recovery-code two-factor authentication on sensitive organization-management endpoints (`PATCH /api/v1/organizations/me/name` and `/me/issuer`). Unlike the existing soft `require2FA` gate, this hard-gates the request: 2FA must be enabled (`403` otherwise) and a valid token/recovery code must be supplied via the `x-2fa-token` header or `twoFactorToken` body field (`401` otherwise). Recovery codes are single-use and consumed on match.
- Updated the OpenAPI annotations on both routes to document the `x-2fa-token` header and the new `401`/`403` responses.
- Reused the project's existing `otplib` dependency and `apiError` response helpers; proper logging and error handling included.

### Backend — API & Database scaling (#713)
- Added migration `052_api_database_scaling_part23.sql` (with matching rollback) introducing read-path index optimizations following the established `0xx_api_database_scaling_partN` pattern:
  - Composite index on `payroll_runs (organization_id, status, created_at DESC)` for org-scoped, status-filtered, newest-first run listings.
  - Partial index on failed `payroll_items` for the payment-retry flow.
- Indexes are idempotent (`IF NOT EXISTS`) and contain no schema/data changes.

## Checklist
- [x] I linked the relevant issue(s) in the summary.
- [x] I added or updated tests for the change.
- [x] I ran the relevant test suite locally.
- [x] I updated documentation where needed, or explained why it was not needed.
- [x] If this change touches the UI, I verified responsive behavior and accessibility.
- [x] I included screenshots, logs, or other proof when they help review.

## Testing
- Frontend: `cd frontend && npm run lint && npx prettier . --check && npm run build && npm test` — the extended `SkeletonLoader` suite covers the new data-table layouts.
- Backend: `cd backend && npm test` — new `require2faForAdmin.test.ts` covers the no-user (`401`), 2FA-not-enabled (`403`), missing-token (`401`), valid-TOTP (`next()`), invalid-token (`401`), single-use recovery-code, and DB-failure (`500`) paths; the existing org controller suite stays green.
- Migration: `npm run db:migrate:dry-run` and running `npm run db:migrate` twice yields `Applied: 0` on the second run; rollback file provided.

## Documentation
- OpenAPI route annotations updated for the 2FA header and new error responses. SQL migrations are self-documented with header comments and `COMMENT ON INDEX` notes, per the contributing guide.

## Accessibility / Responsiveness
- Skeleton placeholders carry `role="presentation"` / `aria-hidden` and contain no text, so screen readers skip them; visible loading state is announced via `sr-only` `aria-live` regions and `aria-busy`. The skeleton rows inherit each table's existing responsive `overflow-x-auto` containers, so mobile/tablet/desktop behavior is unchanged.

## Notes
- Migration follows the immutable-file rule from CONTRIBUTING: it is a new file (`052`), no existing migration was modified, and a matching rollback is included.