### PR TITLE
Validate employee department and position values

### DIFF
--- a/backend/src/controllers/__tests__/employeeController.test.ts
+++ b/backend/src/controllers/__tests__/employeeController.test.ts
@@ -83,6 +83,28 @@ describe('EmployeeController', () => {
       expect(response.body).toHaveProperty('message', 'Validation Error');
       expect(employeeService.create).not.toHaveBeenCalled();
     });
+
+    it('should return 400 for departments outside the allowed list', async () => {
+      const response = await request(app)
+        .post('/api/employees')
+        .send({ ...validEmployeeData, department: 'Enginering' })
+        .expect(400);
+
+      expect(response.body).toHaveProperty('code', 'VALIDATION_ERROR');
+      expect(response.body.details[0].message).toContain('Department must be one of');
+      expect(employeeService.create).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for positions outside the allowed list', async () => {
+      const response = await request(app)
+        .post('/api/employees')
+        .send({ ...validEmployeeData, position: 'Chief Vibes Officer' })
+        .expect(400);
+
+      expect(response.body).toHaveProperty('code', 'VALIDATION_ERROR');
+      expect(response.body.details[0].message).toContain('Position must be one of');
+      expect(employeeService.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /api/employees', () => {
@@ -182,7 +204,11 @@ describe('EmployeeController', () => {
 
   describe('PATCH /api/employees/:id', () => {
     it('should update employee successfully', async () => {
-      const updateData = { first_name: 'Johnny' };
+      const updateData = {
+        first_name: 'Johnny',
+        department: 'Engineering',
+        position: 'Engineer',
+      };
       const mockUpdatedEmployee = { id: 1, first_name: 'Johnny' };
       (employeeService.update as jest.Mock).mockResolvedValue(mockUpdatedEmployee);
 
@@ -194,6 +220,28 @@ describe('EmployeeController', () => {
         1,
         expect.objectContaining(updateData)
       );
+    });
+
+    it('should return 400 for departments outside the allowed list', async () => {
+      const response = await request(app)
+        .patch('/api/employees/1')
+        .send({ department: 'Enginering' })
+        .expect(400);
+
+      expect(response.body).toHaveProperty('code', 'VALIDATION_ERROR');
+      expect(response.body.details[0].message).toContain('Department must be one of');
+      expect(employeeService.update).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for positions outside the allowed list', async () => {
+      const response = await request(app)
+        .patch('/api/employees/1')
+        .send({ position: 'Chief Vibes Officer' })
+        .expect(400);
+
+      expect(response.body).toHaveProperty('code', 'VALIDATION_ERROR');
+      expect(response.body.details[0].message).toContain('Position must be one of');
+      expect(employeeService.update).not.toHaveBeenCalled();
     });
 
     it('should return 400 for negative ID', async () => {

--- a/backend/src/schemas/employeeSchema.ts
+++ b/backend/src/schemas/employeeSchema.ts
@@ -6,6 +6,72 @@ const dateStringSchema = z
   .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
   .optional();
 
+export const EMPLOYEE_DEPARTMENTS = [
+  'Engineering',
+  'Product',
+  'Design',
+  'Sales',
+  'Marketing',
+  'Operations',
+  'Finance',
+  'Human Resources',
+  'Customer Support',
+  'Legal',
+  'IT',
+] as const;
+
+export const EMPLOYEE_POSITIONS = [
+  'Software Engineer',
+  'Senior Software Engineer',
+  'DevOps Engineer',
+  'QA Engineer',
+  'Engineering Manager',
+  'Developer',
+  'Lead Developer',
+  'Engineer',
+  'Product Manager',
+  'Project Manager',
+  'UX Designer',
+  'UI Designer',
+  'Designer',
+  'HR Specialist',
+  'HR Manager',
+  'Finance Operations Specialist',
+  'Accountant',
+  'Payroll Specialist',
+  'Sales Representative',
+  'Sales Manager',
+  'Customer Support Specialist',
+  'Operations Specialist',
+  'Operations Manager',
+  'Marketing Specialist',
+  'Marketing Manager',
+  'Data Analyst',
+  'Business Analyst',
+  'Manager',
+  'Intern',
+] as const;
+
+const allowedDepartmentSet = new Set<string>(EMPLOYEE_DEPARTMENTS);
+const allowedPositionSet = new Set<string>(EMPLOYEE_POSITIONS);
+
+const optionalAllowedString = (
+  fieldName: string,
+  allowedValues: readonly string[],
+  allowedSet: ReadonlySet<string>
+) =>
+  z.preprocess(
+    (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
+    z
+      .string()
+      .trim()
+      .max(100)
+      .refine((value) => allowedSet.has(value), {
+        message: `${fieldName} must be one of: ${allowedValues.join(', ')}`,
+      })
+      .optional()
+  );
+
 export const createEmployeeSchema = z.object({
   organization_id: z.number().int().positive(),
   first_name: z.string().min(1, 'First name is required').max(100),
@@ -18,8 +84,8 @@ export const createEmployeeSchema = z.object({
       message: 'Invalid Stellar wallet address',
     })
     .optional(),
-  position: z.string().max(100).optional(),
-  department: z.string().max(100).optional(),
+  position: optionalAllowedString('Position', EMPLOYEE_POSITIONS, allowedPositionSet),
+  department: optionalAllowedString('Department', EMPLOYEE_DEPARTMENTS, allowedDepartmentSet),
   status: z.enum(['active', 'inactive', 'pending']).optional().default('active'),
   base_salary: z.number().nonnegative().optional().default(0),
   base_currency: z.string().max(12).optional().default('USDC'),


### PR DESCRIPTION
Closes #917
Closes #922

## Summary
Validates employee `department` and `position` values during create/update so typo’d or inconsistent values do not accumulate and break department-based reporting.

## What Changed
- Added hardcoded allow-lists for employee departments and positions.
- Updated employee create/update schemas to reject non-canonical `department` and `position` values.
- Treats blank optional `department` / `position` strings as unset.
- Added controller tests for invalid department and position values on create and update.

## Checklist
- [ ] I linked the relevant issue(s) in the summary.
- [x] I added or updated tests for the change.
- [x] I ran the relevant test suite locally.
- [x] I updated documentation where needed, or explained why it was not needed.
- [x] If this change touches the UI, I verified responsive behavior and accessibility.
- [x] I included screenshots, logs, or other proof when they help review.

## Testing
```bash
npm test -- --config jest.config.cjs employeeController.test.ts --runInBand
