### PR TITLE
feat: settings theme toggle, language toast, URL filter persistence, and keyboard shortcuts

### DIFF
--- a/frontend/src/__tests__/Settings.test.tsx
+++ b/frontend/src/__tests__/Settings.test.tsx
@@ -2,16 +2,23 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 const mockChangeLanguage = vi.fn().mockResolvedValue(undefined);
+const mockToggleTheme = vi.fn();
+const mockNotifySuccess = vi.fn();
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, vars?: Record<string, string>) => {
       const translations: Record<string, string> = {
         'settings.title': 'Settings',
         'settings.languageLabel': 'Language',
         'settings.languageDescription': 'Choose your preferred language',
         'settings.languageEnglish': 'English',
         'settings.languageSpanish': 'Español',
+        'settings.languageSaved': `Language updated to ${vars?.language ?? ''}`,
+        'settings.themeLabel': 'Appearance',
+        'settings.themeDescription': 'Choose your preferred color scheme',
+        'settings.themeDark': 'Dark',
+        'settings.themeLight': 'Light',
       };
       return translations[key] ?? key;
     },
@@ -22,62 +29,113 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+vi.mock('../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'dark',
+    toggleTheme: mockToggleTheme,
+  }),
+}));
+
+vi.mock('../hooks/useNotification', () => ({
+  useNotification: () => ({
+    notifySuccess: mockNotifySuccess,
+    notifyError: vi.fn(),
+    notify: vi.fn(),
+    notifyPaymentSuccess: vi.fn(),
+    notifyPaymentFailure: vi.fn(),
+    notifyWalletEvent: vi.fn(),
+    notifyApiError: vi.fn(),
+  }),
+}));
+
 import Settings from '../pages/Settings';
 
 describe('Settings', () => {
   test('renders settings title', () => {
     render(<Settings />);
-
     expect(screen.getByRole('heading', { name: 'Settings', level: 1 })).toBeTruthy();
   });
 
   test('renders language section heading', () => {
     render(<Settings />);
-
     expect(screen.getByRole('heading', { name: 'Language', level: 2 })).toBeTruthy();
   });
 
   test('renders language options as buttons', () => {
     render(<Settings />);
-
     expect(screen.getAllByText('English').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Español').length).toBeGreaterThan(0);
   });
 
   test('changes language when a language button is clicked', () => {
     render(<Settings />);
-
     const spanishButton = screen.getByRole('button', { name: /Select Español/i });
     fireEvent.click(spanishButton);
-
     expect(mockChangeLanguage).toHaveBeenCalledWith('es');
+  });
+
+  test('shows success toast when language is changed', () => {
+    render(<Settings />);
+    const spanishButton = screen.getByRole('button', { name: /Select Español/i });
+    fireEvent.click(spanishButton);
+    expect(mockNotifySuccess).toHaveBeenCalledWith('Language updated to Español');
   });
 
   test('shows current language indicator', () => {
     render(<Settings />);
-
-    // English is the current language
     expect(screen.getByText(/Current Language/)).toBeTruthy();
   });
 
   test('renders language description text', () => {
     render(<Settings />);
-
     expect(screen.getByText('Choose your preferred language')).toBeTruthy();
   });
 
-  test('renders more settings placeholder', () => {
+  test('renders language buttons as interactive', () => {
     render(<Settings />);
-
-    expect(screen.getByText('More settings coming soon')).toBeTruthy();
-  });
-
-  test('language buttons are interactive', () => {
-    render(<Settings />);
-
     const englishButton = screen.getByRole('button', { name: /Select English/i });
     fireEvent.click(englishButton);
-
     expect(mockChangeLanguage).toHaveBeenCalledWith('en');
+  });
+
+  test('renders appearance section heading', () => {
+    render(<Settings />);
+    expect(screen.getByRole('heading', { name: 'Appearance', level: 2 })).toBeTruthy();
+  });
+
+  test('renders dark and light theme buttons', () => {
+    render(<Settings />);
+    expect(screen.getByRole('button', { name: /Dark/i, hidden: false })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Light/i, hidden: false })).toBeTruthy();
+  });
+
+  test('dark button is aria-pressed when theme is dark', () => {
+    render(<Settings />);
+    const darkButtons = screen.getAllByRole('button');
+    const darkButton = darkButtons.find(
+      (b) => b.textContent?.includes('Dark') && b.getAttribute('aria-pressed') === 'true'
+    );
+    expect(darkButton).toBeTruthy();
+  });
+
+  test('toggleTheme is called when light mode is selected', () => {
+    render(<Settings />);
+    const buttons = screen.getAllByRole('button');
+    const lightButton = buttons.find((b) => b.textContent?.includes('Light'));
+    expect(lightButton).toBeTruthy();
+    fireEvent.click(lightButton!);
+    expect(mockToggleTheme).toHaveBeenCalled();
+  });
+
+  test('toggleTheme is not called when already selected theme is clicked', () => {
+    vi.clearAllMocks();
+    render(<Settings />);
+    const buttons = screen.getAllByRole('button');
+    const darkButton = buttons.find(
+      (b) => b.textContent?.includes('Dark') && b.getAttribute('aria-pressed') === 'true'
+    );
+    expect(darkButton).toBeTruthy();
+    fireEvent.click(darkButton!);
+    expect(mockToggleTheme).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/TransactionHistory.integration.test.tsx
+++ b/frontend/src/__tests__/TransactionHistory.integration.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { describe, test, expect, beforeEach, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // Simple waitFor implementation
@@ -31,7 +31,7 @@ async function waitFor(callback: () => void, options: { timeout?: number } = {})
   callback();
 }
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import TransactionHistory from '../pages/TransactionHistory';
 import * as transactionHistoryApi from '../services/transactionHistoryApi';
 
@@ -84,22 +84,30 @@ vi.mock('@stellar/design-system', () => ({
   ),
 }));
 
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
 /**
  * Helper function to render component with all required providers
  */
 function renderWithProviders(ui: React.ReactElement) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false, // Disable retries in tests
-        gcTime: 0, // Disable caching in tests
-      },
-    },
-  });
-
   return render(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={makeQueryClient()}>
       <BrowserRouter>{ui}</BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+/**
+ * Render with a MemoryRouter so we can seed initial URL query params.
+ */
+function renderWithInitialUrl(ui: React.ReactElement, initialPath: string) {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter initialEntries={[initialPath]}>{ui}</MemoryRouter>
     </QueryClientProvider>
   );
 }
@@ -429,6 +437,85 @@ describe('TransactionHistory Integration', () => {
 
     // Verify Load More button is NOT displayed
     expect(queryByRole('button', { name: /Load older records/i })).not.toBeInTheDocument();
+  });
+
+  // #946 — filters survive navigation (URL persistence)
+  test('restores filters from URL query params on mount', async () => {
+    vi.spyOn(transactionHistoryApi, 'fetchHistoryPage').mockResolvedValue({
+      items: [],
+      hasMore: false,
+      total: 0,
+    });
+
+    const { getByRole, getByLabelText } = renderWithInitialUrl(
+      <TransactionHistory />,
+      '/transactions?status=confirmed&asset=USDC'
+    );
+
+    // The filter count badge should reflect the two seeded params
+    await waitFor(() => {
+      expect(getByRole('button', { name: /Filters \(2\)/i })).toBeInTheDocument();
+    });
+
+    // Open filters and verify the inputs are pre-populated
+    const filtersButton = getByRole('button', { name: /Filters \(2\)/i });
+    await userEvent.setup().click(filtersButton);
+
+    await waitFor(() => {
+      expect(getByLabelText(/Status/i)).toHaveValue('confirmed');
+    });
+  });
+
+  // #947 — keyboard shortcut / opens filters
+  test('pressing / opens the filter panel', async () => {
+    vi.spyOn(transactionHistoryApi, 'fetchHistoryPage').mockResolvedValue({
+      items: [],
+      hasMore: false,
+      total: 0,
+    });
+
+    const { queryByText } = renderWithProviders(<TransactionHistory />);
+
+    // Panel not visible yet
+    expect(queryByText('Advanced Filters')).not.toBeInTheDocument();
+
+    // Simulate pressing / on the document body
+    fireEvent.keyDown(document, { key: '/' });
+
+    await waitFor(() => {
+      expect(queryByText('Advanced Filters')).toBeInTheDocument();
+    });
+  });
+
+  // #947 — keyboard shortcut Escape resets active filters
+  test('pressing Escape resets active filters', async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(transactionHistoryApi, 'fetchHistoryPage').mockResolvedValue({
+      items: [],
+      hasMore: false,
+      total: 0,
+    });
+
+    const { getByRole, getByLabelText } = renderWithProviders(<TransactionHistory />);
+
+    // Open filters and set one
+    const filtersButton = getByRole('button', { name: /Filters/i });
+    await user.click(filtersButton);
+
+    const statusSelect = getByLabelText(/Status/i);
+    await user.selectOptions(statusSelect, 'confirmed');
+
+    await waitFor(() => {
+      expect(getByRole('button', { name: /Filters \(1\)/i })).toBeInTheDocument();
+    });
+
+    // Press Escape — should clear the filter
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(getByRole('button', { name: /Filters$/i })).toBeInTheDocument();
+    });
   });
 
   test('displays contract event badge differently from classic badge', async () => {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -142,7 +142,12 @@
     "languageLabel": "Language",
     "languageDescription": "Choose your preferred language for the dashboard.",
     "languageEnglish": "English",
-    "languageSpanish": "Spanish"
+    "languageSpanish": "Spanish",
+    "languageSaved": "Language updated to {{language}}",
+    "themeLabel": "Appearance",
+    "themeDescription": "Choose your preferred color scheme for the dashboard.",
+    "themeDark": "Dark",
+    "themeLight": "Light"
   },
   "employeeProfile": {
     "title": "Employee Profile",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -142,7 +142,12 @@
     "languageLabel": "Idioma",
     "languageDescription": "Elige tu idioma preferido para el panel.",
     "languageEnglish": "Inglés",
-    "languageSpanish": "Español"
+    "languageSpanish": "Español",
+    "languageSaved": "Idioma actualizado a {{language}}",
+    "themeLabel": "Apariencia",
+    "themeDescription": "Elige tu esquema de color preferido para el panel.",
+    "themeDark": "Oscuro",
+    "themeLight": "Claro"
   },
   "employeeProfile": {
     "title": "Perfil del empleado",

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,8 +1,12 @@
 import { useTranslation } from 'react-i18next';
-import { Globe, Check } from 'lucide-react';
+import { Globe, Check, Moon, Sun } from 'lucide-react';
+import { useTheme } from '../hooks/useTheme';
+import { useNotification } from '../hooks/useNotification';
 
 export default function Settings() {
   const { t, i18n } = useTranslation();
+  const { theme, toggleTheme } = useTheme();
+  const { notifySuccess } = useNotification();
 
   const languages = [
     { code: 'en', name: t('settings.languageEnglish'), nativeName: 'English' },
@@ -11,7 +15,26 @@ export default function Settings() {
 
   const handleChangeLanguage = (languageCode: string) => {
     void i18n.changeLanguage(languageCode);
+    const langName = languages.find((l) => l.code === languageCode)?.nativeName ?? languageCode;
+    notifySuccess(t('settings.languageSaved', { language: langName }));
   };
+
+  const handleThemeChange = (mode: 'dark' | 'light') => {
+    if (theme !== mode) toggleTheme();
+  };
+
+  const themeModes: { mode: 'dark' | 'light'; icon: React.ReactNode; label: string }[] = [
+    {
+      mode: 'dark',
+      icon: <Moon className="h-4 w-4 text-[var(--muted)]" />,
+      label: t('settings.themeDark'),
+    },
+    {
+      mode: 'light',
+      icon: <Sun className="h-4 w-4 text-[var(--muted)]" />,
+      label: t('settings.themeLight'),
+    },
+  ];
 
   return (
     <div className="flex-1 flex flex-col items-center justify-start p-6 md:p-12 max-w-4xl mx-auto w-full">
@@ -84,13 +107,52 @@ export default function Settings() {
           </div>
         </div>
 
-        {/* Additional Settings Placeholder */}
+        {/* Appearance / Theme Settings */}
         <div className="card glass noise p-6 md:p-8">
-          <div className="text-center py-8">
-            <p className="text-sm font-semibold text-[var(--muted)]">More settings coming soon</p>
-            <p className="text-xs text-[var(--muted)] mt-2">
-              Theme preferences, notification settings, and more will be available here.
-            </p>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-hi)] p-2.5">
+              {theme === 'dark' ? (
+                <Moon className="h-5 w-5 text-[var(--accent)]" />
+              ) : (
+                <Sun className="h-5 w-5 text-[var(--accent)]" />
+              )}
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-[var(--text)]">
+                {t('settings.themeLabel')}
+              </h2>
+              <p className="text-sm text-[var(--muted)] mt-1">
+                {t('settings.themeDescription')}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            {themeModes.map(({ mode, icon, label }) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => handleThemeChange(mode)}
+                aria-pressed={theme === mode}
+                className={`relative rounded-2xl border p-4 text-left transition ${
+                  theme === mode
+                    ? 'border-[var(--accent)] bg-[color:rgba(74,240,184,0.08)]'
+                    : 'border-hi bg-[var(--surface-hi)]/70 hover:border-[var(--accent)]/50'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    {icon}
+                    <p className="text-sm font-bold text-[var(--text)]">{label}</p>
+                  </div>
+                  {theme === mode && (
+                    <div className="rounded-full bg-[var(--accent)] p-1">
+                      <Check className="h-4 w-4 text-[var(--bg)]" />
+                    </div>
+                  )}
+                </div>
+              </button>
+            ))}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/TransactionHistory.tsx
+++ b/frontend/src/pages/TransactionHistory.tsx
@@ -70,6 +70,32 @@ export default function TransactionHistory() {
     };
   }, [socket, refetch]);
 
+  // Keyboard shortcuts: / → open filters + focus search; Escape → reset active filters
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const inInput =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable;
+
+      if (e.key === '/' && !inInput && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        setShowFilters(true);
+        setTimeout(() => {
+          document.getElementById('search-filter')?.focus();
+        }, 0);
+      }
+
+      if (e.key === 'Escape' && !inInput && activeFilterCount > 0) {
+        resetFilters();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [activeFilterCount, resetFilters]);
+
   useEffect(() => {
     const shouldPoll = !connected || isPollingFallback;
 
@@ -136,10 +162,14 @@ export default function TransactionHistory() {
             {activeFilterCount > 0 && (
               <button
                 onClick={resetFilters}
+                title="Reset all filters (Esc)"
                 className="text-[10px] font-bold uppercase tracking-widest text-danger hover:underline flex items-center gap-1.5"
               >
                 <X size={12} />
                 Clear All
+                <kbd className="ml-0.5 text-[9px] border border-danger/30 px-1 rounded opacity-60 normal-case">
+                  Esc
+                </kbd>
               </button>
             )}
           </div>
@@ -148,9 +178,12 @@ export default function TransactionHistory() {
             <div className="flex flex-col gap-2">
               <label
                 htmlFor="search-filter"
-                className="text-[10px] font-bold uppercase tracking-widest text-muted ml-1"
+                className="text-[10px] font-bold uppercase tracking-widest text-muted ml-1 flex items-center gap-1.5"
               >
                 Search
+                <kbd className="text-[9px] border border-hi px-1 rounded opacity-50 normal-case font-mono">
+                  /
+                </kbd>
               </label>
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted w-4 h-4 z-10" />


### PR DESCRIPTION
Closes #944
Closes #945
Closes #946
Closes #947

## What changed

- **#944 — Theme toggle in Settings**: Replaced the "More settings coming soon" placeholder with a functional Appearance card. Users can now switch between Dark and Light modes using the same two-button layout as the Language selector. The selected theme is persisted to `localStorage` via the existing `ThemeProvider`.

- **#945 — Language save confirmation toast**: `handleChangeLanguage` now calls `notifySuccess` via `NotificationProvider`/`sonner` immediately after changing the language, showing e.g. _"Language updated to Español"_. Both `en` and `es` translation files gain the `settings.languageSaved` key.

- **#946 — URL filter persistence (test coverage)**: `useFilterState` already writes every filter to the URL via `useSearchParams({ replace: true })`. Added an integration test using `MemoryRouter` with `initialEntries` to assert that filters seeded in the URL are restored on mount — so the behaviour is verified and protected against regression.

- **#947 — Keyboard shortcuts + tooltips**: Added a `keydown` listener on `document` (mounted in `TransactionHistory`):
  - `/` (when not in an input) opens the filter panel and focuses the search input.
  - `Escape` resets all active filters when any are set.
  Discoverability hints (`<kbd>` chips) appear next to the Search label (`/`) and the Clear All button (`Esc`).

## How to test

**#944 — Theme toggle**
1. Open `/settings`.
2. Scroll to the Appearance card.
3. Click "Light" — the UI switches to light mode.
4. Reload — the preference persists via localStorage.

**#945 — Language toast**
1. Open `/settings`.
2. Click the Español button.
3. A success toast reading _"Idioma actualizado a Español"_ appears.

**#946 — URL filter persistence**
1. Open `/transactions?status=confirmed&asset=USDC`.
2. Click the Filters button — Status is pre-set to "Confirmed" and Asset to "USDC".
3. Navigate away and back — filters are still reflected in the URL.

**#947 — Keyboard shortcuts**
1. On `/transactions`, press `/` — filters panel opens and search is focused.
2. Set any filter (e.g. Status = Confirmed), then press `Escape` — all filters clear.
3. The Search label shows a `/` kbd chip; the Clear All button shows an `Esc` chip.