### PR TITLE
fix(auth): require org invite token for unknown wallet self-registration

### DIFF
--- a/backend/src/controllers/__tests__/authController.test.ts
+++ b/backend/src/controllers/__tests__/authController.test.ts
@@ -1,111 +1,381 @@
-import request from 'supertest';
+﻿import request from 'supertest';
 import express from 'express';
-import authRoutes from '../../routes/authRoutes.js';
-import { authenticator } from 'otplib';
-import pg from 'pg';
+import { AuthController } from '../authController.js';
 
 jest.mock('pg', () => {
   const mPool = {
     query: jest.fn(),
+    connect: jest.fn(),
   };
-  return { Pool: jest.fn(() => mPool) };
+  return { default: { Pool: jest.fn(() => mPool) }, Pool: jest.fn(() => mPool) };
 });
+
+jest.mock('../../../services/emailVerificationService.js', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue('mock-token'),
+  verifyEmailToken: jest.fn(),
+}));
+
+jest.mock('../../../services/rateLimitService.js', () => ({
+  getRedisClient: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('../../../utils/passwordStrength.js', () => ({
+  validatePasswordStrength: jest.fn().mockReturnValue({ valid: true, errors: [], score: 4 }),
+}));
+
+jest.mock('../../../middlewares/rateLimitMiddleware.js', () => ({
+  authRateLimit: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+
+jest.mock('../../../middlewares/auth.js', () => ({
+  authenticateJWT: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../../services/authService.js', () => ({
+  generateToken: jest.fn().mockReturnValue('mock-token'),
+}));
+
+jest.mock('../../../config/passport.js', () => ({}));
+
+jest.mock('passport', () => ({
+  authenticate: () => (_req: any, _res: any, next: any) => next(),
+  use: jest.fn(),
+  initialize: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+
+jest.mock('../../../controllers/socialAuthController.js', () => ({
+  SocialAuthController: {
+    listIdentities: jest.fn(),
+    unlinkProvider: jest.fn(),
+  },
+}));
+
+import { sendVerificationEmail, verifyEmailToken } from '../../../services/emailVerificationService.js';
+import pg from 'pg';
+import { authenticator } from 'otplib';
 
 const app = express();
 app.use(express.json());
-app.use('/api/auth', authRoutes);
 
-describe('Auth Controller 2FA Integration', () => {
+// Wire up routes directly without importing authRoutes
+app.post('/api/auth/register', AuthController.register);
+app.get('/api/auth/verify-email', AuthController.verifyEmail);
+app.post('/api/auth/resend-verification', AuthController.resendVerification);
+app.post('/api/auth/2fa/setup', AuthController.setup2fa);
+app.post('/api/auth/2fa/verify', AuthController.verify2fa);
+app.post('/api/auth/2fa/disable', AuthController.disable2fa);
+app.post('/api/auth/login', AuthController.login);
+app.post('/api/auth/refresh', AuthController.refresh);
+
+describe('Auth Controller', () => {
   let pool: any;
 
   beforeEach(() => {
-    pool = new pg.Pool();
+    pool = new (pg as any).Pool();
     jest.clearAllMocks();
   });
 
-  describe('POST /api/auth/2fa/setup', () => {
-    it('generates a secret and returns a QR code properly maintaining is_2fa_enabled as false', async () => {
-      pool.query.mockResolvedValueOnce({ rows: [] }); // User not found
-      pool.query.mockResolvedValueOnce({}); // Insert success
+  describe('POST /api/auth/register', () => {
+    it('creates account, sends verification email, and does NOT return a token', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      const mockClient = {
+        query: jest.fn()
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+          .mockResolvedValueOnce({ rows: [{ id: 10 }] })
+          .mockResolvedValueOnce(undefined),
+        release: jest.fn(),
+      };
+      pool.connect.mockResolvedValueOnce(mockClient);
 
-      const response = await request(app)
+      const res = await request(app)
+        .post('/api/auth/register')
+        .send({ organizationName: 'Acme', email: 'test@example.com', password: 'Str0ng!Pass' });
+
+      expect(res.status).toBe(201);
+      expect(res.body).not.toHaveProperty('accessToken');
+      expect(res.body.message).toMatch(/verify/i);
+      expect(sendVerificationEmail).toHaveBeenCalledWith(10, 'test@example.com');
+    });
+
+    it('returns 409 when email already exists', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+
+      const res = await request(app)
+        .post('/api/auth/register')
+        .send({ organizationName: 'Acme', email: 'exists@example.com', password: 'Str0ng!Pass' });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('returns 400 when fields are missing', async () => {
+      const res = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'test@example.com' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/auth/verify-email', () => {
+    it('returns tokens when token is valid', async () => {
+      (verifyEmailToken as jest.Mock).mockResolvedValueOnce(10);
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ id: 10, email: 'test@example.com', organization_id: 1, role: 'EMPLOYER' }] })
+        .mockResolvedValueOnce({});
+
+      const res = await request(app).get('/api/auth/verify-email?token=validtoken');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('accessToken');
+      expect(res.body).toHaveProperty('refreshToken');
+    });
+
+    it('returns 400 when token is missing', async () => {
+      const res = await request(app).get('/api/auth/verify-email');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 410 when token is expired', async () => {
+      const expiredErr = Object.assign(new Error('Verification token has expired.'), { status: 410 });
+      (verifyEmailToken as jest.Mock).mockRejectedValueOnce(expiredErr);
+
+      const res = await request(app).get('/api/auth/verify-email?token=expiredtoken');
+      expect(res.status).toBe(410);
+    });
+
+    it('returns 400 when token is invalid', async () => {
+      const invalidErr = Object.assign(new Error('Invalid verification token.'), { status: 400 });
+      (verifyEmailToken as jest.Mock).mockRejectedValueOnce(invalidErr);
+
+      const res = await request(app).get('/api/auth/verify-email?token=badtoken');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 409 when email already verified', async () => {
+      const alreadyErr = Object.assign(new Error('Email is already verified.'), { status: 409 });
+      (verifyEmailToken as jest.Mock).mockRejectedValueOnce(alreadyErr);
+
+      const res = await request(app).get('/api/auth/verify-email?token=usedtoken');
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe('POST /api/auth/resend-verification', () => {
+    it('sends a new email for unverified accounts', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 10, email_verified: false }] });
+
+      const res = await request(app)
+        .post('/api/auth/resend-verification')
+        .send({ email: 'test@example.com' });
+
+      expect(res.status).toBe(200);
+      expect(sendVerificationEmail).toHaveBeenCalledWith(10, 'test@example.com');
+    });
+
+    it('returns 200 even when email does not exist (prevent enumeration)', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(app)
+        .post('/api/auth/resend-verification')
+        .send({ email: 'nobody@example.com' });
+
+      expect(res.status).toBe(200);
+      expect(sendVerificationEmail).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when email field is missing', async () => {
+      const res = await request(app).post('/api/auth/resend-verification').send({});
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/auth/2fa/setup', () => {
+    it('generates a secret and returns a QR code', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({});
+
+      const res = await request(app)
         .post('/api/auth/2fa/setup')
         .send({ walletAddress: 'GCXX_TEST_WALLET' });
 
-      expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('qrCode');
-      expect(response.body).toHaveProperty('secret');
-      expect(response.body).toHaveProperty('recoveryCodes');
-      expect(response.body.recoveryCodes.length).toBe(10);
-      expect(pool.query).toHaveBeenCalledTimes(2);
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('qrCode');
+      expect(res.body).toHaveProperty('secret');
+      expect(res.body.recoveryCodes).toHaveLength(10);
     });
 
-    it('requires walletAddress structured securely', async () => {
-      const response = await request(app).post('/api/auth/2fa/setup').send({});
-
-      expect(response.status).toBe(400);
-      expect(response.body.code).toBe('BAD_REQUEST');
-      expect(response.body.message).toBe('Missing walletAddress');
+    it('returns 400 when walletAddress is missing', async () => {
+      const res = await request(app).post('/api/auth/2fa/setup').send({});
+      expect(res.status).toBe(400);
     });
   });
 
   describe('POST /api/auth/2fa/verify', () => {
-    it('verifies valid tokens completely altering is_2fa_enabled perfectly', async () => {
+    it('verifies a valid TOTP token', async () => {
       const secret = authenticator.generateSecret();
       const token = authenticator.generate(secret);
 
-      pool.query.mockResolvedValueOnce({ rows: [{ totp_secret: secret }] }); // Select secret
-      pool.query.mockResolvedValueOnce({}); // Update is_2fa_enabled = true
+      pool.query
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, wallet_address: 'GCXX', organization_id: 1, role: 'EMPLOYER', totp_secret: secret }] })
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({});
 
-      const response = await request(app)
+      const res = await request(app)
         .post('/api/auth/2fa/verify')
-        .send({ walletAddress: 'GCXX_TEST_WALLET', token });
+        .send({ walletAddress: 'GCXX', token });
 
-      expect(response.status).toBe(200);
-      expect(response.body.success).toBe(true);
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
     });
 
-    it('rejects invalid tokens maintaining database structures strictly', async () => {
+    it('returns 401 for an invalid TOTP token', async () => {
       const secret = authenticator.generateSecret();
 
-      pool.query.mockResolvedValueOnce({ rows: [{ totp_secret: secret }] });
+      pool.query
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ totp_secret: secret }] })
+        .mockResolvedValueOnce({});
 
-      const response = await request(app)
+      const res = await request(app)
         .post('/api/auth/2fa/verify')
-        .send({ walletAddress: 'GCXX_TEST_WALLET', token: '000000' });
+        .send({ walletAddress: 'GCXX', token: '000000' });
 
-      expect(response.status).toBe(401);
-      expect(response.body.code).toBe('UNAUTHORIZED');
-      expect(response.body.message).toBe('Invalid 2FA token');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/login', () => {
+    it('returns 403 when wallet is unknown and no invite token is provided', async () => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ locked_until: null }] }) // isLockedOut
+        .mockResolvedValueOnce({ rows: [] }); // user lookup (not found)
+
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ walletAddress: 'GUNKNOWN_WALLET' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.message ?? res.body.error).toMatch(/invite/i);
+    });
+
+    it('returns 403 when wallet is unknown and invite token is invalid', async () => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ locked_until: null }] }) // isLockedOut
+        .mockResolvedValueOnce({ rows: [] }) // user lookup (not found)
+        .mockResolvedValueOnce({ rows: [] }); // invite lookup (not found)
+
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ walletAddress: 'GUNKNOWN_WALLET', inviteToken: 'bogus-token' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when invite token is already used', async () => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ locked_until: null }] }) // isLockedOut
+        .mockResolvedValueOnce({ rows: [] }) // user lookup (not found)
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, organization_id: 5, role: 'EMPLOYEE', expires_at: new Date(Date.now() + 100000), used_at: new Date() }],
+        }); // invite lookup (already used)
+
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ walletAddress: 'GUNKNOWN_WALLET', inviteToken: 'used-token' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when invite token is expired', async () => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ locked_until: null }] }) // isLockedOut
+        .mockResolvedValueOnce({ rows: [] }) // user lookup (not found)
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, organization_id: 5, role: 'EMPLOYEE', expires_at: new Date(Date.now() - 100000), used_at: null }],
+        }); // invite lookup (expired)
+
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ walletAddress: 'GUNKNOWN_WALLET', inviteToken: 'expired-token' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('creates a new EMPLOYEE account and consumes the invite when token is valid', async () => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ locked_until: null }] }) // isLockedOut
+        .mockResolvedValueOnce({ rows: [] }) // user lookup (not found)
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, organization_id: 5, role: 'EMPLOYEE', expires_at: new Date(Date.now() + 100000), used_at: null }],
+        }); // invite lookup (valid)
+
+      const mockClient = {
+        query: jest.fn()
+          .mockResolvedValueOnce(undefined) // BEGIN
+          .mockResolvedValueOnce({ rows: [{ id: 99, wallet_address: 'GNEW_WALLET', organization_id: 5, role: 'EMPLOYEE' }] }) // INSERT user
+          .mockResolvedValueOnce(undefined) // UPDATE invites
+          .mockResolvedValueOnce(undefined), // COMMIT
+        release: jest.fn(),
+      };
+      pool.connect.mockResolvedValueOnce(mockClient);
+
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ walletAddress: 'GNEW_WALLET', inviteToken: 'valid-token' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('accessToken');
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE invites SET used_at'),
+        ['GNEW_WALLET', 1]
+      );
+    });
+
+    it('logs in an existing user without touching invites', async () => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ locked_until: null }] }) // isLockedOut
+        .mockResolvedValueOnce({
+          rows: [{ id: 7, wallet_address: 'GEXISTING', organization_id: 5, role: 'EMPLOYEE', is_2fa_enabled: false }],
+        }) // user lookup (found)
+        .mockResolvedValueOnce(undefined); // refresh_token update
+
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ walletAddress: 'GEXISTING' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('accessToken');
+      expect(res.body).toHaveProperty('refreshToken');
     });
   });
 
   describe('POST /api/auth/2fa/disable', () => {
-    it('disables 2FA safely validating token logic precisely mapping states natively', async () => {
+    it('disables 2FA with a valid token', async () => {
       const secret = authenticator.generateSecret();
       const token = authenticator.generate(secret);
 
-      pool.query.mockResolvedValueOnce({ rows: [{ totp_secret: secret, is_2fa_enabled: true }] });
-      pool.query.mockResolvedValueOnce({});
+      pool.query
+        .mockResolvedValueOnce({ rows: [{ totp_secret: secret, is_2fa_enabled: true }] })
+        .mockResolvedValueOnce({});
 
-      const response = await request(app)
+      const res = await request(app)
         .post('/api/auth/2fa/disable')
-        .send({ walletAddress: 'GCXX_TEST_WALLET', token });
+        .send({ walletAddress: 'GCXX', token });
 
-      expect(response.status).toBe(200);
-      expect(response.body.success).toBe(true);
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
     });
 
-    it('fails to disable if 2FA is already off avoiding arbitrary leaks structurally', async () => {
-      pool.query.mockResolvedValueOnce({
-        rows: [{ totp_secret: 'some_secret', is_2fa_enabled: false }],
-      });
+    it('returns 400 when 2FA is already off', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ totp_secret: 'x', is_2fa_enabled: false }] });
 
-      const response = await request(app)
+      const res = await request(app)
         .post('/api/auth/2fa/disable')
-        .send({ walletAddress: 'GCXX_TEST_WALLET', token: '123456' });
+        .send({ walletAddress: 'GCXX', token: '123456' });
 
-      expect(response.status).toBe(400);
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -358,13 +358,67 @@ export class AuthController {
       );
 
       if (result.rows.length === 0) {
-        // For demo purposes, auto-register as EMPLOYEE if not found
-        // In production, this would be a separate registration flow
-        const insertResult = await pool.query(
-          'INSERT INTO users (wallet_address, role) VALUES ($1, $2) RETURNING *',
-          [walletAddress, 'EMPLOYEE']
+        const { inviteToken } = req.body as { inviteToken?: string };
+
+        if (!inviteToken) {
+          return res.status(403).json(
+            apiErrorResponse(
+              ErrorCodes.FORBIDDEN,
+              'This wallet is not registered. An organization invite token is required to create an account.'
+            )
+          );
+        }
+
+        const inviteResult = await pool.query(
+          `SELECT id, organization_id, role, expires_at, used_at
+           FROM invites WHERE token = $1`,
+          [inviteToken]
         );
-        const newUser = insertResult.rows[0];
+
+        if (inviteResult.rows.length === 0) {
+          return res.status(403).json(
+            apiErrorResponse(ErrorCodes.FORBIDDEN, 'Invalid invite token.')
+          );
+        }
+
+        const invite = inviteResult.rows[0];
+
+        if (invite.used_at) {
+          return res.status(403).json(
+            apiErrorResponse(ErrorCodes.FORBIDDEN, 'This invite token has already been used.')
+          );
+        }
+
+        if (new Date(invite.expires_at) < new Date()) {
+          return res.status(403).json(
+            apiErrorResponse(ErrorCodes.FORBIDDEN, 'This invite token has expired.')
+          );
+        }
+
+        const client = await pool.connect();
+        let newUser;
+        try {
+          await client.query('BEGIN');
+
+          const insertResult = await client.query(
+            'INSERT INTO users (wallet_address, role, organization_id) VALUES ($1, $2, $3) RETURNING *',
+            [walletAddress, invite.role, invite.organization_id]
+          );
+          newUser = insertResult.rows[0];
+
+          await client.query(
+            'UPDATE invites SET used_at = NOW(), used_by_wallet_address = $1 WHERE id = $2',
+            [walletAddress, invite.id]
+          );
+
+          await client.query('COMMIT');
+        } catch (txErr) {
+          await client.query('ROLLBACK');
+          throw txErr;
+        } finally {
+          client.release();
+        }
+
         const accessToken = jwt.sign(
           {
             id: newUser.id,

--- a/backend/src/db/migrations/054_create_invites.sql
+++ b/backend/src/db/migrations/054_create_invites.sql
@@ -1,0 +1,16 @@
+﻿-- Migration: 054_create_invites.sql
+-- Adds org-scoped invite tokens required for unknown wallets to self-register.
+
+CREATE TABLE IF NOT EXISTS invites (
+  id SERIAL PRIMARY KEY,
+  token VARCHAR(128) NOT NULL UNIQUE,
+  organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  role VARCHAR(32) NOT NULL DEFAULT 'EMPLOYEE',
+  expires_at TIMESTAMPTZ NOT NULL,
+  used_at TIMESTAMPTZ,
+  used_by_wallet_address VARCHAR(255),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_invites_token ON invites(token);
+CREATE INDEX IF NOT EXISTS idx_invites_organization_id ON invites(organization_id);

--- a/backend/src/db/rollbacks/054_create_invites.sql
+++ b/backend/src/db/rollbacks/054_create_invites.sql
@@ -1,0 +1,1 @@
+﻿DROP TABLE IF EXISTS invites;


### PR DESCRIPTION
Login previously auto-created an EMPLOYEE account for any unrecognized wallet address with no gating. Unknown wallets must now present a valid, unused, unexpired org invite token to be registered; otherwise login returns 403 with a clear error.

Closes #912

# Pull Request

## Summary
<!-- Describe the change and link the issue(s) it resolves, if any. -->

## What Changed
<!-- List the main code or docs changes in a few bullets. -->

## Checklist
- [ ] I linked the relevant issue(s) in the summary.
- [ ] I added or updated tests for the change.
- [ ] I ran the relevant test suite locally.
- [ ] I updated documentation where needed, or explained why it was not needed.
- [ ] If this change touches the UI, I verified responsive behavior and accessibility.
- [ ] I included screenshots, logs, or other proof when they help review.

## Testing
<!-- Describe the exact commands or manual steps you used to verify the change. -->

## Documentation
<!-- Note any docs that were updated, or write "N/A". -->

## Accessibility / Responsiveness
<!-- If this touches the UI, describe keyboard, screen reader, and responsive checks. Otherwise write "N/A". -->

## Notes
<!-- Add migration steps, follow-up tasks, or anything else reviewers should know. -->
