### PR TITLE
implement smart wallet, revenue split 

### DIFF
--- a/contracts/revenue_split/src/lib.rs
+++ b/contracts/revenue_split/src/lib.rs
@@ -23,6 +23,12 @@ pub enum RevenueSplitError {
     UnauthorizedDistribution = 7,
     ContractPaused = 8,
     UnsupportedAsset = 9,
+    /// Admin or Recipients storage entry is missing; contract may not be initialized.
+    NotInitialized = 10,
+    /// Accumulated basis-points sum overflowed u32 during share validation.
+    ShareOverflow = 11,
+    /// Distribution or preview amount must not be negative.
+    InvalidAmount = 12,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -153,7 +159,7 @@ impl RevenueSplitContract {
     }
 
     /// Returns the current admin address.
-    pub fn get_admin(env: Env) -> Address {
+    pub fn get_admin(env: Env) -> Result<Address, RevenueSplitError> {
         Self::load_admin(&env)
     }
 
@@ -163,14 +169,17 @@ impl RevenueSplitContract {
     }
 
     /// Previews how an incoming amount would be distributed across recipients.
-    pub fn preview_distribution(env: Env, amount: i128) -> Vec<DistributionPreview> {
+    pub fn preview_distribution(
+        env: Env,
+        amount: i128,
+    ) -> Result<Vec<DistributionPreview>, RevenueSplitError> {
         let shares = Self::load_recipients(&env);
         Self::build_distribution_preview(&env, &shares, amount)
     }
 
     /// Allows the current admin to set a new admin.
     pub fn set_admin(env: Env, new_admin: Address) -> Result<(), RevenueSplitError> {
-        let admin = Self::load_admin(&env);
+        let admin = Self::load_admin(&env)?;
         admin.require_auth();
         env.storage().persistent().set(&DataKey::Admin, &new_admin);
         Self::bump_core_ttl(&env);
@@ -180,6 +189,7 @@ impl RevenueSplitContract {
             new_admin,
         }
         .publish(&env);
+        Ok(())
     }
 
     /// Updates the recipient splits dynamically (admin only).
@@ -187,7 +197,7 @@ impl RevenueSplitContract {
         env: Env,
         new_shares: Vec<RecipientShare>,
     ) -> Result<(), RevenueSplitError> {
-        let admin = Self::load_admin(&env);
+        let admin = Self::load_admin(&env)?;
         admin.require_auth();
         Self::validate_shares(&new_shares)?;
         let recipient_count = new_shares.len();
@@ -208,13 +218,14 @@ impl RevenueSplitContract {
     /// While paused, all `distribute` calls are rejected. Administrative
     /// functions (`set_admin`, `update_recipients`, `bump_ttl`) remain
     /// available so that the contract can be restored to a healthy state.
-    pub fn set_paused(env: Env, paused: bool) {
-        let admin = Self::load_admin(&env);
+    pub fn set_paused(env: Env, paused: bool) -> Result<(), RevenueSplitError> {
+        let admin = Self::load_admin(&env)?;
         admin.require_auth();
 
         env.storage().instance().set(&DataKey::Paused, &paused);
 
         PauseStateChangedEvent { paused, admin }.publish(&env);
+        Ok(())
     }
 
     /// Returns `true` if the contract is currently paused.
@@ -239,7 +250,7 @@ impl RevenueSplitContract {
     /// Once at least one asset is added, `distribute` only accepts listed
     /// assets.
     pub fn add_supported_asset(env: Env, token: Address) -> Result<(), RevenueSplitError> {
-        let admin = Self::load_admin(&env);
+        let admin = Self::load_admin(&env)?;
         admin.require_auth();
 
         let mut assets = Self::load_supported_assets_or_empty(&env);
@@ -254,7 +265,7 @@ impl RevenueSplitContract {
 
     /// Removes a token asset from the supported-asset allowlist (admin only).
     pub fn remove_supported_asset(env: Env, token: Address) -> Result<(), RevenueSplitError> {
-        let admin = Self::load_admin(&env);
+        let admin = Self::load_admin(&env)?;
         admin.require_auth();
 
         let assets = Self::load_supported_assets_or_empty(&env);
@@ -313,7 +324,7 @@ impl RevenueSplitContract {
 
         let shares = Self::load_recipients(&env);
         let recipient_count = shares.len();
-        let preview = Self::build_distribution_preview(&env, &shares, amount);
+        let preview = Self::build_distribution_preview(&env, &shares, amount)?;
         let client = token::Client::new(&env, &token);
 
         for payment in preview.iter() {
@@ -376,10 +387,11 @@ impl RevenueSplitContract {
     }
 
     /// Extends TTL for all critical contract state (admin only).
-    pub fn bump_ttl(env: Env) {
-        let admin = Self::load_admin(&env);
+    pub fn bump_ttl(env: Env) -> Result<(), RevenueSplitError> {
+        let admin = Self::load_admin(&env)?;
         admin.require_auth();
         Self::bump_core_ttl(&env);
+        Ok(())
     }
 
     // ── Private helpers ───────────────────────────────────────────────────
@@ -420,11 +432,11 @@ impl RevenueSplitContract {
         Ok(())
     }
 
-    fn load_admin(env: &Env) -> Address {
+    fn load_admin(env: &Env) -> Result<Address, RevenueSplitError> {
         env.storage()
             .persistent()
             .get(&DataKey::Admin)
-            .expect("Admin entry unavailable; restore and retry")
+            .ok_or(RevenueSplitError::NotInitialized)
     }
 
     fn load_recipients(env: &Env) -> Vec<RecipientShare> {
@@ -450,23 +462,27 @@ impl RevenueSplitContract {
         let mut total_bp = 0u32;
         let mut i = 0u32;
         while i < shares.len() {
-            let share = shares.get(i).expect("Recipient share missing");
+            // Index is bounded by `i < shares.len()`, so None is an unreachable
+            // invariant violation; surface it as a typed error rather than panicking.
+            let share = shares.get(i).ok_or(RevenueSplitError::ZeroRecipients)?;
             if share.basis_points == 0 {
                 return Err(RevenueSplitError::ZeroBasisPoints);
             }
 
             let mut j = i + 1;
             while j < shares.len() {
-                let other = shares.get(j).expect("Recipient share missing");
+                let other = shares.get(j).ok_or(RevenueSplitError::ZeroRecipients)?;
                 if share.destination == other.destination {
                     return Err(RevenueSplitError::DuplicateRecipient);
                 }
                 j += 1;
             }
 
+            // checked_add guards against maliciously large basis_points values that
+            // would silently wrap around and bypass the BasisPointsSumMismatch check.
             total_bp = total_bp
                 .checked_add(share.basis_points)
-                .expect("Share total overflow");
+                .ok_or(RevenueSplitError::ShareOverflow)?;
             i += 1;
         }
 
@@ -536,9 +552,9 @@ impl RevenueSplitContract {
         env: &Env,
         shares: &Vec<RecipientShare>,
         amount: i128,
-    ) -> Vec<DistributionPreview> {
+    ) -> Result<Vec<DistributionPreview>, RevenueSplitError> {
         if amount < 0 {
-            panic!("Amount must not be negative");
+            return Err(RevenueSplitError::InvalidAmount);
         }
 
         let mut preview = Vec::new(env);
@@ -562,7 +578,7 @@ impl RevenueSplitContract {
             });
         }
 
-        preview
+        Ok(preview)
     }
 
     fn bump_core_ttl(env: &Env) {

--- a/contracts/revenue_split/src/test.rs
+++ b/contracts/revenue_split/src/test.rs
@@ -965,3 +965,134 @@ fn test_distribute_noop_on_zero_amount() {
     assert_eq!(token_client.balance(&recipient), 0);
     assert_eq!(client.get_distribution_count(), 0);
 }
+
+// ══════════════════════════════════════════════════════════════════════════════
+// ── ISSUE #892: set_admin / load_admin must not panic ────────────────────────
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_set_admin_before_init_returns_not_initialized() {
+    // Calling set_admin on an uninitialized contract must return
+    // NotInitialized instead of panicking.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+    let result = client.try_set_admin(&new_admin);
+    assert_eq!(result, Err(Ok(RevenueSplitError::NotInitialized)));
+}
+
+#[test]
+fn test_get_admin_before_init_returns_not_initialized() {
+    let env = Env::default();
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+
+    let result = client.try_get_admin();
+    assert_eq!(result, Err(Ok(RevenueSplitError::NotInitialized)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// ── ISSUE #893: validate_shares() must return typed errors, not panic ─────────
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_validate_shares_overflow_returns_share_overflow() {
+    // Passing a share whose basis_points is large enough that accumulating
+    // two of them overflows u32 must return ShareOverflow, not panic.
+    // We use two recipients each with u32::MAX / 2 + 1, guaranteeing overflow.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    // u32::MAX / 2 + 1 = 2_147_483_648; two of these overflow u32.
+    let large_bp: u32 = u32::MAX / 2 + 1;
+    let shares = Vec::from_array(
+        &env,
+        [
+            RecipientShare {
+                destination: r1.clone(),
+                basis_points: large_bp,
+            },
+            RecipientShare {
+                destination: r2.clone(),
+                basis_points: large_bp,
+            },
+        ],
+    );
+
+    let result = client.try_init(&admin, &shares);
+    assert_eq!(result, Err(Ok(RevenueSplitError::ShareOverflow)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// ── ISSUE #895: build_distribution_preview() must return typed error ──────────
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_preview_distribution_negative_amount_returns_invalid_amount() {
+    // preview_distribution(-1) must return InvalidAmount, not panic.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+
+    let shares = Vec::from_array(
+        &env,
+        [RecipientShare {
+            destination: recipient.clone(),
+            basis_points: 10_000,
+        }],
+    );
+    client.init(&admin, &shares);
+
+    let result = client.try_preview_distribution(&-1_i128);
+    assert_eq!(result, Err(Ok(RevenueSplitError::InvalidAmount)));
+}
+
+#[test]
+fn test_preview_distribution_zero_amount_returns_empty_amounts() {
+    // Zero is valid — each recipient gets 0, no panic.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+
+    let shares = Vec::from_array(
+        &env,
+        [
+            RecipientShare {
+                destination: r1.clone(),
+                basis_points: 6000,
+            },
+            RecipientShare {
+                destination: r2.clone(),
+                basis_points: 4000,
+            },
+        ],
+    );
+    client.init(&admin, &shares);
+
+    let preview = client.preview_distribution(&0_i128);
+    for entry in preview.iter() {
+        assert_eq!(entry.amount, 0);
+    }
+}

--- a/contracts/smart_wallet/src/lib.rs
+++ b/contracts/smart_wallet/src/lib.rs
@@ -326,6 +326,27 @@ impl SmartWalletContract {
         let threshold = Self::load_threshold(env)?;
 
         let mut valid_signatures = 0u32;
+        // Tracks the signer-list indices that have already been matched to a
+        // proof in this batch.  The duplicate-detection invariant is:
+        //
+        //   Each signer index may appear in `used_signers` at most once.
+        //
+        // Enforcement uses two complementary layers:
+        //   1. Inner-loop skip (primary)  – before testing a signer for a
+        //      match, we skip it if its index is already in `used_signers`.
+        //      This means a used signer slot can never become `matched_signer_index`,
+        //      so the same signer cannot be counted twice even if the same proof
+        //      is submitted multiple times in the `signatures` list.
+        //   2. Post-loop assertion (defensive) – after the inner loop we verify
+        //      that `matched_signer_index` (when Some) is not already in
+        //      `used_signers`.  Because the inner-loop skip makes this
+        //      unreachable in practice, this check is a safety belt against
+        //      future refactors that might break the skip invariant.
+        //
+        // Consequence: submitting the same signer's proof twice (or more)
+        // causes the second occurrence's inner loop to find no unused signer
+        // slot that matches, resulting in `UnknownSigner` — not `DuplicateSigner`.
+        // The `DuplicateSigner` branch exists solely as the defensive layer.
         let mut used_signers: Vec<u32> = Vec::new(env);
 
         let mut signature_index = 0u32;
@@ -334,9 +355,17 @@ impl SmartWalletContract {
                 .get(signature_index)
                 .ok_or(WalletError::InvalidSignature)?;
 
+            // ── Inner loop: find an unused signer slot that matches this proof ─
+            // Note: key-type is part of identity.  An Ed25519 proof for a
+            // secp256k1 signer slot (or vice-versa) never matches because
+            // `signer_matches_proof` performs a type-aware comparison.  This
+            // ensures proofs of different key types from the "same person"
+            // (holding multiple registered keys) each satisfy their own distinct
+            // signer slot and are never conflated.
             let mut matched_signer_index: Option<u32> = None;
             let mut signer_index = 0u32;
             while signer_index < signers.len() {
+                // Layer 1: skip slots already consumed by an earlier proof.
                 if used_signers.iter().any(|used| used == signer_index) {
                     signer_index += 1;
                     continue;
@@ -378,7 +407,15 @@ impl SmartWalletContract {
                 signer_index += 1;
             }
 
+            // If no unused signer matched, the proof is either unknown or a
+            // duplicate attempt (all matching slots were already consumed by
+            // the inner-loop skip above).  Both cases are surfaced as
+            // UnknownSigner from the caller's perspective.
             let signer_index = matched_signer_index.ok_or(WalletError::UnknownSigner)?;
+
+            // Layer 2 (defensive): assert the matched index was indeed unused.
+            // This should be unreachable given the inner-loop skip, but is
+            // retained as a safety belt.
             if used_signers.iter().any(|used| used == signer_index) {
                 return Err(WalletError::DuplicateSigner);
             }

--- a/contracts/smart_wallet/src/test.rs
+++ b/contracts/smart_wallet/src/test.rs
@@ -371,3 +371,112 @@ fn mixed_multisig_correct_types_satisfy_threshold() {
         SmartWalletContract::verify_signatures_inner(&env, &payload, &proofs).unwrap();
     });
 }
+
+// ══════════════════════════════════════════════════════════════════════════════
+// ── ISSUE #900: duplicate-signer guard and cross-key-type tests ───────────────
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Submitting the same signer's proof twice must not count toward the threshold
+/// more than once.
+///
+/// How the guard works: the inner loop in verify_signatures_inner() skips any
+/// signer slot already in `used_signers`.  When the same proof is submitted a
+/// second time, no unused matching slot remains and the call returns
+/// `UnknownSigner` rather than incrementing `valid_signatures` again.
+#[test]
+fn duplicate_ed25519_proof_only_counts_once() {
+    let env = Env::default();
+
+    let (ed_signer_key, ed_signing_key) = make_ed25519_signer(&env, [50u8; 32]);
+    // Register one signer; threshold = 1 so the first proof satisfies it.
+    let signers = Vec::from_array(&env, [ed_signer_key]);
+    let (contract_id, _client) = register_wallet(&env, signers, 1);
+
+    let raw = Bytes::from_slice(&env, &[55u8; 32]);
+    let payload = env.crypto().sha256(&raw);
+    let proof = sign_ed25519(&payload, &ed_signing_key, &env);
+
+    // Submit the same proof twice.  The first consumption of slot 0 is valid;
+    // the second finds slot 0 already in `used_signers` and cannot re-match.
+    let proofs = Vec::from_array(&env, [proof.clone(), proof]);
+    env.as_contract(&contract_id, || {
+        let result = SmartWalletContract::verify_signatures_inner(&env, &payload, &proofs);
+        assert_eq!(result, Err(WalletError::UnknownSigner));
+    });
+}
+
+/// 2-of-2 wallet: attacker submits signer A's proof twice instead of A + B.
+/// The duplicate must NOT satisfy the threshold.
+#[test]
+fn duplicate_ed25519_proof_cannot_satisfy_two_of_two_threshold() {
+    let env = Env::default();
+
+    let (ed_signer_key_a, ed_signing_key_a) = make_ed25519_signer(&env, [60u8; 32]);
+    let (ed_signer_key_b, _) = make_ed25519_signer(&env, [61u8; 32]);
+    let signers = Vec::from_array(&env, [ed_signer_key_a, ed_signer_key_b]);
+    let (contract_id, _client) = register_wallet(&env, signers, 2);
+
+    let raw = Bytes::from_slice(&env, &[66u8; 32]);
+    let payload = env.crypto().sha256(&raw);
+    let proof_a = sign_ed25519(&payload, &ed_signing_key_a, &env);
+
+    // Slot A is consumed by the first proof; the second finds no unused match.
+    let proofs = Vec::from_array(&env, [proof_a.clone(), proof_a]);
+    env.as_contract(&contract_id, || {
+        let result = SmartWalletContract::verify_signatures_inner(&env, &payload, &proofs);
+        assert_eq!(result, Err(WalletError::UnknownSigner));
+    });
+}
+
+/// Ed25519 and secp256k1 keys from the "same person" occupy separate signer
+/// slots and are counted independently — no cross-type conflation or
+/// double-counting in either direction.
+#[test]
+fn ed25519_and_secp256k1_same_person_count_as_independent_signers() {
+    let env = Env::default();
+
+    let (ed_signer_key, ed_signing_key) = make_ed25519_signer(&env, [70u8; 32]);
+    let (secp_signer_key, secp_signing_key) = make_secp256k1_signer(&env, [71u8; 32]);
+
+    // Register both key types; threshold = 2.
+    let signers = Vec::from_array(&env, [ed_signer_key, secp_signer_key]);
+    let (contract_id, _client) = register_wallet(&env, signers, 2);
+
+    let raw = Bytes::from_slice(&env, &[77u8; 32]);
+    let payload = env.crypto().sha256(&raw);
+    let proofs = Vec::from_array(
+        &env,
+        [
+            sign_ed25519(&payload, &ed_signing_key, &env),
+            sign_secp256k1(&payload, &secp_signing_key, &env),
+        ],
+    );
+
+    env.as_contract(&contract_id, || {
+        // Each key fills its own slot (indices 0 and 1) → valid_signatures = 2.
+        SmartWalletContract::verify_signatures_inner(&env, &payload, &proofs).unwrap();
+    });
+}
+
+/// Cross-type mismatch: an Ed25519 proof submitted to a wallet whose only
+/// signer is registered as secp256k1 must return UnknownSigner.
+/// Confirms signer_matches_proof() is type-aware and never cross-matches.
+#[test]
+fn cross_type_ed25519_proof_against_secp256k1_slot_fails() {
+    let env = Env::default();
+
+    let (_ed_key, ed_signing_key) = make_ed25519_signer(&env, [80u8; 32]);
+    let (secp_key, _) = make_secp256k1_signer(&env, [81u8; 32]);
+
+    let signers = Vec::from_array(&env, [secp_key]);
+    let (contract_id, _client) = register_wallet(&env, signers, 1);
+
+    let raw = Bytes::from_slice(&env, &[88u8; 32]);
+    let payload = env.crypto().sha256(&raw);
+    let proof = Vec::from_array(&env, [sign_ed25519(&payload, &ed_signing_key, &env)]);
+
+    env.as_contract(&contract_id, || {
+        let result = SmartWalletContract::verify_signatures_inner(&env, &payload, &proof);
+        assert_eq!(result, Err(WalletError::UnknownSigner));
+    });
+}


### PR DESCRIPTION
## Summary

This PR addresses four assigned issues across the backend and contract layers of PayD.

---

### #759 / #019 — Implement Payroll Run Audit Log & Reporting

- Added `item_deleted` audit log entry to the `deletePayrollItem` endpoint — previously the deletion was silent in the audit trail.
- Added `getPayrollItemById` helper to `PayrollBonusService` to capture item metadata before deletion for accurate audit records.
- Added `GET /api/v1/payroll-bonus/runs/:id/report` — a combined payroll run report endpoint that returns the full run summary (metadata + item breakdown) alongside the paginated audit trail in a single response. Reduces client round-trips for the reporting UI.

### #714 / #269 — API & Database Scaling Part 24

- Added migration `049_api_database_scaling_part24.sql`:
  - `db_pool_utilisation` table with a generated `utilisation_pct` column and a partial index for high-utilisation events (≥80%) — enables connection pool capacity planning.
  - `org_query_throughput` table for per-organisation API throughput counters with p95 latency tracking — enables fair-use enforcement and noisy-neighbour detection.
  - Covering index on `payroll_runs (organization_id, status, period_start DESC)` including `batch_id, total_amount, asset_code, created_at`.
  - Covering index on `payroll_audit_logs (organization_id, action, created_at DESC)` including `actor_type, actor_email, tx_hash, amount`.
  - Partial index on `payroll_items` for `status = 'failed'` — speeds up failure-investigation queries.
  - Covering index on `bulk_payment_batches (organization_id, status, created_at DESC)`.
  - Prune functions for both new tables (7-day and 30-day retention).

### #772 / #032 — CONTRACT Legacy Issue - Maintenance & Stability

Contract maintenance standards applied per `contracts/MAINTENANCE_GUIDE.md`. The existing contract architecture already follows the documented patterns (checked arithmetic, auth guards, typed errors, TTL management, circuit breaker). No regressions introduced.

### #771 / #031 — CONTRACT Legacy Issue - Maintenance & Stability

Same as above — contract layer reviewed against the maintenance guide. Existing contracts pass the documented standards. No regressions introduced.

---

### #696 — [BACKEND] Implement Advanced Audit Log for All Admin Actions

- Added migration `048_create_admin_audit_log.sql`: append-only `admin_audit_log` table (PostgreSQL rules prevent UPDATE/DELETE) with JSONB old/new state capture, severity levels (info/warning/critical), and 6 covering indexes.
- Added `AdminAuditService` with `log()` (fire-and-forget safe), `list()` (multi-filter pagination), `summary()` (aggregated counts), and `exportCsv()` (max 10k rows, Content-Disposition header).
- Added `auditAction()` middleware factory that intercepts `res.json` on mutating requests and records audit entries without blocking the main request path.
- Added `GET /api/v1/admin-audit` (list), `GET /api/v1/admin-audit/summary`, and `GET /api/v1/admin-audit/export` — all gated behind `EMPLOYER` role + `isolateOrganization`.

### #186 / #187 — Issue ORGUSD Custom Asset on Stellar Testnet

- Added `contracts/orgusd` Soroban contract implementing the full ORGUSD lifecycle: `initialize`, `mint`, `burn`, `clawback`, `transfer`, `authorize`, `revoke`, `freeze`, `unfreeze`.
- Typed `OrgUsdError` enum (9 variants) with `#[contracterror]`; typed events for every state transition.
- Auth-required / auth-revocable flags enforced at contract layer; dual active-account guard on `transfer`.
- SEP-0034 metadata (`name()`, `version()`, `author()`, `sep1_metadata()`).
- 20 unit tests covering happy-path and all error paths.
- Registered `contracts/orgusd` in workspace `Cargo.toml`.

### #341 — Standardize API Error Response Format

- Added `errorHandlerMiddleware` as the single Express error handler (4-argument signature), replacing the previous inline handler in `app.ts`.
- Handler cascade: `ZodError` → 400 `VALIDATION_ERROR` with per-field details; HTTP-tagged errors → passthrough status; `TypeError | RangeError | SyntaxError` → 400 `BAD_REQUEST`; fallback → 500 `INTERNAL_ERROR` (message redacted in production).
- All responses include `{ code, message, details, requestId }` shape.
- 18 integration tests covering every branch, status-code mapping, and production vs development message visibility.

### #892 — [revenue_split] `set_admin()` missing Result return type

- Converted `load_admin()` from panicking `.expect()` to `Result<Address, RevenueSplitError>` with new `NotInitialized = 10` variant.
- Updated all 7 callers (`get_admin`, `set_admin`, `set_paused`, `update_recipients`, `add_supported_asset`, `remove_supported_asset`, `bump_ttl`) to propagate errors with `?`.

### #893 — [revenue_split] `validate_shares()` panics via `expect()`

- Replaced three `.expect()` calls with `ok_or(RevenueSplitError::ZeroRecipients)?` / `ok_or(RevenueSplitError::ShareOverflow)?`.
- Added `ShareOverflow = 11` error variant for `checked_add` overflow on `basis_points` accumulation.

### #895 — [revenue_split] `build_distribution_preview()` panics on negative amount

- Replaced `panic!("Amount must not be negative")` with `return Err(RevenueSplitError::InvalidAmount)`.
- Added `InvalidAmount = 12` error variant; changed return type to `Result<Vec<DistributionPreview>, RevenueSplitError>` and updated callers `preview_distribution()` and `distribute()`.
- Added 5 tests: not-initialized guard, share overflow, negative amount, zero amount, and multi-recipient preview.

### #900 — [smart_wallet] `verify_signatures_inner()` duplicate-signer guard is unclear and untested

- Added extensive inline documentation to `verify_signatures_inner()` explaining the two-layer deduplication invariant: Layer 1 (inner-loop skip, primary) and Layer 2 (post-loop assertion, defensive safety belt).
- Documented that duplicate proofs surface as `UnknownSigner` (not `DuplicateSigner`) and that key-type identity prevents cross-type proof reuse.
- Added 4 tests: duplicate Ed25519 proof to 1-of-1, duplicate proof to 2-of-2, independent Ed25519+secp256k1 slots for the same person, and cross-type proof rejection.

---

## Testing

- TypeScript: no diagnostics on changed files.
- Rust: `cargo test` passes for `orgusd`, `revenue_split`, and `smart_wallet`.
- Migration follows the same `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` pattern as prior migrations.
- Audit log endpoint wiring verified against existing `PayrollAuditService` interface.

---


Closes #892
Closes #893
Closes #895
Closes #900
