### PR TITLE
feat(cross_asset_payment): replace panics in accept_admin_transfer with typed errors

### DIFF
--- a/contracts/cross_asset_payment/src/lib.rs
+++ b/contracts/cross_asset_payment/src/lib.rs
@@ -22,6 +22,8 @@ pub enum CrossAssetPaymentError {
     AdminMismatch = 9,
     LedgerReplayDetected = 10,
     ContractPaused = 11,
+    NotProposedAdmin = 12,
+    NoPendingAdminTransfer = 13,
 }
 
 /// Emitted when the current admin proposes a new admin (two-step transfer).
@@ -192,15 +194,15 @@ impl CrossAssetPaymentContract {
     ///
     /// On success the caller becomes the new admin and the pending proposal is
     /// cleared, completing the two-step handoff.
-    pub fn accept_admin_transfer(env: Env, new_admin: Address) {
+    pub fn accept_admin_transfer(env: Env, new_admin: Address) -> Result<(), CrossAssetPaymentError> {
         let pending: Address = env
             .storage()
             .persistent()
             .get(&DataKey::PendingAdmin)
-            .expect("No pending admin transfer");
+            .ok_or(CrossAssetPaymentError::NoPendingAdminTransfer)?;
 
         if pending != new_admin {
-            panic!("Caller is not the proposed admin");
+            return Err(CrossAssetPaymentError::NotProposedAdmin);
         }
 
         new_admin.require_auth();
@@ -209,7 +211,7 @@ impl CrossAssetPaymentContract {
             .storage()
             .persistent()
             .get(&DataKey::Admin)
-            .expect("Not initialized");
+            .ok_or(CrossAssetPaymentError::NotInitialized)?;
 
         env.storage().persistent().set(&DataKey::Admin, &new_admin);
         env.storage().persistent().remove(&DataKey::PendingAdmin);
@@ -220,6 +222,8 @@ impl CrossAssetPaymentContract {
             new_admin,
         }
         .publish(&env);
+
+        Ok(())
     }
 
     /// Cancels the pending admin transfer proposal. Only the current admin may call this.

--- a/contracts/cross_asset_payment/src/test.rs
+++ b/contracts/cross_asset_payment/src/test.rs
@@ -570,7 +570,6 @@ fn test_accept_admin_transfer_allows_new_admin_operations() {
 }
 
 #[test]
-#[should_panic(expected = "Caller is not the proposed admin")]
 fn test_accept_admin_transfer_rejects_wrong_caller() {
     let (env, _admin, _contract_id, client) = setup();
 
@@ -579,18 +578,28 @@ fn test_accept_admin_transfer_rejects_wrong_caller() {
 
     client.propose_admin_transfer(&proposed);
 
-    // Impostor tries to accept — must panic
-    client.accept_admin_transfer(&impostor);
+    let result = client.try_accept_admin_transfer(&impostor);
+    assert_eq!(result, Err(Ok(CrossAssetPaymentError::NotProposedAdmin)));
 }
 
 #[test]
-#[should_panic(expected = "No pending admin transfer")]
-fn test_accept_admin_transfer_with_no_proposal_panics() {
+fn test_accept_admin_transfer_with_no_proposal_returns_error() {
     let (env, _admin, _contract_id, client) = setup();
 
     let random = Address::generate(&env);
-    // No proposal has been made
-    client.accept_admin_transfer(&random);
+    let result = client.try_accept_admin_transfer(&random);
+    assert_eq!(result, Err(Ok(CrossAssetPaymentError::NoPendingAdminTransfer)));
+}
+
+#[test]
+fn test_accept_admin_transfer_correct_caller_succeeds() {
+    let (env, _admin, _contract_id, client) = setup();
+
+    let new_admin = Address::generate(&env);
+    client.propose_admin_transfer(&new_admin);
+
+    let result = client.try_accept_admin_transfer(&new_admin);
+    assert_eq!(result, Ok(()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `NotProposedAdmin` (code 12) and `NoPendingAdminTransfer` (code 13) to `CrossAssetPaymentError`
- Changes `accept_admin_transfer` return type from `()` to `Result<(), CrossAssetPaymentError>` so callers get a recognisable error code instead of an opaque abort
- Replaces `panic!("Caller is not the proposed admin")` with `Err(CrossAssetPaymentError::NotProposedAdmin)`
- Replaces both `.expect()` calls in the same function with `ok_or(...)` returning typed errors
- Updates two `#[should_panic]` tests to assert the new typed errors via `try_accept_admin_transfer`
- Adds a third test confirming the happy path still succeeds

## Issues closed

Closes #878
Closes #876
Closes #881
Closes #874