### PR TITLE
fix(backend): input validation for issues #914, #915, #918, #919

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,6 +38,7 @@ import contractRoutes from './routes/contractRoutes.js';
 import ratesRoutes from './routes/ratesRoutes.js';
 import stellarThrottlingRoutes from './routes/stellarThrottlingRoutes.js';
 import scalingRoutes from './routes/scalingRoutes.js';
+import { MAX_BULK_IMPORT_REQUEST_BYTES } from './schemas/bulkImportSchema.js';
 
 const __appFilename = fileURLToPath(import.meta.url);
 const __appDirname = path.dirname(__appFilename);
@@ -83,7 +84,17 @@ app.use(requestIdMiddleware);
 // Structured JSON request logging + Prometheus metrics (replaces morgan)
 app.use(requestLogger);
 app.use(metricsMiddleware);
-app.use(express.json());
+
+const defaultJsonParser = express.json();
+const bulkImportJsonParser = express.json({ limit: MAX_BULK_IMPORT_REQUEST_BYTES });
+
+app.use((req, res, next) => {
+  if (req.method === 'POST' && /\/employees\/bulk-import\/?$/.test(req.path)) {
+    return bulkImportJsonParser(req, res, next);
+  }
+  return defaultJsonParser(req, res, next);
+});
+
 app.use(express.urlencoded({ extended: true }));
 app.use(passport.initialize());
 

--- a/backend/src/controllers/__tests__/bulkImportController.test.ts
+++ b/backend/src/controllers/__tests__/bulkImportController.test.ts
@@ -1,0 +1,96 @@
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../../config/database.js', () => ({
+  __esModule: true,
+  pool: {
+    query: jest.fn(),
+  },
+}));
+
+jest.mock('../../config/env', () => ({
+  config: {
+    DATABASE_URL: 'postgres://mock',
+    PORT: 3000,
+  },
+}));
+
+jest.mock('../../middlewares/auth.js', () => ({
+  __esModule: true,
+  default: (req: any, _res: any, next: any) => {
+    req.user = { id: 1, organizationId: 1, role: 'EMPLOYER' };
+    next();
+  },
+  authenticateJWT: (req: any, _res: any, next: any) => {
+    req.user = { id: 1, organizationId: 1, role: 'EMPLOYER' };
+    next();
+  },
+}));
+
+jest.mock('../../middlewares/rbac.js', () => ({
+  __esModule: true,
+  authorizeRoles: () => (_req: any, _res: any, next: any) => next(),
+  isolateOrganization: (_req: any, _res: any, next: any) => next(),
+}));
+
+import employeeRoutes from '../../routes/employeeRoutes.js';
+import { csvPayrollImportService } from '../../services/csvPayrollImportService.js';
+import { MAX_BULK_IMPORT_CSV_BYTES, MAX_BULK_IMPORT_REQUEST_BYTES } from '../../schemas/bulkImportSchema.js';
+
+jest.mock('../../services/csvPayrollImportService.js', () => ({
+  csvPayrollImportService: {
+    processCsv: jest.fn(),
+  },
+  UnsupportedCsvEncodingError: class UnsupportedCsvEncodingError extends Error {
+    constructor() {
+      super('Unsupported CSV encoding: only UTF-8 encoded files are supported.');
+      this.name = 'UnsupportedCsvEncodingError';
+    }
+  },
+}));
+
+const app = express();
+app.use((req, res, next) => {
+  if (req.method === 'POST' && /\/employees\/bulk-import\/?$/.test(req.path)) {
+    return express.json({ limit: MAX_BULK_IMPORT_REQUEST_BYTES })(req, res, next);
+  }
+  return express.json()(req, res, next);
+});
+app.use('/api/employees', employeeRoutes);
+
+describe('BulkImportController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects oversized CSV uploads with 413', async () => {
+    const oversizedCsv = 'a'.repeat(MAX_BULK_IMPORT_CSV_BYTES + 1);
+
+    const response = await request(app)
+      .post('/api/employees/bulk-import')
+      .send({ csv: oversizedCsv })
+      .expect(413);
+
+    expect(response.body).toHaveProperty('code', 'PAYLOAD_TOO_LARGE');
+    expect(response.body.message).toContain(String(MAX_BULK_IMPORT_CSV_BYTES));
+    expect(csvPayrollImportService.processCsv).not.toHaveBeenCalled();
+  });
+
+  it('accepts CSV within the size limit', async () => {
+    const csvContent =
+      'first_name,last_name,email\nJohn,Doe,john@example.com';
+    (csvPayrollImportService.processCsv as jest.Mock).mockResolvedValue({
+      totalRows: 1,
+      successCount: 1,
+      errorCount: 0,
+      errors: [],
+    });
+
+    await request(app)
+      .post('/api/employees/bulk-import')
+      .send({ csv: csvContent })
+      .expect(201);
+
+    expect(csvPayrollImportService.processCsv).toHaveBeenCalledWith(1, csvContent);
+  });
+});

--- a/backend/src/controllers/__tests__/employeeController.test.ts
+++ b/backend/src/controllers/__tests__/employeeController.test.ts
@@ -123,6 +123,19 @@ describe('EmployeeController', () => {
     it('should return 400 for invalid query params', async () => {
       await request(app).get('/api/employees?status=invalid_status').expect(400);
     });
+
+    it('should return 400 when limit exceeds maximum allowed value', async () => {
+      const response = await request(app).get('/api/employees?limit=999999').expect(400);
+
+      expect(response.body).toHaveProperty('code', 'VALIDATION_ERROR');
+      expect(response.body).toHaveProperty('message', 'Validation Error');
+      expect(employeeService.findAll).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when page is zero or negative', async () => {
+      await request(app).get('/api/employees?page=0').expect(400);
+      expect(employeeService.findAll).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /api/employees/:id', () => {

--- a/backend/src/controllers/__tests__/paymentController.test.ts
+++ b/backend/src/controllers/__tests__/paymentController.test.ts
@@ -3,22 +3,36 @@ import request from 'supertest';
 import { PaymentController } from '../paymentController.js';
 import { AnchorService } from '../../services/anchorService.js';
 import { findConversionPaths } from '../../services/crossAssetPaymentService.js';
+import { Sep31TrackingService } from '../../services/sep31TrackingService.js';
 
 jest.mock('../../services/anchorService.js', () => ({
   AnchorService: {
     authenticate: jest.fn(),
     getSEP24Info: jest.fn(),
     getSEP31Info: jest.fn(),
+    initiatePayment: jest.fn(),
     initiateSEP24Withdrawal: jest.fn(),
     getSEP24Transaction: jest.fn(),
   },
 }));
 
+jest.mock('../../services/sep31TrackingService.js', () => ({
+  Sep31TrackingService: {
+    recordInitiation: jest.fn(),
+    updateFromPoll: jest.fn(),
+  },
+}));
+
+const VALID_SENDER_KEY = 'G' + 'A'.repeat(55);
+
 jest.mock('@stellar/stellar-sdk', () => ({
   Keypair: {
     fromSecret: jest.fn((secret: string) => ({
-      publicKey: () => (secret === 'SVALID' ? 'GSENDER' : 'GBAD'),
+      publicKey: () => (secret === 'SVALID' ? VALID_SENDER_KEY : 'GBAD'),
     })),
+  },
+  StrKey: {
+    isValidEd25519PublicKey: (key: string) => key.startsWith('G') && key.length === 56,
   },
 }));
 
@@ -47,7 +61,7 @@ describe('PaymentController SEP-24 endpoints', () => {
       .send({
         domain: 'anchor.example',
         secretKey: 'SVALID',
-        senderPublicKey: 'GSENDER',
+        senderPublicKey: VALID_SENDER_KEY,
         transactionData: { asset_code: 'USD', lang: 'en' },
       });
 
@@ -67,7 +81,7 @@ describe('PaymentController SEP-24 endpoints', () => {
       .send({
         domain: 'anchor.example',
         secretKey: 'SVALID',
-        senderPublicKey: 'GSENDER',
+        senderPublicKey: VALID_SENDER_KEY,
         transactionData: { asset_code: 'USD' },
         redirect: true,
       });
@@ -96,5 +110,122 @@ describe('PaymentController pathfinding', () => {
     expect(response.status).toBe(400);
     expect(response.body.error).toContain('Invalid asset identifier');
     expect(findConversionPaths).not.toHaveBeenCalled();
+  });
+});
+
+describe('PaymentController getAnchorInfo', () => {
+  const app = express();
+  app.use(express.json());
+  app.get('/anchor-info', PaymentController.getAnchorInfo);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects malformed domain before any anchor lookup', async () => {
+    const response = await request(app)
+      .get('/anchor-info')
+      .query({ domain: 'not-a-valid-domain!!' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+    expect(AnchorService.getSEP31Info).not.toHaveBeenCalled();
+    expect(AnchorService.getSEP24Info).not.toHaveBeenCalled();
+  });
+
+  it('returns anchor info for a valid domain', async () => {
+    (AnchorService.getSEP31Info as jest.Mock).mockResolvedValueOnce({ version: '1.0' });
+
+    const response = await request(app)
+      .get('/anchor-info')
+      .query({ domain: 'anchor.example' })
+      .expect(200);
+
+    expect(response.body).toEqual({ version: '1.0' });
+    expect(AnchorService.getSEP31Info).toHaveBeenCalledWith('anchor.example');
+  });
+});
+
+describe('PaymentController initiateSEP31', () => {
+  const app = express();
+  app.use(express.json());
+  app.post('/sep31/initiate', PaymentController.initiateSEP31);
+
+  const validBody = {
+    domain: 'anchor.example',
+    secretKey: 'SVALID',
+    senderPublicKey: VALID_SENDER_KEY,
+    paymentData: {
+      amount: '100.00',
+      asset_code: 'USDC',
+      receiver_id: 'receiver-123',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects missing paymentData fields before calling AnchorService', async () => {
+    const response = await request(app)
+      .post('/sep31/initiate')
+      .send({
+        ...validBody,
+        paymentData: { amount: '100.00' },
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+    expect(AnchorService.authenticate).not.toHaveBeenCalled();
+    expect(AnchorService.initiatePayment).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed amount in paymentData', async () => {
+    const response = await request(app)
+      .post('/sep31/initiate')
+      .send({
+        ...validBody,
+        paymentData: {
+          amount: '-50',
+          asset_code: 'USDC',
+          receiver_id: 'receiver-123',
+        },
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+    expect(AnchorService.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid domain format', async () => {
+    const response = await request(app)
+      .post('/sep31/initiate')
+      .send({
+        ...validBody,
+        domain: 'https://evil.example/path',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+    expect(AnchorService.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('initiates payment when payload is valid', async () => {
+    (AnchorService.authenticate as jest.Mock).mockResolvedValueOnce('sep10-token');
+    (AnchorService.initiatePayment as jest.Mock).mockResolvedValueOnce({
+      id: 'tx-1',
+      status: 'pending',
+    });
+
+    const response = await request(app).post('/sep31/initiate').send(validBody);
+
+    expect(response.status).toBe(200);
+    expect(AnchorService.authenticate).toHaveBeenCalled();
+    expect(AnchorService.initiatePayment).toHaveBeenCalledWith(
+      'anchor.example',
+      'sep10-token',
+      validBody.paymentData
+    );
+    expect(Sep31TrackingService.recordInitiation).toHaveBeenCalled();
   });
 });

--- a/backend/src/controllers/bulkImportController.ts
+++ b/backend/src/controllers/bulkImportController.ts
@@ -1,27 +1,49 @@
 import { Request, Response } from 'express';
+import { z } from 'zod';
 import {
   UnsupportedCsvEncodingError,
   csvPayrollImportService,
 } from '../services/csvPayrollImportService.js';
+import {
+  bulkImportBodySchema,
+  isCsvContentOversized,
+  MAX_BULK_IMPORT_CSV_BYTES,
+} from '../schemas/bulkImportSchema.js';
+import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
 import logger from '../utils/logger.js';
 
 export class BulkImportController {
   async import(req: Request, res: Response) {
     try {
-      const organizationId = req.user?.organizationId ?? Number(req.body.organization_id);
-      const csvContent = req.body.csv; // Assuming the CSV is sent as a string in the 'csv' field
-
-      if (!organizationId) {
-        return res.status(400).json({ error: 'Missing organization_id' });
+      const parsed = bulkImportBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json(
+            apiErrorResponse(ErrorCodes.VALIDATION_ERROR, 'Validation Error', parsed.error.issues)
+          );
       }
 
-      if (!csvContent) {
-        return res.status(400).json({ error: 'Missing csv content' });
+      const organizationId = req.user?.organizationId ?? parsed.data.organization_id;
+      const csvContent = parsed.data.csv;
+
+      if (!organizationId) {
+        return res
+          .status(400)
+          .json(apiErrorResponse(ErrorCodes.BAD_REQUEST, 'Missing organization_id'));
+      }
+
+      if (isCsvContentOversized(csvContent)) {
+        return res.status(413).json(
+          apiErrorResponse(
+            ErrorCodes.PAYLOAD_TOO_LARGE,
+            `CSV content exceeds maximum size of ${MAX_BULK_IMPORT_CSV_BYTES} bytes`
+          )
+        );
       }
 
       const result = await csvPayrollImportService.processCsv(organizationId, csvContent);
 
-      // Return 207 Multi-Status if there were any errors, otherwise 200/201
       const statusCode = result.errorCount > 0 ? 207 : result.successCount > 0 ? 201 : 200;
 
       res.status(statusCode).json({
@@ -42,6 +64,12 @@ export class BulkImportController {
           error: 'Unsupported Encoding',
           message: error.message,
         });
+      }
+
+      if (error instanceof z.ZodError) {
+        return res
+          .status(400)
+          .json(apiErrorResponse(ErrorCodes.VALIDATION_ERROR, 'Validation Error', error.issues));
       }
 
       logger.error('Bulk Import Controller Error:', error);

--- a/backend/src/controllers/paymentController.ts
+++ b/backend/src/controllers/paymentController.ts
@@ -3,6 +3,8 @@ import { AnchorService } from '../services/anchorService.js';
 import { Keypair } from '@stellar/stellar-sdk';
 import { findConversionPaths, type PathfindRequest } from '../services/crossAssetPaymentService.js';
 import { Sep31TrackingService } from '../services/sep31TrackingService.js';
+import { anchorInfoQuerySchema, initiateSep31Schema } from '../schemas/paymentSchema.js';
+import { apiErrorResponse, ErrorCodes } from '../utils/apiError.js';
 
 const STELLAR_ASSET_REGEX = /^(native|[A-Z0-9]{1,12}:G[A-Z2-7]{55})$/;
 
@@ -15,14 +17,20 @@ export class PaymentController {
    * GET /api/payments/anchor-info
    */
   static async getAnchorInfo(req: Request, res: Response) {
-    const { domain, protocol } = req.query;
-    if (!domain) return res.status(400).json({ error: 'Domain required' });
+    const parsed = anchorInfoQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json(apiErrorResponse(ErrorCodes.VALIDATION_ERROR, 'Validation Error', parsed.error.issues));
+    }
+
+    const { domain, protocol } = parsed.data;
 
     try {
       const info =
         protocol === 'sep24'
-          ? await AnchorService.getSEP24Info(domain as string)
-          : await AnchorService.getSEP31Info(domain as string);
+          ? await AnchorService.getSEP24Info(domain)
+          : await AnchorService.getSEP31Info(domain);
       res.json(info);
     } catch (error: any) {
       res.status(500).json({ error: error.message });
@@ -33,13 +41,14 @@ export class PaymentController {
    * POST /api/payments/sep31/initiate
    */
   static async initiateSEP31(req: Request, res: Response) {
-    const { domain, paymentData, secretKey, senderPublicKey } = req.body;
-
-    if (!domain || !paymentData || !secretKey || !senderPublicKey) {
-      return res.status(400).json({
-        error: 'Missing required fields: domain, paymentData, secretKey, senderPublicKey',
-      });
+    const parsed = initiateSep31Schema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json(apiErrorResponse(ErrorCodes.VALIDATION_ERROR, 'Validation Error', parsed.error.issues));
     }
+
+    const { domain, paymentData, secretKey, senderPublicKey } = parsed.data;
 
     try {
       const clientKeypair = Keypair.fromSecret(secretKey);

--- a/backend/src/schemas/bulkImportSchema.ts
+++ b/backend/src/schemas/bulkImportSchema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+/** Maximum UTF-8 byte length for bulk-import CSV payload (~1 MB). */
+export const MAX_BULK_IMPORT_CSV_BYTES = 1_048_576;
+
+/** JSON body limit for bulk-import requests (CSV max + encoding overhead). */
+export const MAX_BULK_IMPORT_REQUEST_BYTES = MAX_BULK_IMPORT_CSV_BYTES + 65_536;
+
+export const bulkImportBodySchema = z.object({
+  organization_id: z.coerce.number().int().positive().optional(),
+  csv: z.string().min(1, 'Missing csv content'),
+});
+
+export type BulkImportBody = z.infer<typeof bulkImportBodySchema>;
+
+export function isCsvContentOversized(csvContent: string): boolean {
+  return Buffer.byteLength(csvContent, 'utf8') > MAX_BULK_IMPORT_CSV_BYTES;
+}

--- a/backend/src/schemas/employeeSchema.ts
+++ b/backend/src/schemas/employeeSchema.ts
@@ -56,19 +56,17 @@ export const createEmployeeSchema = z.object({
 
 export const updateEmployeeSchema = createEmployeeSchema.partial().omit({ organization_id: true });
 
+export const EMPLOYEE_LIST_MAX_LIMIT = 100;
+
 export const employeeQuerySchema = z.object({
-  page: z
-    .string()
-    .regex(/^\d+$/)
-    .transform(Number)
+  page: z.coerce.number().int().min(1).optional().default(1),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(EMPLOYEE_LIST_MAX_LIMIT)
     .optional()
-    .default('1' as any),
-  limit: z
-    .string()
-    .regex(/^\d+$/)
-    .transform(Number)
-    .optional()
-    .default('10' as any),
+    .default(10),
   q: z.string().optional(),
   search: z.string().optional(),
   status: z.enum(['active', 'inactive', 'pending']).optional(),

--- a/backend/src/schemas/paymentSchema.ts
+++ b/backend/src/schemas/paymentSchema.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { StrKey } from '@stellar/stellar-sdk';
+
+/** Hostname-style domain (no scheme, path, port, or userinfo). */
+export const domainSchema = z
+  .string()
+  .min(1, 'Domain required')
+  .max(253)
+  .refine(
+    (value) =>
+      /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,63}$/.test(
+        value
+      ) &&
+      !value.includes('://') &&
+      !value.includes('/') &&
+      !value.includes('@'),
+    { message: 'Invalid domain format' }
+  );
+
+export const anchorInfoQuerySchema = z.object({
+  domain: domainSchema,
+  protocol: z.enum(['sep24', 'sep31']).optional(),
+});
+
+/** Core SEP-31 /transactions fields forwarded to the anchor. */
+export const sep31PaymentDataSchema = z.object({
+  amount: z
+    .string()
+    .min(1, 'amount is required')
+    .regex(/^\d+(\.\d+)?$/, 'amount must be a positive decimal string'),
+  asset_code: z
+    .string()
+    .min(1, 'asset_code is required')
+    .max(12)
+    .regex(/^[A-Za-z0-9]+$/, 'asset_code must be alphanumeric'),
+  receiver_id: z.string().min(1, 'receiver_id is required'),
+});
+
+export const initiateSep31Schema = z.object({
+  domain: domainSchema,
+  secretKey: z.string().min(1, 'secretKey is required'),
+  senderPublicKey: z
+    .string()
+    .length(56, 'senderPublicKey must be a valid Stellar public key')
+    .refine((value) => StrKey.isValidEd25519PublicKey(value), {
+      message: 'Invalid Stellar public key',
+    }),
+  paymentData: sep31PaymentDataSchema,
+});
+
+export type Sep31PaymentData = z.infer<typeof sep31PaymentDataSchema>;
+export type InitiateSep31Input = z.infer<typeof initiateSep31Schema>;

--- a/backend/src/utils/apiError.ts
+++ b/backend/src/utils/apiError.ts
@@ -41,6 +41,7 @@ export const ErrorCodes = {
   INTERNAL_ERROR: 'INTERNAL_ERROR',
   RATE_LIMITED: 'RATE_LIMITED',
   BAD_REQUEST: 'BAD_REQUEST',
+  PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];


### PR DESCRIPTION
## Summary

Adds schema-layer validation and controller tests for four API boundary hardening issues:

- **#914 — Employee list pagination bounds:** `employeeQuerySchema` now enforces `page >= 1` and `1 <= limit <= 100`. Out-of-range values return `400 VALIDATION_ERROR` before hitting the database.
- **#915 — Bulk CSV import size limit:** Bulk import rejects CSV content over 1 MB with `413 PAYLOAD_TOO_LARGE`. A route-specific JSON body parser allows legitimate imports while keeping the default limit elsewhere.
- **#918 — Anchor domain validation:** `getAnchorInfo` validates the `domain` query parameter (hostname format, no scheme/path) and returns `400` before any outbound SEP discovery lookup.
- **#919 — SEP-31 payment payload validation:** `initiateSEP31` validates `paymentData` (`amount`, `asset_code`, `receiver_id`) plus request fields via Zod before calling `AnchorService`.

Closes #914
Closes #915
Closes #918
Closes #919

## Test plan

- [x] `npx jest --config jest.config.cjs --testPathPattern="bulkImportController|employeeController|paymentController"` — 30 tests pass
- [ ] Verify `GET /api/employees?limit=999999` returns 400
- [ ] Verify `POST /api/employees/bulk-import` with >1 MB CSV returns 413
- [ ] Verify `GET /api/payments/anchor-info?domain=not-valid!!` returns 400 without anchor lookup
- [ ] Verify `POST /api/payments/sep31/initiate` with missing/malformed `paymentData` returns 400 before authentication


Made with [Cursor](https://cursor.com)