### PR TITLE
fix: resolve issues #863, #864, #865, #867

### DIFF
--- a/contracts/asset_path_payment/src/lib.rs
+++ b/contracts/asset_path_payment/src/lib.rs
@@ -99,6 +99,14 @@ pub struct ContractStatusChangedEvent {
     pub admin: Address,
 }
 
+/// Event emitted when tokens are withdrawn from the contract
+#[contractevent]
+pub struct WithdrawEvent {
+    pub asset: Address,
+    pub amount: i128,
+    pub to: Address,
+}
+
 const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
 const TEMPORARY_TTL_THRESHOLD: u32 = 2_000;
@@ -303,6 +311,12 @@ impl AssetPathPaymentContract {
             return Err(PathPaymentError::PaymentNotPending);
         }
 
+        // Validate actual_source_amount is non-negative — a negative value could
+        // corrupt downstream settlement accounting.
+        if actual_source_amount < 0 {
+            return Err(PathPaymentError::InvalidAmount);
+        }
+
         // Verify slippage protection
         if actual_dest_amount < record.dest_min_amount {
             record.status = symbol_short!("failed");
@@ -413,6 +427,13 @@ impl AssetPathPaymentContract {
     }
 
     /// Admin-only function to withdraw tokens (for refunds)
+    ///
+    /// # Failure behavior
+    /// The underlying `token::Client::transfer` will panic (revert the entire call)
+    /// if the transfer fails — e.g. the recipient lacks a trustline for the asset
+    /// or the contract has insufficient balance. Because a Soroban panic reverts
+    /// all state changes, the contract's escrow balances remain consistent even
+    /// when a withdrawal attempt fails.
     pub fn withdraw(
         env: Env,
         asset: Address,
@@ -428,6 +449,13 @@ impl AssetPathPaymentContract {
 
         let token_client = token::Client::new(&env, &asset);
         token_client.transfer(&env.current_contract_address(), &to, &amount);
+
+        WithdrawEvent {
+            asset,
+            amount,
+            to,
+        }
+        .publish(&env);
 
         Ok(())
     }

--- a/contracts/asset_path_payment/src/test.rs
+++ b/contracts/asset_path_payment/src/test.rs
@@ -360,6 +360,43 @@ fn test_complete_path_payment_slippage_rejection() {
 }
 
 #[test]
+fn test_complete_path_payment_rejects_negative_source_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let source = create_token_contract(&env, &Address::generate(&env));
+    let dest = create_token_contract(&env, &Address::generate(&env));
+    let stellar = token::StellarAssetClient::new(&env, &source);
+    stellar.mint(&from, &5000);
+
+    let contract_id = env.register(AssetPathPaymentContract, ());
+    let client = AssetPathPaymentContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let id = client.initiate_path_payment(
+        &from,
+        &to,
+        &source,
+        &dest,
+        &200,
+        &180,
+        &200,
+        &Vec::new(&env),
+    );
+
+    // Negative actual_source_amount must be rejected
+    let result = client.try_complete_path_payment(&id, &(-50), &190);
+    assert_eq!(result, Err(Ok(PathPaymentError::InvalidAmount)));
+
+    // Record must remain pending (state unchanged)
+    let record = client.get_payment(&id).unwrap();
+    assert_eq!(record.status, symbol_short!("pending"));
+}
+
+#[test]
 fn test_fail_path_payment_with_partial_failure_flag() {
     let env = Env::default();
     env.mock_all_auths();
@@ -508,6 +545,76 @@ fn test_withdraw_success() {
 
     assert_eq!(tc.balance(&recipient), 150);
     assert_eq!(tc.balance(&contract_id), 150);
+}
+
+#[test]
+fn test_withdraw_transfer_failure_preserves_contract_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let from = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let source = create_token_contract(&env, &token_admin);
+    let stellar = token::StellarAssetClient::new(&env, &source);
+    stellar.mint(&from, &5000);
+
+    let contract_id = env.register(AssetPathPaymentContract, ());
+    let client = AssetPathPaymentContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let to = Address::generate(&env);
+    let dest = create_token_contract(&env, &Address::generate(&env));
+
+    // Send tokens to contract escrow
+    client.initiate_path_payment(&from, &to, &source, &dest, &300, &270, &300, &Vec::new(&env));
+
+    let tc = token::Client::new(&env, &source);
+    assert_eq!(tc.balance(&contract_id), 300);
+
+    // Attempt to withdraw more than the contract holds — transfer will panic,
+    // which reverts the entire call and leaves contract balance unchanged.
+    let recipient = Address::generate(&env);
+    let result = client.try_withdraw(&source, &500, &recipient);
+    assert!(result.is_err());
+
+    // Contract balance must be preserved after failed withdrawal.
+    assert_eq!(tc.balance(&contract_id), 300);
+}
+
+#[test]
+fn test_withdraw_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let from = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let source = create_token_contract(&env, &token_admin);
+    let stellar = token::StellarAssetClient::new(&env, &source);
+    stellar.mint(&from, &5000);
+
+    let contract_id = env.register(AssetPathPaymentContract, ());
+    let client = AssetPathPaymentContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let to = Address::generate(&env);
+    let dest = create_token_contract(&env, &Address::generate(&env));
+    let recipient = Address::generate(&env);
+
+    client.initiate_path_payment(&from, &to, &source, &dest, &300, &270, &300, &Vec::new(&env));
+    client.withdraw(&source, &150, &recipient);
+
+    // Verify the withdraw event was published with expected topics/data
+    let events = env.events().all();
+    let withdraw_event = events.iter().find(|(_, topics, _)| {
+        let topic0: soroban_sdk::Symbol = topics.get(0).unwrap();
+        topic0 == symbol_short!("withdraw")
+    });
+    assert!(
+        withdraw_event.is_some(),
+        "expected a WithdrawEvent to be emitted on successful withdraw()"
+    );
 }
 
 // ══════════════════════════════════════════════════════════════════════════════

--- a/contracts/bulk_payment/README.md
+++ b/contracts/bulk_payment/README.md
@@ -27,7 +27,7 @@ Soroban contract for payroll-sized batch payments with per-account spending limi
 | `get_throttle_config()` | Reads global batch throttling. |
 | `estimate_batch_fee(payment_count, base_fee_stroops, fee_bump_required)` | Estimates batch fee and budget in stroops. |
 | `execute_batch(sender, token, payments, expected_sequence)` | Executes all-or-nothing batch payments. |
-| `execute_batch_partial(sender, token, payments, expected_sequence)` | Executes legacy best-effort batch payments. |
+| `execute_batch_partial(sender, token, payments, expected_sequence)` | Best-effort batch payments. Returns `BatchPartialResult` with a `failures` list of `(index, amount, reason)` for skipped entries. |
 | `execute_batch_v2(sender, token, payments, expected_sequence, all_or_nothing)` | Executes tracked batch payments with per-payment status. |
 | `refund_failed_payment(batch_id, payment_index)` | Refunds a failed v2 payment entry. |
 | `schedule_batch(sender, token, payments, execute_after_ledger)` | Escrows and schedules a future batch. |

--- a/contracts/bulk_payment/src/lib.rs
+++ b/contracts/bulk_payment/src/lib.rs
@@ -338,6 +338,23 @@ pub struct BatchStatusMap {
     pub status_words: Vec<u32>,
 }
 
+/// A single skipped/failed entry reported by `execute_batch_partial`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FailureEntry {
+    pub index: u32,
+    pub amount: i128,
+    pub reason: Symbol,
+}
+
+/// Extended result returned by `execute_batch_partial`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BatchPartialResult {
+    pub batch_id: u64,
+    pub failures: Vec<FailureEntry>,
+}
+
 /// Configuration for automatic distribution account re-funding.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -985,7 +1002,7 @@ impl BulkPaymentContract {
         token: Address,
         payments: Vec<PaymentOp>,
         expected_sequence: u64,
-    ) -> Result<u64, ContractError> {
+    ) -> Result<BatchPartialResult, ContractError> {
         Self::require_not_paused(&env)?;
         sender.require_auth();
         Self::require_unique_ledger(&env, &sender)?;
@@ -1022,12 +1039,23 @@ impl BulkPaymentContract {
         let mut actual_success: u32 = 0;
         let mut fail_count: u32 = 0;
         let mut total_sent: i128 = 0;
+        let mut failures: Vec<FailureEntry> = Vec::new(&env);
 
         let mut payment_index: u32 = 0;
         for op in payments.iter() {
             // Optimized: single pass for validation and distribution
             if op.amount <= 0 || remaining < op.amount {
+                let reason = if op.amount <= 0 {
+                    symbol_short!("bad_amt")
+                } else {
+                    symbol_short!("low_bal")
+                };
                 fail_count += 1;
+                failures.push_back(FailureEntry {
+                    index: payment_index,
+                    amount: op.amount,
+                    reason,
+                });
                 PaymentSkippedEvent {
                     batch_id,
                     payment_index,
@@ -1090,7 +1118,7 @@ impl BulkPaymentContract {
             fail_count,
         }
         .publish(&env);
-        Ok(batch_id)
+        Ok(BatchPartialResult { batch_id, failures })
     }
 
     // ── Graceful revert with refund (Issue #261) ──────────────────────────

--- a/contracts/bulk_payment/src/test.rs
+++ b/contracts/bulk_payment/src/test.rs
@@ -174,6 +174,50 @@ fn test_batch_count_increments() {
 // ── execute_batch_partial ─────────────────────────────────────────────────────
 
 #[test]
+fn test_partial_batch_reports_failure_entries() {
+    let (env, sender, token, client) = setup();
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+
+    let mut payments: Vec<PaymentOp> = Vec::new(&env);
+    payments.push_back(PaymentOp {
+        recipient: r1.clone(),
+        amount: 100,
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
+    payments.push_back(PaymentOp {
+        recipient: r2.clone(),
+        amount: 0, // invalid → reported in failures list
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
+    payments.push_back(PaymentOp {
+        recipient: r3.clone(),
+        amount: -5, // invalid → reported in failures list
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
+
+    let result = client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
+
+    assert_eq!(result.failures.len(), 2);
+
+    let f1 = result.failures.get(0).unwrap();
+    assert_eq!(f1.index, 1);
+    assert_eq!(f1.amount, 0);
+    assert_eq!(f1.reason, soroban_sdk::symbol_short!("bad_amt"));
+
+    let f2 = result.failures.get(1).unwrap();
+    assert_eq!(f2.index, 2);
+    assert_eq!(f2.amount, -5);
+    assert_eq!(f2.reason, soroban_sdk::symbol_short!("bad_amt"));
+
+    // Successful payment still went through
+    let tc = TokenClient::new(&env, &token);
+    assert_eq!(tc.balance(&r1), 100);
+}
+
+#[test]
 fn test_partial_batch_skips_insufficient_funds() {
     let (env, sender, token, client) = setup();
 
@@ -192,11 +236,13 @@ fn test_partial_batch_skips_insufficient_funds() {
         category: soroban_sdk::symbol_short!("payroll"),
     }); // invalid → skip
 
-    let batch_id = client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
+    let result = client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
 
-    let record = client.get_batch(&batch_id);
+    let record = client.get_batch(&result.batch_id);
     assert_eq!(record.success_count, 1);
     assert_eq!(record.fail_count, 1);
+    assert_eq!(result.failures.len(), 1);
+    assert_eq!(result.failures.get(0).unwrap().index, 1);
 
     let tc = TokenClient::new(&env, &token);
     assert_eq!(tc.balance(&r1), 500_000);
@@ -214,11 +260,13 @@ fn test_partial_batch_all_fail_status_is_rollbck() {
         category: soroban_sdk::symbol_short!("payroll"),
     });
 
-    let batch_id = client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
+    let result = client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
 
-    let record = client.get_batch(&batch_id);
+    let record = client.get_batch(&result.batch_id);
     assert_eq!(record.success_count, 0);
     assert_eq!(record.fail_count, 1);
+    assert_eq!(result.failures.len(), 1);
+    assert_eq!(result.failures.get(0).unwrap().index, 0);
 }
 
 #[test]
@@ -556,7 +604,7 @@ fn test_partial_batch_usage_tracks_actual_sent() {
         category: soroban_sdk::symbol_short!("payroll"),
     }); // skipped
 
-    client.execute_batch_partial(&sender, &token, &payments, &0);
+    let _ = client.execute_batch_partial(&sender, &token, &payments, &0);
 
     let usage = client.get_account_usage(&sender);
     // Only the 500 that was actually sent should be tracked
@@ -697,7 +745,7 @@ fn test_benchmark_50_payment_partial_batch() {
         });
     }
 
-    let batch_id = client.execute_batch_partial(&sender, &token_id, &payments, &0);
+    let result = client.execute_batch_partial(&sender, &token_id, &payments, &0);
 
     let tc = TokenClient::new(&env, &token_id);
     for i in 0..50 {
@@ -707,10 +755,11 @@ fn test_benchmark_50_payment_partial_batch() {
 
     assert_eq!(tc.balance(&sender), 50_000);
 
-    let record = client.get_batch(&batch_id);
+    let record = client.get_batch(&result.batch_id);
     assert_eq!(record.total_sent, 50_000);
     assert_eq!(record.success_count, 50);
     assert_eq!(record.fail_count, 0);
+    assert_eq!(result.failures.len(), 0);
 }
 
 /// Verify atomicity: if a payment has invalid amount, entire batch reverts
@@ -2425,7 +2474,7 @@ fn test_throttle_blocks_execute_batch_partial() {
     client.set_throttle_config(&100, &3);
     let payments = one_payment(&env);
 
-    client.execute_batch_partial(&sender, &token, &payments, &0);
+    let _ = client.execute_batch_partial(&sender, &token, &payments, &0);
 
     env.ledger().set_sequence_number(102); // gap = 2, need ≥ 3
     let result = client.try_execute_batch_partial(&sender, &token, &payments, &1);
@@ -2438,11 +2487,11 @@ fn test_throttle_allows_execute_batch_partial_after_gap() {
     client.set_throttle_config(&100, &3);
     let payments = one_payment(&env);
 
-    client.execute_batch_partial(&sender, &token, &payments, &0);
+    let _ = client.execute_batch_partial(&sender, &token, &payments, &0);
 
     env.ledger().set_sequence_number(103); // gap = 3, exactly meets min_ledger_gap
-    let batch_id = client.execute_batch_partial(&sender, &token, &payments, &1);
-    assert_eq!(batch_id, 2);
+    let result = client.execute_batch_partial(&sender, &token, &payments, &1);
+    assert_eq!(result.batch_id, 2);
 }
 
 #[test]
@@ -2501,7 +2550,7 @@ fn test_dust_amounts_paid_exactly_no_residual_held() {
         category: soroban_sdk::symbol_short!("payroll"),
     });
 
-    let batch_id = client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
+    let result = client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
 
     let tc = TokenClient::new(&env, &token);
     assert_eq!(tc.balance(&r1), 100_000);
@@ -2510,9 +2559,10 @@ fn test_dust_amounts_paid_exactly_no_residual_held() {
     // Sender lost exactly the sum of all amounts — no residual held by contract
     assert_eq!(tc.balance(&sender), 1_000_000 - 150_001);
 
-    let record = client.get_batch(&batch_id);
+    let record = client.get_batch(&result.batch_id);
     assert_eq!(record.success_count, 3);
     assert_eq!(record.fail_count, 0);
+    assert_eq!(result.failures.len(), 0);
 }
 
 #[test]
@@ -2542,7 +2592,7 @@ fn test_dust_invalid_mix_refunds_correctly() {
         category: soroban_sdk::symbol_short!("payroll"),
     });
 
-    client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
+    let _ = client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
 
     let tc = TokenClient::new(&env, &token);
     assert_eq!(tc.balance(&r1), 200_000);

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -89,7 +89,7 @@ Handles payroll disbursement to up to 100 employees per transaction envelope.
 |---|---|
 | `initialize(admin)` | Sets contract admin; callable once |
 | `execute_batch(sender, token, payments, seq)` | All-or-nothing batch; reverts on any invalid amount |
-| `execute_batch_partial(sender, token, payments, seq)` | Best-effort batch; skips invalid entries |
+| `execute_batch_partial(sender, token, payments, seq)` | Best-effort batch; returns `BatchPartialResult` with `failures` list |
 | `execute_batch_v2(…, all_or_nothing)` | Unified entry with per-payment `PaymentEntry` records |
 | `refund_failed_payment(batch_id, idx)` | Returns held funds for a `Failed` entry to the sender |
 | `set_account_limits(account, daily, weekly, monthly)` | Admin-configurable spend limits per account |


### PR DESCRIPTION
## Summary

Fixes four issues across the bulk_payment and asset_path_payment contracts.

### Issues Resolved

**#863 — [asset_path_payment] actual_source_amount not validated as non-negative before storage**
- Added explicit `actual_source_amount < 0` check with `InvalidAmount` error in `complete_path_payment`
- Added unit test `test_complete_path_payment_rejects_negative_source_amount`

**#864 — [asset_path_payment] token::Client::transfer failure during escrow release is unhandled**
- Documented the panic-on-failure behavior in the `withdraw()` doc comment
- Added unit test `test_withdraw_transfer_failure_preserves_contract_balance` confirming contract state is consistent after a failed transfer

**#865 — [asset_path_payment] No event emitted on successful withdraw()**
- Added `WithdrawEvent` contract event struct with `asset`, `amount`, `to` fields
- Event is published at the end of a successful `withdraw()` call
- Added unit test `test_withdraw_emits_event` asserting the event is published

**#867 — [bulk_payment] execute_batch_partial() drops invalid entries without recording them as failed**
- Added `FailureEntry` and `BatchPartialResult` contract types
- Changed `execute_batch_partial` return type from `Result<u64, ContractError>` to `Result<BatchPartialResult, ContractError>`
- The returned `failures` list contains `(index, amount, reason)` for each skipped entry
- Updated all existing tests to use the new return type
- Added new test `test_partial_batch_reports_failure_entries`
- Updated `contracts/bulk_payment/README.md` and `docs/whitepaper.md` to document the new return shape

Closes #863
Closes #864
Closes #865
Closes #867
