### PR TITLE
fix: validate path assets and rate amounts

### DIFF
--- a/backend/src/controllers/__tests__/paymentController.test.ts
+++ b/backend/src/controllers/__tests__/paymentController.test.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { PaymentController } from '../paymentController.js';
 import { AnchorService } from '../../services/anchorService.js';
+import { findConversionPaths } from '../../services/crossAssetPaymentService.js';
 
 jest.mock('../../services/anchorService.js', () => ({
   AnchorService: {
@@ -19,6 +20,10 @@ jest.mock('@stellar/stellar-sdk', () => ({
       publicKey: () => (secret === 'SVALID' ? 'GSENDER' : 'GBAD'),
     })),
   },
+}));
+
+jest.mock('../../services/crossAssetPaymentService.js', () => ({
+  findConversionPaths: jest.fn(),
 }));
 
 describe('PaymentController SEP-24 endpoints', () => {
@@ -69,5 +74,27 @@ describe('PaymentController SEP-24 endpoints', () => {
 
     expect(response.status).toBe(303);
     expect(response.headers.location).toBe('https://anchor.example/interactive/withdraw-1');
+  });
+});
+
+describe('PaymentController pathfinding', () => {
+  const app = express();
+  app.use(express.json());
+  app.post('/pathfind', PaymentController.findPaths);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects malformed asset identifiers before pathfinding', async () => {
+    const response = await request(app).post('/pathfind').send({
+      fromAsset: 'not-a-stellar-asset',
+      toAsset: 'native',
+      amount: '10',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('Invalid asset identifier');
+    expect(findConversionPaths).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/controllers/__tests__/ratesController.test.ts
+++ b/backend/src/controllers/__tests__/ratesController.test.ts
@@ -1,9 +1,10 @@
 import request from 'supertest';
 import express from 'express';
 import { RatesController } from '../ratesController.js';
-import { getOrgUsdRates } from '../../services/fxRateService.js';
+import { convertOrgUsdAmount, getOrgUsdRates } from '../../services/fxRateService.js';
 
 jest.mock('../../services/fxRateService.js', () => ({
+  convertOrgUsdAmount: jest.fn(),
   getOrgUsdRates: jest.fn(),
 }));
 
@@ -41,5 +42,22 @@ describe('RatesController GET /rates', () => {
     expect(response.status).toBe(502);
     expect(response.body.error).toBe('Bad Gateway');
     expect(response.body.message).toContain('Unable to load exchange rates');
+  });
+});
+
+describe('RatesController GET /rates/convert', () => {
+  const app = express();
+  app.get('/rates/convert', RatesController.convert);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects out-of-bounds amounts', async () => {
+    const response = await request(app).get('/rates/convert?amount=1e30&from=ORGUSD&to=KES');
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toContain('no greater than');
+    expect(convertOrgUsdAmount).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/controllers/paymentController.ts
+++ b/backend/src/controllers/paymentController.ts
@@ -4,6 +4,12 @@ import { Keypair } from '@stellar/stellar-sdk';
 import { findConversionPaths, type PathfindRequest } from '../services/crossAssetPaymentService.js';
 import { Sep31TrackingService } from '../services/sep31TrackingService.js';
 
+const STELLAR_ASSET_REGEX = /^(native|[A-Z0-9]{1,12}:G[A-Z2-7]{55})$/;
+
+function isValidStellarAssetIdentifier(asset: unknown): asset is string {
+  return typeof asset === 'string' && STELLAR_ASSET_REGEX.test(asset);
+}
+
 export class PaymentController {
   /**
    * GET /api/payments/anchor-info
@@ -71,6 +77,16 @@ export class PaymentController {
     if (!fromAsset || !toAsset || !amount || amount <= 0) {
       return res.status(400).json({
         error: 'Invalid pathfind request: fromAsset, toAsset, and positive amount required',
+      });
+    }
+
+    if (
+      !isValidStellarAssetIdentifier(fromAsset) ||
+      !isValidStellarAssetIdentifier(toAsset)
+    ) {
+      return res.status(400).json({
+        error:
+          'Invalid asset identifier: assets must be "native" or "CODE:ISSUER" with a valid Stellar issuer account',
       });
     }
 

--- a/backend/src/controllers/ratesController.ts
+++ b/backend/src/controllers/ratesController.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express';
 import { convertOrgUsdAmount, getOrgUsdRates } from '../services/fxRateService.js';
 
+const MAX_CONVERT_AMOUNT = 1e15;
+
 export class RatesController {
   /**
    * GET /rates — ORGUSD→fiat conversion (ORGUSD ≡ USD), backed by live FX with Redis cache.
@@ -35,10 +37,10 @@ export class RatesController {
         return;
       }
 
-      if (!Number.isFinite(amount) || amount < 0) {
+      if (!Number.isFinite(amount) || amount < 0 || amount > MAX_CONVERT_AMOUNT) {
         res.status(400).json({
           error: 'Bad Request',
-          message: 'Query parameter "amount" must be a non-negative number.',
+          message: `Query parameter "amount" must be a non-negative number no greater than ${MAX_CONVERT_AMOUNT}.`,
         });
         return;
       }


### PR DESCRIPTION
## Summary

- Validate `fromAsset` and `toAsset` in pathfinding requests before calling Horizon pathfinding.
- Reject malformed asset identifiers unless they are `native` or `CODE:ISSUER`.
- Add a maximum conversion amount bound of `1e15` to `/api/rates/convert`.
- Add focused controller tests for malformed path assets and out-of-bounds conversion amounts.

Closes #920
Closes #921 
Closes #926 
Closes #923

