### PR TITLE
feat: add per-chart export to PNG/SVG in PayrollAnalytics

### DIFF
--- a/frontend/src/pages/PayrollAnalytics.tsx
+++ b/frontend/src/pages/PayrollAnalytics.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import {
@@ -20,9 +20,10 @@ import {
 } from 'recharts';
 import type { PieLabelRenderProps } from 'recharts';
 import { Card } from '@stellar/design-system';
-import { BarChart2, LineChart as LineChartIcon, Download, RefreshCw } from 'lucide-react';
+import { BarChart2, LineChart as LineChartIcon, Download, RefreshCw, FileImage } from 'lucide-react';
 import axiosInstance from '../api/axiosInstance';
 import { parseDateString } from '../utils/dateHelpers';
+import { exportAsPng, exportAsSvg } from '../utils/exportChart';
 
 // recharts v3 + React 19: Legend's class-component typings conflict with React.JSX.
 const SafeLegend = Legend as unknown as React.FC<object>;
@@ -208,6 +209,11 @@ export default function PayrollAnalytics() {
   const [dateRangeError, setDateRangeError] = useState('');
   const [trendType, setTrendType] = useState<TrendChartType>('line');
   const [activePreset, setActivePreset] = useState<string | null>(null);
+
+  const trendChartRef = useRef<HTMLDivElement>(null!);
+  const pieChartRef = useRef<HTMLDivElement>(null!);
+  const paymentChartRef = useRef<HTMLDivElement>(null!);
+  const deptChartRef = useRef<HTMLDivElement>(null!);
 
   // Default org ID – replace with real auth context when available
   const organizationId = 1;
@@ -509,10 +515,27 @@ export default function PayrollAnalytics() {
                       >
                         <Download className="w-4 h-4" />
                       </button>
+                      <button
+                        onClick={() => exportAsPng(trendChartRef.current, 'payroll_trend.png')}
+                        aria-label="Export trend chart as PNG"
+                        title="Export PNG"
+                        className="p-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition"
+                      >
+                        <FileImage className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => exportAsSvg(trendChartRef.current, 'payroll_trend.svg')}
+                        aria-label="Export trend chart as SVG"
+                        title="Export SVG"
+                        className="p-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition"
+                      >
+                        <FileImage className="w-4 h-4" />
+                      </button>
                     </div>
                   </div>
 
-                  <ResponsiveContainer width="100%" height={280}>
+                  <div ref={trendChartRef}>
+                    <ResponsiveContainer width="100%" height={280}>
                     {trendType === 'area' ? (
                       <AreaChart data={data.trends}>
                         <defs>
@@ -584,6 +607,7 @@ export default function PayrollAnalytics() {
                       </LineChart>
                     )}
                   </ResponsiveContainer>
+                  </div>
                 </div>
               </Card>
             </motion.div>
@@ -592,13 +616,36 @@ export default function PayrollAnalytics() {
             <motion.div variants={cardVariants}>
               <Card>
                 <div className="p-6">
-                  <h2 className="text-lg font-bold text-[var(--text)] mb-1">
-                    Cost Breakdown by Currency
-                  </h2>
-                  <p className="text-xs text-[var(--muted)] mb-4">
-                    Distribution of payroll across different assets
-                  </p>
-                  <ResponsiveContainer width="100%" height={280}>
+                  <div className="flex items-start justify-between mb-1">
+                    <div>
+                      <h2 className="text-lg font-bold text-[var(--text)]">
+                        Cost Breakdown by Currency
+                      </h2>
+                      <p className="text-xs text-[var(--muted)] mt-1">
+                        Distribution of payroll across different assets
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1 mt-1">
+                      <button
+                        onClick={() => exportAsPng(pieChartRef.current, 'currency_breakdown.png')}
+                        aria-label="Export currency chart as PNG"
+                        title="Export PNG"
+                        className="p-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition"
+                      >
+                        <FileImage className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => exportAsSvg(pieChartRef.current, 'currency_breakdown.svg')}
+                        aria-label="Export currency chart as SVG"
+                        title="Export SVG"
+                        className="p-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition"
+                      >
+                        <FileImage className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                  <div ref={pieChartRef}>
+                    <ResponsiveContainer width="100%" height={280}>
                     <PieChart>
                       <Pie
                         data={data.currencyBreakdown}
@@ -629,6 +676,7 @@ export default function PayrollAnalytics() {
                       <SafeLegend />
                     </PieChart>
                   </ResponsiveContainer>
+                  </div>
                 </div>
               </Card>
             </motion.div>
@@ -637,13 +685,36 @@ export default function PayrollAnalytics() {
             <motion.div variants={cardVariants} className="lg:col-span-2">
               <Card>
                 <div className="p-6">
-                  <h2 className="text-lg font-bold text-[var(--text)] mb-1">
-                    Payment Success / Failure Rate
-                  </h2>
-                  <p className="text-xs text-[var(--muted)] mb-4">
-                    Monthly transaction success, failure, and pending metrics
-                  </p>
-                  <ResponsiveContainer width="100%" height={280}>
+                  <div className="flex items-start justify-between mb-1">
+                    <div>
+                      <h2 className="text-lg font-bold text-[var(--text)]">
+                        Payment Success / Failure Rate
+                      </h2>
+                      <p className="text-xs text-[var(--muted)] mt-1">
+                        Monthly transaction success, failure, and pending metrics
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1 mt-1">
+                      <button
+                        onClick={() => exportAsPng(paymentChartRef.current, 'payment_success_rate.png')}
+                        aria-label="Export payment chart as PNG"
+                        title="Export PNG"
+                        className="p-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition"
+                      >
+                        <FileImage className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => exportAsSvg(paymentChartRef.current, 'payment_success_rate.svg')}
+                        aria-label="Export payment chart as SVG"
+                        title="Export SVG"
+                        className="p-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition"
+                      >
+                        <FileImage className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                  <div ref={paymentChartRef}>
+                    <ResponsiveContainer width="100%" height={280}>
                     <BarChart data={data.paymentMetrics}>
                       <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
                       <XAxis
@@ -664,6 +735,7 @@ export default function PayrollAnalytics() {
                       <Bar dataKey="pending" name="Pending" fill="#f59e0b" radius={[4, 4, 0, 0]} />
                     </BarChart>
                   </ResponsiveContainer>
+                  </div>
                 </div>
               </Card>
             </motion.div>
@@ -673,16 +745,39 @@ export default function PayrollAnalytics() {
               <motion.div variants={cardVariants} className="lg:col-span-2">
                 <Card>
                   <div className="p-6">
-                    <h2 className="text-lg font-bold text-[var(--text)] mb-1">
-                      Payroll by Department
-                    </h2>
-                    <p className="text-xs text-[var(--muted)] mb-4">
-                      Total expenditure and headcount per department
-                    </p>
-                    <ResponsiveContainer
-                      width="100%"
-                      height={Math.max(220, data.departmentBreakdown.length * 44)}
-                    >
+                    <div className="flex items-start justify-between mb-1">
+                      <div>
+                        <h2 className="text-lg font-bold text-[var(--text)]">
+                          Payroll by Department
+                        </h2>
+                        <p className="text-xs text-[var(--muted)] mt-1">
+                          Total expenditure and headcount per department
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 mt-1">
+                        <button
+                          onClick={() => exportAsPng(deptChartRef.current, 'payroll_by_department.png')}
+                          aria-label="Export department chart as PNG"
+                          title="Export PNG"
+                          className="p-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition"
+                        >
+                          <FileImage className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => exportAsSvg(deptChartRef.current, 'payroll_by_department.svg')}
+                          aria-label="Export department chart as SVG"
+                          title="Export SVG"
+                          className="p-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition"
+                        >
+                          <FileImage className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </div>
+                    <div ref={deptChartRef}>
+                      <ResponsiveContainer
+                        width="100%"
+                        height={Math.max(220, data.departmentBreakdown.length * 44)}
+                      >
                       <BarChart
                         data={data.departmentBreakdown}
                         layout="vertical"
@@ -731,6 +826,7 @@ export default function PayrollAnalytics() {
                         />
                       </BarChart>
                     </ResponsiveContainer>
+                    </div>
                   </div>
                 </Card>
               </motion.div>

--- a/frontend/src/pages/__tests__/PayrollAnalytics.test.tsx
+++ b/frontend/src/pages/__tests__/PayrollAnalytics.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => mockQuery(...args),
+}));
+
+vi.mock('../../api/axiosInstance', () => ({
+  default: { get: vi.fn().mockRejectedValue(new Error('mock')) },
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<object>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock('@stellar/design-system', () => ({
+  Card: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+vi.mock('../../utils/exportChart', () => ({
+  exportAsPng: vi.fn(),
+  exportAsSvg: vi.fn(),
+}));
+
+import PayrollAnalytics from '../PayrollAnalytics';
+
+function mockSuccessData() {
+  mockQuery.mockReturnValue({
+    data: {
+      summary: { totalPayroll: 500000, totalTransactions: 350, successRate: 94.2, activeEmployees: 42 },
+      trends: [
+        { month: 'Jan 25', total: 40000, count: 16 },
+        { month: 'Feb 25', total: 42000, count: 17 },
+      ],
+      currencyBreakdown: [
+        { currency: 'USDC', value: 62 },
+        { currency: 'XLM', value: 28 },
+      ],
+      paymentMetrics: [
+        { month: 'Jan 25', success: 80, failure: 5, pending: 2 },
+        { month: 'Feb 25', success: 85, failure: 3, pending: 1 },
+      ],
+      departmentBreakdown: [
+        { department: 'Engineering', total: 200000, headcount: 18 },
+        { department: 'Sales', total: 100000, headcount: 10 },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  });
+}
+
+describe('PayrollAnalytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders export PNG buttons for each chart', () => {
+    mockSuccessData();
+    render(<PayrollAnalytics />);
+
+    const pngButtons = screen.getAllByRole('button', { name: /export.*PNG/i });
+    expect(pngButtons.length).toBe(4);
+  });
+
+  it('renders export SVG buttons for each chart', () => {
+    mockSuccessData();
+    render(<PayrollAnalytics />);
+
+    const svgButtons = screen.getAllByRole('button', { name: /export.*SVG/i });
+    expect(svgButtons.length).toBe(4);
+  });
+
+  it('calls exportAsPng when PNG button is clicked', async () => {
+    mockSuccessData();
+    const { exportAsPng } = await import('../../utils/exportChart');
+    render(<PayrollAnalytics />);
+
+    const pngButtons = screen.getAllByRole('button', { name: /export.*PNG/i });
+    fireEvent.click(pngButtons[0]);
+
+    expect(exportAsPng).toHaveBeenCalled();
+  });
+
+  it('calls exportAsSvg when SVG button is clicked', async () => {
+    mockSuccessData();
+    const { exportAsSvg } = await import('../../utils/exportChart');
+    render(<PayrollAnalytics />);
+
+    const svgButtons = screen.getAllByRole('button', { name: /export.*SVG/i });
+    fireEvent.click(svgButtons[0]);
+
+    expect(exportAsSvg).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/__tests__/exportChart.test.ts
+++ b/frontend/src/utils/__tests__/exportChart.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { exportAsSvg } from '../exportChart';
+
+describe('exportChart', () => {
+  let container: HTMLElement;
+  let anchorClick: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', '100');
+    svg.setAttribute('height', '100');
+    container.appendChild(svg);
+
+    anchorClick = vi.fn();
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'a') {
+        const anchor = origCreateElement('a') as HTMLAnchorElement;
+        anchor.click = anchorClick;
+        return anchor;
+      }
+      return origCreateElement(tagName);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exportAsSvg creates a download with SVG content', () => {
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL');
+    exportAsSvg(container, 'test.svg');
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    const blob = createObjectURLSpy.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe('image/svg+xml;charset=utf-8');
+    expect(anchorClick).toHaveBeenCalled();
+  });
+
+  it('exportAsSvg uses default filename when none provided', () => {
+    exportAsSvg(container);
+    expect(anchorClick).toHaveBeenCalled();
+  });
+
+  it('does nothing when container has no SVG element', () => {
+    const emptyContainer = document.createElement('div');
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL');
+
+    exportAsSvg(emptyContainer);
+
+    expect(createObjectURLSpy).not.toHaveBeenCalled();
+    expect(anchorClick).not.toHaveBeenCalled();
+  });
+
+  it('serialized SVG blob type is correct', () => {
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL');
+    exportAsSvg(container, 'valid.svg');
+
+    const blob = createObjectURLSpy.mock.calls[0][0] as Blob;
+    expect(blob.type).toContain('image/svg+xml');
+  });
+
+  it('appends and removes anchor element from body', () => {
+    const appendChild = vi.spyOn(document.body, 'appendChild');
+    const removeChild = vi.spyOn(document.body, 'removeChild');
+
+    exportAsSvg(container, 'test.svg');
+
+    expect(appendChild).toHaveBeenCalledTimes(1);
+    expect(removeChild).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/utils/exportChart.ts
+++ b/frontend/src/utils/exportChart.ts
@@ -1,0 +1,61 @@
+function getChartSvg(container: HTMLElement): SVGSVGElement | null {
+  const svg = container.querySelector('svg');
+  return svg instanceof SVGSVGElement ? svg : null;
+}
+
+function serializeSvg(svg: SVGSVGElement): string {
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  const serializer = new XMLSerializer();
+  return serializer.serializeToString(clone);
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function exportAsSvg(container: HTMLElement, filename = 'chart.svg'): void {
+  const svg = getChartSvg(container);
+  if (!svg) return;
+  const svgString = serializeSvg(svg);
+  const blob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+  downloadBlob(blob, filename);
+}
+
+export function exportAsPng(container: HTMLElement, filename = 'chart.png'): void {
+  const svg = getChartSvg(container);
+  if (!svg) return;
+
+  const svgString = serializeSvg(svg);
+  const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+
+  const img = new Image();
+  img.onload = () => {
+    const canvas = document.createElement('canvas');
+    const rect = svg.getBoundingClientRect();
+    canvas.width = rect.width * 2;
+    canvas.height = rect.height * 2;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      ctx.scale(2, 2);
+      ctx.drawImage(img, 0, 0, rect.width, rect.height);
+      canvas.toBlob((blob) => {
+        if (blob) downloadBlob(blob, filename);
+        URL.revokeObjectURL(url);
+      }, 'image/png');
+    } else {
+      URL.revokeObjectURL(url);
+    }
+  };
+  img.onerror = () => {
+    URL.revokeObjectURL(url);
+  };
+  img.src = url;
+}


### PR DESCRIPTION
## Description

Charts on `PayrollAnalytics.tsx` can now be exported as PNG or SVG images, enabling finance teams to download individual charts for reports and presentations.

## Changes

### New files
- **`frontend/src/utils/exportChart.ts`** – Utility functions `exportAsPng` and `exportAsSvg` that extract the SVG from a chart container, serialize it, and trigger a download
- **`frontend/src/utils/__tests__/exportChart.test.ts`** – 5 unit tests covering SVG export, blob type validation, missing-SVG guard, and DOM append/remove behavior
- **`frontend/src/pages/__tests__/PayrollAnalytics.test.tsx`** – 4 component tests verifying PNG/SVG export buttons render for all 4 charts and trigger the correct export functions on click

### Modified files
- **`frontend/src/pages/PayrollAnalytics.tsx`**
  - Added `useRef` hooks for each chart container (trend, currency, payment, department)
  - Added PNG + SVG export buttons with `FileImage` icons to all four chart headers
  - Wrapped each `ResponsiveContainer` in a `ref`-attached `<div>` for DOM targeting

## Testing

\`\`\`
✓ src/utils/__tests__/exportChart.test.ts (5 tests)
✓ src/pages/__tests__/PayrollAnalytics.test.tsx (4 tests)
\`\`\`

All existing tests continue to pass.

Closes #951
Closes #952 
Closes #953 
Closes #954 