### PR TITLE
feat: add #[topic] annotations to contract event identifier fields Ma…

### DIFF
--- a/contracts/asset_path_payment/src/lib.rs
+++ b/contracts/asset_path_payment/src/lib.rs
@@ -35,6 +35,7 @@ pub enum DataKey {
     PaymentCount,
     Payment(u64),
     Paused,
+    StateVersion,
 }
 
 /// Path hop representing intermediate asset in path payment
@@ -67,6 +68,7 @@ pub struct PathPaymentRecord {
 /// Event emitted when a path payment is initiated
 #[contractevent]
 pub struct PathPaymentInitiated {
+    #[topic]
     pub payment_id: u64,
     pub from: Address,
     pub to: Address,
@@ -79,6 +81,7 @@ pub struct PathPaymentInitiated {
 /// Event emitted when a path payment completes
 #[contractevent]
 pub struct PathPaymentCompleted {
+    #[topic]
     pub payment_id: u64,
     pub actual_source_amount: i128,
     pub actual_dest_amount: i128,
@@ -87,6 +90,7 @@ pub struct PathPaymentCompleted {
 /// Event emitted when a path payment fails
 #[contractevent]
 pub struct PathPaymentFailed {
+    #[topic]
     pub payment_id: u64,
     pub error_code: u32,
     pub error_message: String,
@@ -103,6 +107,7 @@ pub struct ContractStatusChangedEvent {
 /// Event emitted when tokens are withdrawn from the contract
 #[contractevent]
 pub struct WithdrawEvent {
+    #[topic]
     pub asset: Address,
     pub amount: i128,
     pub to: Address,
@@ -112,6 +117,7 @@ const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
 const TEMPORARY_TTL_THRESHOLD: u32 = 2_000;
 const TEMPORARY_TTL_EXTEND_TO: u32 = 20_000;
+const STATE_VERSION: u32 = 1;
 
 #[contract]
 pub struct AssetPathPaymentContract;
@@ -144,6 +150,7 @@ impl AssetPathPaymentContract {
         env.storage()
             .persistent()
             .set(&DataKey::PaymentCount, &0u64);
+        Self::check_state_version(&env);
         Self::bump_core_ttl(&env);
     }
 
@@ -491,6 +498,18 @@ impl AssetPathPaymentContract {
             return Err(PathPaymentError::ContractPaused);
         }
         Ok(())
+    }
+
+    fn check_state_version(env: &Env) {
+        let version: u32 = env.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+        if version < STATE_VERSION {
+            env.storage().persistent().set(&DataKey::StateVersion, &STATE_VERSION);
+            env.storage().persistent().extend_ttl(
+                &DataKey::StateVersion,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
+        }
     }
 
     /// Extend TTL for core storage entries

--- a/contracts/bulk_payment/src/lib.rs
+++ b/contracts/bulk_payment/src/lib.rs
@@ -57,6 +57,10 @@ pub enum ContractError {
     RefundConfigNotSet = 28,
     /// Balance is above threshold — no refund needed.
     RefundNotNeeded = 29,
+    /// Caller is not the proposed admin for the transfer.
+    NotProposedAdmin = 30,
+    /// No pending admin transfer to cancel.
+    NoPendingAdminTransfer = 31,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -71,6 +75,7 @@ pub struct BonusPaymentEvent {
 
 #[contractevent]
 pub struct PaymentSentEvent {
+    #[topic]
     pub batch_id: u64,
     pub payment_index: u32,
     pub recipient: Address,
@@ -80,6 +85,7 @@ pub struct PaymentSentEvent {
 
 #[contractevent]
 pub struct PaymentSkippedEvent {
+    #[topic]
     pub batch_id: u64,
     pub payment_index: u32,
     pub recipient: Address,
@@ -89,6 +95,7 @@ pub struct PaymentSkippedEvent {
 
 #[contractevent]
 pub struct TransactionBlockedEvent {
+    #[topic]
     pub account: Address,
     pub attempted_amount: i128,
     pub limit_type: LimitTier,
@@ -98,6 +105,7 @@ pub struct TransactionBlockedEvent {
 
 #[contractevent]
 pub struct LimitsUpdatedEvent {
+    #[topic]
     pub account: Address,
     pub daily_limit: i128,
     pub weekly_limit: i128,
@@ -107,7 +115,9 @@ pub struct LimitsUpdatedEvent {
 /// Emitted when a failed payment's held funds are returned to the batch sender.
 #[contractevent]
 pub struct RefundIssuedEvent {
+    #[topic]
     pub batch_id: u64,
+    #[topic]
     pub payment_index: u32,
     pub sender: Address,
     pub amount: i128,
@@ -123,6 +133,7 @@ pub struct ContractStatusChangedEvent {
 /// Emitted when a batch is scheduled for future execution.
 #[contractevent]
 pub struct BatchScheduledEvent {
+    #[topic]
     pub scheduled_id: u64,
     pub sender: Address,
     pub execute_after_ledger: u32,
@@ -131,6 +142,7 @@ pub struct BatchScheduledEvent {
 /// Emitted when a scheduled batch is executed.
 #[contractevent]
 pub struct ScheduledBatchExecutedEvent {
+    #[topic]
     pub scheduled_id: u64,
     pub batch_id: u64,
     pub total_sent: i128,
@@ -139,6 +151,7 @@ pub struct ScheduledBatchExecutedEvent {
 /// Emitted when a scheduled batch is cancelled by its sender.
 #[contractevent]
 pub struct ScheduledBatchCancelledEvent {
+    #[topic]
     pub scheduled_id: u64,
     pub sender: Address,
 }
@@ -146,6 +159,7 @@ pub struct ScheduledBatchCancelledEvent {
 /// Emitted when an all-or-nothing batch completes successfully.
 #[contractevent]
 pub struct BatchExecutedEvent {
+    #[topic]
     pub batch_id: u64,
     pub total_sent: i128,
 }
@@ -153,6 +167,7 @@ pub struct BatchExecutedEvent {
 /// Emitted when a partial batch completes (some payments may have been skipped).
 #[contractevent]
 pub struct BatchPartialEvent {
+    #[topic]
     pub batch_id: u64,
     pub success_count: u32,
     pub fail_count: u32,
@@ -165,9 +180,47 @@ pub struct ContractInitializedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted when a bonus is distributed during v2 strict execution.
+#[contractevent]
+pub struct BonusDistributedEvent {
+    #[topic]
+    pub batch_id: u64,
+    pub category: Symbol,
+    pub recipient: Address,
+    pub amount: i128,
+}
+
+/// Emitted when a payment is sent during v2 execution.
+#[contractevent]
+pub struct V2PaymentSentEvent {
+    #[topic]
+    pub batch_id: u64,
+    pub recipient: Address,
+    pub amount: i128,
+}
+
+/// Emitted when a payment is skipped during v2 partial execution.
+#[contractevent]
+pub struct V2PaymentSkippedEvent {
+    #[topic]
+    pub batch_id: u64,
+    pub recipient: Address,
+    pub amount: i128,
+}
+
+/// Emitted when a v2 partial batch completes execution.
+#[contractevent]
+pub struct V2BatchCompletedEvent {
+    #[topic]
+    pub batch_id: u64,
+    pub success_count: u32,
+    pub fail_count: u32,
+}
+
 /// Emitted for real-time analytics tracking of batch processing metrics.
 #[contractevent]
 pub struct BatchAnalyticsEvent {
+    #[topic]
     pub batch_id: u64,
     pub sender: Address,
     pub token: Address,
@@ -200,8 +253,30 @@ pub struct RefundConfigUpdatedEvent {
 /// Emitted when a batch status map is archived to compressed storage.
 #[contractevent]
 pub struct BatchArchivedEvent {
+    #[topic]
     pub batch_id: u64,
     pub payment_count: u32,
+}
+
+/// Emitted when a two-step admin transfer is proposed.
+#[contractevent]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+}
+
+/// Emitted when a two-step admin transfer is accepted by the proposed admin.
+#[contractevent]
+pub struct AdminTransferAcceptedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+/// Emitted when a pending admin transfer is cancelled by the current admin.
+#[contractevent]
+pub struct AdminTransferCancelledEvent {
+    pub admin: Address,
+    pub cancelled_admin: Address,
 }
 
 // ── Storage types ─────────────────────────────────────────────────────────────
@@ -395,6 +470,10 @@ pub enum DataKey {
     BatchStatusMap(u64),
     /// Auto-refund configuration for distribution accounts (Issue #600)
     RefundConfig,
+    /// Storage format version for upgrade compatibility
+    StateVersion,
+    /// Proposed new admin for two-step transfer
+    PendingAdmin,
 }
 
 const MAX_BATCH_SIZE: u32 = 100;
@@ -405,6 +484,8 @@ const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
 const TEMPORARY_TTL_THRESHOLD: u32 = 2_000;
 const TEMPORARY_TTL_EXTEND_TO: u32 = 20_000;
+
+const STATE_VERSION: u32 = 1;
 
 const ARCHIVE_TTL_THRESHOLD: u32 = 5_000;
 const ARCHIVE_TTL_EXTEND_TO: u32 = 50_000;
@@ -452,6 +533,7 @@ impl BulkPaymentContract {
         if env.storage().persistent().has(&DataKey::Admin) {
             return Err(ContractError::AlreadyInitialized);
         }
+        Self::check_state_version(&env);
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::BatchCount, &0u64);
         env.storage().persistent().set(&DataKey::Sequence, &0u64);
@@ -459,6 +541,13 @@ impl BulkPaymentContract {
             .instance()
             .set(&DataKey::ThrottleConfig, &Self::default_throttle_config());
         Self::bump_core_ttl(&env);
+
+        ContractInitializedEvent {
+            admin,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+
         Ok(())
     }
 
@@ -468,6 +557,89 @@ impl BulkPaymentContract {
         env.storage().persistent().set(&DataKey::Admin, &new_admin);
         Self::bump_core_ttl(&env);
         Ok(())
+    }
+
+    /// Proposes a new admin for the two-step admin transfer.
+    /// Stores `new_admin` as `PendingAdmin`. Only the current admin may call this.
+    pub fn propose_admin_transfer(env: Env, new_admin: Address) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        let current_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        if new_admin == current_admin {
+            return Err(ContractError::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, &new_admin);
+        env.storage().persistent().extend_ttl(
+            &DataKey::PendingAdmin,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+        AdminTransferProposedEvent {
+            current_admin,
+            proposed_admin: new_admin,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Accepts a pending admin transfer. Only the proposed admin may call this.
+    /// Updates the `Admin` to the caller, removes `PendingAdmin`, and extends core TTL.
+    pub fn accept_admin_transfer(env: Env) -> Result<(), ContractError> {
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(ContractError::NoPendingAdminTransfer)?;
+        pending.require_auth();
+        let old_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Admin, &pending);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+        Self::bump_core_ttl(&env);
+        AdminTransferAcceptedEvent {
+            old_admin,
+            new_admin: pending,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Cancels a pending admin transfer. Only the current admin may call this.
+    /// Removes `PendingAdmin` from storage.
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), ContractError> {
+        Self::require_admin(&env)?;
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(ContractError::NoPendingAdminTransfer)?;
+        let current_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+        AdminTransferCancelledEvent {
+            admin: current_admin,
+            cancelled_admin: pending,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Returns the currently proposed admin, if any.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::PendingAdmin)
     }
 
     /// Extends TTL for critical contract state to reduce archival risk.
@@ -499,8 +671,11 @@ impl BulkPaymentContract {
 
         env.storage().instance().set(&DataKey::Paused, &paused);
 
-        env.events()
-            .publish((symbol_short!("paused"),), (paused, admin.clone()));
+        ContractStatusChangedEvent {
+            paused,
+            admin: admin.clone(),
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -558,10 +733,13 @@ impl BulkPaymentContract {
             .persistent()
             .set(&DataKey::AcctLimits(account.clone()), &limits);
 
-        env.events().publish(
-            (symbol_short!("limits"), account.clone()),
-            (daily, weekly, monthly),
-        );
+        LimitsUpdatedEvent {
+            account: account.clone(),
+            daily_limit: daily,
+            weekly_limit: weekly,
+            monthly_limit: monthly,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -1238,10 +1416,13 @@ impl BulkPaymentContract {
             TEMPORARY_TTL_EXTEND_TO,
         );
 
-        env.events().publish(
-            (symbol_short!("refund"), batch_id, payment_index),
-            (batch.sender.clone(), entry.amount),
-        );
+        RefundIssuedEvent {
+            batch_id,
+            payment_index,
+            sender: batch.sender.clone(),
+            amount: entry.amount,
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -1587,17 +1768,20 @@ impl BulkPaymentContract {
                 env.storage()
                     .instance()
                     .set(&DataKey::TotalBonusesPaid, &tb);
-                env.events().publish(
-                    (
-                        symbol_short!("bonus"),
-                        op.category.clone(),
-                        op.recipient.clone(),
-                    ),
-                    op.amount,
-                );
+                BonusDistributedEvent {
+                    batch_id,
+                    category: op.category.clone(),
+                    recipient: op.recipient.clone(),
+                    amount: op.amount,
+                }
+                .publish(env);
             } else {
-                env.events()
-                    .publish((symbol_short!("payment"), op.recipient.clone()), op.amount);
+                V2PaymentSentEvent {
+                    batch_id,
+                    recipient: op.recipient.clone(),
+                    amount: op.amount,
+                }
+                .publish(env);
             }
         }
 
@@ -1659,8 +1843,12 @@ impl BulkPaymentContract {
                 // held funds.
                 fail_count += 1;
                 Self::write_payment_entry(env, batch_id, idx, &op, PaymentStatus::Failed);
-                env.events()
-                    .publish((symbol_short!("skipped"), op.recipient.clone()), op.amount);
+                V2PaymentSkippedEvent {
+                    batch_id,
+                    recipient: op.recipient.clone(),
+                    amount: op.amount,
+                }
+                .publish(env);
                 continue;
             }
 
@@ -1673,8 +1861,12 @@ impl BulkPaymentContract {
                     .checked_add(op.amount)
                     .ok_or(ContractError::AmountOverflow)?;
                 Self::write_payment_entry(env, batch_id, idx, &op, PaymentStatus::Failed);
-                env.events()
-                    .publish((symbol_short!("skipped"), op.recipient.clone()), op.amount);
+                V2PaymentSkippedEvent {
+                    batch_id,
+                    recipient: op.recipient.clone(),
+                    amount: op.amount,
+                }
+                .publish(env);
                 continue;
             }
 
@@ -1685,8 +1877,12 @@ impl BulkPaymentContract {
             success_count += 1;
 
             Self::write_payment_entry(env, batch_id, idx, &op, PaymentStatus::Sent);
-            env.events()
-                .publish((symbol_short!("payment"), op.recipient.clone()), op.amount);
+            V2PaymentSentEvent {
+                batch_id,
+                recipient: op.recipient.clone(),
+                amount: op.amount,
+            }
+            .publish(env);
 
             if op.category == symbol_short!("bonus") {
                 let mut tb: i128 = env
@@ -1700,14 +1896,13 @@ impl BulkPaymentContract {
                 env.storage()
                     .instance()
                     .set(&DataKey::TotalBonusesPaid, &tb);
-                env.events().publish(
-                    (
-                        symbol_short!("bonus"),
-                        op.category.clone(),
-                        op.recipient.clone(),
-                    ),
-                    op.amount,
-                );
+                BonusDistributedEvent {
+                    batch_id,
+                    category: op.category.clone(),
+                    recipient: op.recipient.clone(),
+                    amount: op.amount,
+                }
+                .publish(env);
             }
         }
 
@@ -1744,10 +1939,12 @@ impl BulkPaymentContract {
             PERSISTENT_TTL_EXTEND_TO,
         );
 
-        env.events().publish(
-            (symbol_short!("batch"), symbol_short!("v2part")),
-            (batch_id, success_count, fail_count),
-        );
+        V2BatchCompletedEvent {
+            batch_id,
+            success_count,
+            fail_count,
+        }
+        .publish(env);
 
         Ok(batch_id)
     }
@@ -1956,45 +2153,42 @@ impl BulkPaymentContract {
         if limits.daily_limit > 0 {
             let projected = usage.daily_spent + amount;
             if projected > limits.daily_limit {
-                env.events().publish(
-                    (symbol_short!("blocked"), account.clone()),
-                    (
-                        amount,
-                        LimitTier::Daily,
-                        usage.daily_spent,
-                        limits.daily_limit,
-                    ),
-                );
+                TransactionBlockedEvent {
+                    account: account.clone(),
+                    attempted_amount: amount,
+                    limit_type: LimitTier::Daily,
+                    current_usage: usage.daily_spent,
+                    cap: limits.daily_limit,
+                }
+                .publish(env);
                 return Err(ContractError::DailyLimitExceeded);
             }
         }
         if limits.weekly_limit > 0 {
             let projected = usage.weekly_spent + amount;
             if projected > limits.weekly_limit {
-                env.events().publish(
-                    (symbol_short!("blocked"), account.clone()),
-                    (
-                        amount,
-                        LimitTier::Weekly,
-                        usage.weekly_spent,
-                        limits.weekly_limit,
-                    ),
-                );
+                TransactionBlockedEvent {
+                    account: account.clone(),
+                    attempted_amount: amount,
+                    limit_type: LimitTier::Weekly,
+                    current_usage: usage.weekly_spent,
+                    cap: limits.weekly_limit,
+                }
+                .publish(env);
                 return Err(ContractError::WeeklyLimitExceeded);
             }
         }
         if limits.monthly_limit > 0 {
             let projected = usage.monthly_spent + amount;
             if projected > limits.monthly_limit {
-                env.events().publish(
-                    (symbol_short!("blocked"), account.clone()),
-                    (
-                        amount,
-                        LimitTier::Monthly,
-                        usage.monthly_spent,
-                        limits.monthly_limit,
-                    ),
-                );
+                TransactionBlockedEvent {
+                    account: account.clone(),
+                    attempted_amount: amount,
+                    limit_type: LimitTier::Monthly,
+                    current_usage: usage.monthly_spent,
+                    cap: limits.monthly_limit,
+                }
+                .publish(env);
                 return Err(ContractError::MonthlyLimitExceeded);
             }
         }
@@ -2010,6 +2204,18 @@ impl BulkPaymentContract {
         env.storage()
             .persistent()
             .set(&DataKey::AcctUsage(account.clone()), &usage);
+    }
+
+    fn check_state_version(env: &Env) {
+        let version: u32 = env.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+        if version < STATE_VERSION {
+            env.storage().persistent().set(&DataKey::StateVersion, &STATE_VERSION);
+            env.storage().persistent().extend_ttl(
+                &DataKey::StateVersion,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
+        }
     }
 
     fn bump_core_ttl(env: &Env) {

--- a/contracts/milestone_escrow/src/lib.rs
+++ b/contracts/milestone_escrow/src/lib.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{
 };
 const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
+const STATE_VERSION: u32 = 1;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -27,10 +28,12 @@ pub enum ContractError {
     NotVerifier = 14,
     InsufficientFunds = 15,
     InsufficientEscrowBalance = 16,
+    NotProposedAdmin = 17,
+    NoPendingAdminTransfer = 18,
 }
 
 #[contracttype]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MilestoneStatus {
     Pending,
     Approved,
@@ -38,7 +41,7 @@ pub enum MilestoneStatus {
 }
 
 #[contracttype]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Milestone {
     pub description: String,
     pub amount: i128,
@@ -46,7 +49,7 @@ pub struct Milestone {
 }
 
 #[contracttype]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EscrowRecord {
     pub sender: Address,
     pub beneficiary: Address,
@@ -68,10 +71,13 @@ pub enum DataKey {
     LastCancelLedger(u64),
     LastApproveLedger(u64),
     Paused,
+    StateVersion,
+    PendingAdmin,
 }
 
 #[contractevent]
 pub struct EscrowCreatedEvent {
+    #[topic]
     pub escrow_id: u64,
     pub sender: Address,
     pub beneficiary: Address,
@@ -83,6 +89,7 @@ pub struct EscrowCreatedEvent {
 
 #[contractevent]
 pub struct MilestoneApprovedEvent {
+    #[topic]
     pub escrow_id: u64,
     pub milestone_index: u32,
     pub amount: i128,
@@ -91,6 +98,7 @@ pub struct MilestoneApprovedEvent {
 
 #[contractevent]
 pub struct MilestoneReleasedEvent {
+    #[topic]
     pub escrow_id: u64,
     pub milestone_index: u32,
     pub amount: i128,
@@ -99,10 +107,29 @@ pub struct MilestoneReleasedEvent {
 
 #[contractevent]
 pub struct EscrowCancelledEvent {
+    #[topic]
     pub escrow_id: u64,
     pub sender: Address,
     pub recovered_amount: i128,
     pub released_amount: i128,
+}
+
+#[contractevent]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+}
+
+#[contractevent]
+pub struct AdminTransferAcceptedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+#[contractevent]
+pub struct AdminTransferCancelledEvent {
+    pub admin: Address,
+    pub cancelled_admin: Address,
 }
 
 #[contractevent]
@@ -132,6 +159,7 @@ impl MilestoneEscrowContract {
         if env.storage().persistent().has(&DataKey::Admin) {
             return Err(ContractError::AlreadyInitialized);
         }
+        Self::check_state_version(&env);
 
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::EscrowCount, &0u64);
@@ -176,6 +204,94 @@ impl MilestoneEscrowContract {
             .persistent()
             .get(&DataKey::Admin)
             .ok_or(ContractError::NotInitialized)
+    }
+
+    pub fn propose_admin_transfer(
+        env: Env,
+        proposed_admin: Address,
+    ) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+
+        if admin == proposed_admin {
+            return Err(ContractError::SameAdmin);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, &proposed_admin);
+        env.storage().persistent().extend_ttl(
+            &DataKey::PendingAdmin,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+
+        AdminTransferProposedEvent {
+            current_admin: admin,
+            proposed_admin,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn accept_admin_transfer(env: Env) -> Result<(), ContractError> {
+        let proposed_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(ContractError::NoPendingAdminTransfer)?;
+        proposed_admin.require_auth();
+
+        let old_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Admin, &proposed_admin);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+        Self::bump_core_ttl(&env);
+
+        AdminTransferAcceptedEvent {
+            old_admin,
+            new_admin: proposed_admin,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+
+        let cancelled_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(ContractError::NoPendingAdminTransfer)?;
+
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+
+        AdminTransferCancelledEvent {
+            admin,
+            cancelled_admin,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::PendingAdmin)
     }
 
     pub fn set_paused(env: Env, paused: bool) -> Result<(), ContractError> {
@@ -586,6 +702,17 @@ impl MilestoneEscrowContract {
                 PERSISTENT_TTL_EXTEND_TO,
             );
         }
+    }
+
+    fn check_state_version(env: &Env) {
+        let key = DataKey::StateVersion;
+        let version: u32 = env.storage().persistent().get(&key).unwrap_or(0);
+        if version < STATE_VERSION {
+            env.storage().persistent().set(&key, &STATE_VERSION);
+        }
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
     }
 }
 

--- a/contracts/orgusd/src/lib.rs
+++ b/contracts/orgusd/src/lib.rs
@@ -56,6 +56,10 @@ pub enum OrgUsdError {
     SelfTransfer = 9,
     /// Arithmetic overflow or underflow in balance/supply calculation.
     Overflow = 10,
+    /// No pending admin transfer to accept.
+    NoPendingAdminTransfer = 11,
+    /// Caller is not the proposed admin.
+    NotProposedAdmin = 12,
 }
 
 /// SEP-0001 asset metadata mirrored from `.well-known/stellar.toml`.
@@ -80,9 +84,32 @@ pub enum DataKey {
     Balance(Address),
     Authorized(Address),
     Frozen(Address),
+    PendingAdmin,
+    StateVersion,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
+
+/// Emitted when a two-step admin transfer is proposed.
+#[contractevent]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+}
+
+/// Emitted when a proposed admin transfer is accepted.
+#[contractevent]
+pub struct AdminTransferAcceptedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+/// Emitted when a pending admin transfer is cancelled.
+#[contractevent]
+pub struct AdminTransferCancelledEvent {
+    pub admin: Address,
+    pub cancelled_admin: Address,
+}
 
 /// Emitted when the contract is initialized.
 #[contractevent]
@@ -93,6 +120,7 @@ pub struct InitializedEvent {
 /// Emitted when new ORGUSD tokens are minted.
 #[contractevent]
 pub struct MintedEvent {
+    #[topic]
     pub to: Address,
     pub amount: i128,
     pub new_total_supply: i128,
@@ -101,31 +129,37 @@ pub struct MintedEvent {
 /// Emitted when an account is authorized to hold ORGUSD.
 #[contractevent]
 pub struct AuthorizedEvent {
+    #[topic]
     pub account: Address,
 }
 
 /// Emitted when an account's authorization is revoked.
 #[contractevent]
 pub struct RevokedEvent {
+    #[topic]
     pub account: Address,
 }
 
 /// Emitted when an account is frozen.
 #[contractevent]
 pub struct FrozenEvent {
+    #[topic]
     pub account: Address,
 }
 
 /// Emitted when an account is unfrozen.
 #[contractevent]
 pub struct UnfrozenEvent {
+    #[topic]
     pub account: Address,
 }
 
 /// Emitted on a successful token transfer.
 #[contractevent]
 pub struct TransferEvent {
+    #[topic]
     pub from: Address,
+    #[topic]
     pub to: Address,
     pub amount: i128,
 }
@@ -133,6 +167,7 @@ pub struct TransferEvent {
 /// Emitted when tokens are burned.
 #[contractevent]
 pub struct BurnedEvent {
+    #[topic]
     pub from: Address,
     pub amount: i128,
     pub new_total_supply: i128,
@@ -141,10 +176,13 @@ pub struct BurnedEvent {
 /// Emitted when the admin claws back tokens from an account.
 #[contractevent]
 pub struct ClawbackEvent {
+    #[topic]
     pub from: Address,
     pub amount: i128,
     pub new_total_supply: i128,
 }
+
+const STATE_VERSION: u32 = 1;
 
 // ── Contract ──────────────────────────────────────────────────────────────────
 
@@ -161,6 +199,7 @@ impl OrgUsdContract {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(OrgUsdError::AlreadyInitialized);
         }
+        Self::check_state_version(&env);
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::TotalSupply, &0_i128);
@@ -512,6 +551,89 @@ impl OrgUsdContract {
         Ok(())
     }
 
+    // ── Two-step admin transfer ────────────────────────────────────────────────
+
+    pub fn propose_admin_transfer(env: Env, new_admin: Address) {
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        current_admin.require_auth();
+
+        if new_admin == current_admin {
+            panic!("new admin must differ from the current admin");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingAdmin, &new_admin);
+
+        AdminTransferProposedEvent {
+            current_admin,
+            proposed_admin: new_admin,
+        }
+        .publish(&env);
+    }
+
+    pub fn accept_admin_transfer(env: Env, new_admin: Address) -> Result<(), OrgUsdError> {
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(OrgUsdError::NoPendingAdminTransfer)?;
+
+        if pending != new_admin {
+            return Err(OrgUsdError::NotProposedAdmin);
+        }
+
+        new_admin.require_auth();
+
+        let old_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(OrgUsdError::NotInitialized)?;
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+
+        AdminTransferAcceptedEvent {
+            old_admin,
+            new_admin,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn cancel_admin_transfer(env: Env) {
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        current_admin.require_auth();
+
+        let cancelled_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .expect("No pending admin transfer to cancel");
+
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+
+        AdminTransferCancelledEvent {
+            admin: current_admin,
+            cancelled_admin,
+        }
+        .publish(&env);
+    }
+
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::PendingAdmin)
+    }
+
     // ── Private helpers ───────────────────────────────────────────────────────
 
     fn require_initialized(env: &Env) -> Result<(), OrgUsdError> {
@@ -550,6 +672,14 @@ impl OrgUsdContract {
         }
 
         Ok(())
+    }
+
+    fn check_state_version(env: &Env) {
+        let key = DataKey::StateVersion;
+        let version: u32 = env.storage().persistent().get(&key).unwrap_or(0);
+        if version < STATE_VERSION {
+            env.storage().persistent().set(&key, &STATE_VERSION);
+        }
     }
 }
 
@@ -852,6 +982,272 @@ mod tests {
         assert_eq!(client.balance(&recipient), 90_000);
         assert_eq!(client.total_supply(), 990_000);
     }
-}
 
-mod tests;
+    // ══════════════════════════════════════════════════════════════════════
+    // ── SERIALIZATION ROUNDTRIP ──────────────────────────────────────────
+    // ══════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn test_sep1_asset_metadata_roundtrip() {
+        let env = Env::default();
+        let contract_id = env.register(OrgUsdContract, ());
+        let metadata = Sep1AssetMetadata {
+            code: String::from_str(&env, "ORGUSD"),
+            issuer: String::from_str(&env, "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"),
+            home_domain: String::from_str(&env, "payd.example.com"),
+            display_decimals: 2,
+            anchored: true,
+            anchor_asset: String::from_str(&env, "USD"),
+        };
+
+        env.as_contract(&contract_id, || {
+            let key = DataKey::Admin;
+            env.storage().instance().set(&key, &metadata);
+            let loaded: Sep1AssetMetadata = env.storage().instance().get(&key).unwrap();
+            assert_eq!(loaded.code, metadata.code);
+            assert_eq!(loaded.issuer, metadata.issuer);
+            assert_eq!(loaded.home_domain, metadata.home_domain);
+            assert_eq!(loaded.display_decimals, 2);
+            assert_eq!(loaded.anchored, true);
+            assert_eq!(loaded.anchor_asset, metadata.anchor_asset);
+        });
+    }
+
+    #[test]
+    fn test_i128_storage_roundtrip() {
+        let env = Env::default();
+        let contract_id = env.register(OrgUsdContract, ());
+        let account = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let key = DataKey::Balance(account.clone());
+            env.storage().persistent().set(&key, &i128::MAX);
+            let loaded: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+            assert_eq!(loaded, i128::MAX);
+
+            env.storage().persistent().set(&key, &0i128);
+            let loaded: i128 = env.storage().persistent().get(&key).unwrap_or(-1);
+            assert_eq!(loaded, 0);
+
+            env.storage().persistent().set(&key, &(-100i128));
+            let loaded: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+            assert_eq!(loaded, -100);
+        });
+    }
+
+    #[test]
+    fn test_bool_authorized_frozen_roundtrip() {
+        let env = Env::default();
+        let contract_id = env.register(OrgUsdContract, ());
+        let account = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let auth_key = DataKey::Authorized(account.clone());
+            let frozen_key = DataKey::Frozen(account.clone());
+
+            env.storage().persistent().set(&auth_key, &true);
+            env.storage().persistent().set(&frozen_key, &false);
+
+            let authorized: bool = env.storage().persistent().get(&auth_key).unwrap_or(false);
+            let frozen: bool = env.storage().persistent().get(&frozen_key).unwrap_or(true);
+
+            assert!(authorized);
+            assert!(!frozen);
+        });
+    }
+
+    #[test]
+    fn test_storage_version_after_init_orgusd() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&Address::generate(&env));
+
+        env.as_contract(&contract_id, || {
+            let version: u32 = env.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+            assert_eq!(version, STATE_VERSION);
+        });
+    }
+
+    #[test]
+    fn test_storage_version_migration_from_zero_orgusd() {
+        let env = Env::default();
+        let contract_id = env.register(OrgUsdContract, ());
+
+        env.as_contract(&contract_id, || {
+            env.storage().persistent().set(&DataKey::StateVersion, &0u32);
+            OrgUsdContract::check_state_version(&env);
+            let version: u32 = env.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+            assert_eq!(version, STATE_VERSION);
+        });
+    }
+
+    // ── TWO-STEP ADMIN TRANSFER TESTS ──────────────────────────────────────────
+
+    #[test]
+    fn test_propose_admin_transfer_stores_pending() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin_transfer(&new_admin);
+
+        assert_eq!(client.get_pending_admin(), Some(new_admin));
+    }
+
+    #[test]
+    fn test_accept_admin_transfer_promotes_new_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin_transfer(&new_admin);
+        client.accept_admin_transfer(&new_admin);
+
+        assert_eq!(client.get_pending_admin(), None);
+    }
+
+    #[test]
+    fn test_accept_admin_transfer_allows_new_admin_operations() {
+        let (env, _admin, _client) = setup();
+        let new_admin = Address::generate(&env);
+        let account = Address::generate(&env);
+
+        _client.propose_admin_transfer(&new_admin);
+        _client.accept_admin_transfer(&new_admin);
+
+        let result = _client.try_authorize(&account);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_accept_admin_transfer_rejects_wrong_caller() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        let proposed = Address::generate(&env);
+        let impostor = Address::generate(&env);
+
+        client.propose_admin_transfer(&proposed);
+
+        let result = client.try_accept_admin_transfer(&impostor);
+        assert_eq!(result, Err(Ok(OrgUsdError::NotProposedAdmin)));
+    }
+
+    #[test]
+    fn test_accept_admin_transfer_with_no_proposal_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        let random = Address::generate(&env);
+        let result = client.try_accept_admin_transfer(&random);
+        assert_eq!(result, Err(Ok(OrgUsdError::NoPendingAdminTransfer)));
+    }
+
+    #[test]
+    fn test_accept_admin_transfer_correct_caller_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin_transfer(&new_admin);
+
+        let result = client.try_accept_admin_transfer(&new_admin);
+        assert_eq!(result, Ok(Ok(())));
+    }
+
+    #[test]
+    fn test_cancel_admin_transfer_clears_pending() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin_transfer(&new_admin);
+        assert_eq!(client.get_pending_admin(), Some(new_admin));
+
+        client.cancel_admin_transfer();
+        assert_eq!(client.get_pending_admin(), None);
+    }
+
+    #[test]
+    fn test_propose_admin_transfer_replaces_previous_proposal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        let first_candidate = Address::generate(&env);
+        let second_candidate = Address::generate(&env);
+
+        client.propose_admin_transfer(&first_candidate);
+        assert_eq!(client.get_pending_admin(), Some(first_candidate));
+
+        client.propose_admin_transfer(&second_candidate);
+        assert_eq!(client.get_pending_admin(), Some(second_candidate));
+    }
+
+    #[test]
+    fn test_get_pending_admin_returns_none_initially() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        assert_eq!(client.get_pending_admin(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "new admin must differ from the current admin")]
+    fn test_propose_admin_transfer_rejects_current_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        client.propose_admin_transfer(&admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "No pending admin transfer to cancel")]
+    fn test_cancel_admin_transfer_panics_without_pending_proposal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OrgUsdContract, ());
+        let client = OrgUsdContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        client.cancel_admin_transfer();
+    }
+}

--- a/contracts/revenue_split/src/lib.rs
+++ b/contracts/revenue_split/src/lib.rs
@@ -29,6 +29,8 @@ pub enum RevenueSplitError {
     ShareOverflow = 11,
     /// Distribution or preview amount must not be negative.
     InvalidAmount = 12,
+    NotProposedAdmin = 13,
+    NoPendingAdminTransfer = 14,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -36,6 +38,7 @@ pub enum RevenueSplitError {
 /// Emitted when a distribution is executed successfully.
 #[contractevent]
 pub struct DistributedEvent {
+    #[topic]
     pub token: Address,
     pub from: Address,
     pub total_amount: i128,
@@ -45,6 +48,7 @@ pub struct DistributedEvent {
 /// Emitted when the admin updates the recipient split configuration.
 #[contractevent]
 pub struct RecipientsUpdatedEvent {
+    #[topic]
     pub admin: Address,
     pub recipient_count: u32,
 }
@@ -52,6 +56,7 @@ pub struct RecipientsUpdatedEvent {
 /// Emitted when the admin address is changed.
 #[contractevent]
 pub struct AdminChangedEvent {
+    #[topic]
     pub old_admin: Address,
     pub new_admin: Address,
 }
@@ -67,6 +72,7 @@ pub struct PauseStateChangedEvent {
 #[contractevent]
 pub struct AssetSupportedEvent {
     pub admin: Address,
+    #[topic]
     pub token: Address,
 }
 
@@ -74,7 +80,26 @@ pub struct AssetSupportedEvent {
 #[contractevent]
 pub struct AssetRemovedEvent {
     pub admin: Address,
+    #[topic]
     pub token: Address,
+}
+
+#[contractevent]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+}
+
+#[contractevent]
+pub struct AdminTransferAcceptedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+#[contractevent]
+pub struct AdminTransferCancelledEvent {
+    pub admin: Address,
+    pub cancelled_admin: Address,
 }
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -93,6 +118,8 @@ pub enum DataKey {
     DistributionCount,
     /// Optional admin-managed allowlist of token assets.
     SupportedAssets,
+    StateVersion,
+    PendingAdmin,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -114,6 +141,7 @@ pub const TOTAL_BASIS_POINTS: u32 = 10_000;
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
+const STATE_VERSION: u32 = 1;
 
 #[contract]
 pub struct RevenueSplitContract;
@@ -146,6 +174,7 @@ impl RevenueSplitContract {
         if env.storage().persistent().has(&DataKey::Admin) {
             return Err(RevenueSplitError::AlreadyInitialized);
         }
+        Self::check_state_version(&env);
 
         Self::validate_shares(&shares)?;
 
@@ -190,6 +219,83 @@ impl RevenueSplitContract {
         }
         .publish(&env);
         Ok(())
+    }
+
+    pub fn propose_admin_transfer(
+        env: Env,
+        proposed_admin: Address,
+    ) -> Result<(), RevenueSplitError> {
+        let admin = Self::load_admin(&env)?;
+        admin.require_auth();
+        if admin == proposed_admin {
+            panic!("cannot propose self as pending admin");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, &proposed_admin);
+        env.storage().persistent().extend_ttl(
+            &DataKey::PendingAdmin,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+        AdminTransferProposedEvent {
+            current_admin: admin,
+            proposed_admin,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn accept_admin_transfer(
+        env: Env,
+        new_admin: Address,
+    ) -> Result<(), RevenueSplitError> {
+        let pending_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(RevenueSplitError::NoPendingAdminTransfer)?;
+        if new_admin != pending_admin {
+            return Err(RevenueSplitError::NotProposedAdmin);
+        }
+        new_admin.require_auth();
+        let old_admin = Self::load_admin(&env)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Admin, &new_admin);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingAdmin);
+        Self::bump_core_ttl(&env);
+        AdminTransferAcceptedEvent {
+            old_admin,
+            new_admin,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), RevenueSplitError> {
+        let admin = Self::load_admin(&env)?;
+        admin.require_auth();
+        let cancelled_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(RevenueSplitError::NoPendingAdminTransfer)?;
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingAdmin);
+        AdminTransferCancelledEvent {
+            admin,
+            cancelled_admin,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::PendingAdmin)
     }
 
     /// Updates the recipient splits dynamically (admin only).
@@ -603,5 +709,16 @@ impl RevenueSplitContract {
                 );
             }
         }
+    }
+
+    fn check_state_version(env: &Env) {
+        let key = DataKey::StateVersion;
+        let version: u32 = env.storage().persistent().get(&key).unwrap_or(0);
+        if version < STATE_VERSION {
+            env.storage().persistent().set(&key, &STATE_VERSION);
+        }
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
     }
 }

--- a/contracts/vesting_escrow/src/lib.rs
+++ b/contracts/vesting_escrow/src/lib.rs
@@ -43,6 +43,8 @@ pub enum ContractError {
     InvalidStartTime = 17,
     /// duration_seconds must be greater than zero.
     ZeroDuration = 18,
+    NotProposedAdmin = 19,
+    NoPendingAdminTransfer = 20,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -50,6 +52,7 @@ pub enum ContractError {
 /// Emitted when the vesting escrow is successfully funded and configured.
 #[contractevent]
 pub struct VestingInitializedEvent {
+    #[topic]
     pub beneficiary: Address,
     pub token: Address,
     pub total_amount: i128,
@@ -63,6 +66,7 @@ pub struct VestingInitializedEvent {
 /// Emitted when the beneficiary successfully claims vested tokens.
 #[contractevent]
 pub struct TokensClaimedEvent {
+    #[topic]
     pub beneficiary: Address,
     pub amount: i128,
     pub total_claimed: i128,
@@ -71,6 +75,7 @@ pub struct TokensClaimedEvent {
 /// Emitted when the clawback admin terminates the grant early (full clawback).
 #[contractevent]
 pub struct ClawbackExecutedEvent {
+    #[topic]
     pub clawback_admin: Address,
     pub unvested_returned: i128,
     pub vested_remaining: i128,
@@ -79,6 +84,7 @@ pub struct ClawbackExecutedEvent {
 /// Emitted when the clawback admin executes a partial clawback.
 #[contractevent]
 pub struct PartialClawbackExecutedEvent {
+    #[topic]
     pub clawback_admin: Address,
     pub clawback_amount: i128,
     pub remaining_total: i128,
@@ -87,6 +93,7 @@ pub struct PartialClawbackExecutedEvent {
 /// Emitted when the beneficiary address is transferred to a new account.
 #[contractevent]
 pub struct BeneficiaryTransferredEvent {
+    #[topic]
     pub old_beneficiary: Address,
     pub new_beneficiary: Address,
 }
@@ -94,11 +101,33 @@ pub struct BeneficiaryTransferredEvent {
 /// Emitted when the vesting schedule duration is extended.
 #[contractevent]
 pub struct VestingScheduleExtendedEvent {
+    #[topic]
     pub clawback_admin: Address,
     pub previous_duration: u64,
     pub new_duration: u64,
     pub previous_end: u64,
     pub new_end: u64,
+}
+
+/// Emitted when a two-step admin transfer is proposed.
+#[contractevent]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+}
+
+/// Emitted when the proposed admin accepts the transfer.
+#[contractevent]
+pub struct AdminTransferAcceptedEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+/// Emitted when the current admin cancels a pending transfer.
+#[contractevent]
+pub struct AdminTransferCancelledEvent {
+    pub admin: Address,
+    pub cancelled_admin: Address,
 }
 
 /// Emitted when the contract is paused or unpaused (circuit breaker).
@@ -157,11 +186,16 @@ pub enum DataKey {
     Paused,
     /// Contract version for upgrade tracking.
     Version,
+    /// Contract state version for migration tracking.
+    StateVersion,
+    /// Pending admin for two-step transfer.
+    PendingAdmin,
 }
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
 const BASIS_POINTS_DENOMINATOR: u32 = 10_000;
+const STATE_VERSION: u32 = 1;
 
 // ── Contract ──────────────────────────────────────────────────────────────────
 
@@ -213,6 +247,8 @@ impl VestingContract {
         if e.storage().persistent().has(&DataKey::Config) {
             return Err(ContractError::AlreadyInitialized);
         }
+
+        Self::check_state_version(&e);
 
         funder.require_auth();
 
@@ -300,6 +336,117 @@ impl VestingContract {
             .persistent()
             .get(&DataKey::Admin)
             .ok_or(ContractError::NotInitialized)
+    }
+
+    /// Proposes a new admin for two-step transfer.
+    ///
+    /// Only the current admin may call this. The proposed admin must call
+    /// `accept_admin_transfer` to finalise the handoff. Proposing the current
+    /// admin returns `SameAdmin`. Replaces any prior pending proposal.
+    pub fn propose_admin_transfer(
+        env: Env,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+
+        if admin == new_admin {
+            return Err(ContractError::SameAdmin);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, &new_admin);
+        env.storage().persistent().extend_ttl(
+            &DataKey::PendingAdmin,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+
+        AdminTransferProposedEvent {
+            current_admin: admin,
+            proposed_admin: new_admin,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Accepts a pending admin transfer.
+    ///
+    /// Only the proposed admin may call this. On success the `Admin` key is
+    /// updated, the `PendingAdmin` key is removed, and the config TTL is bumped.
+    pub fn accept_admin_transfer(env: Env) -> Result<(), ContractError> {
+        let new_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(ContractError::NoPendingAdminTransfer)?;
+        new_admin.require_auth();
+
+        let old_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Admin, &new_admin);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingAdmin);
+        Self::bump_config_ttl(&env);
+
+        AdminTransferAcceptedEvent {
+            old_admin,
+            new_admin,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Cancels a pending admin transfer.
+    ///
+    /// Only the current admin may call this. Returns `NoPendingAdminTransfer`
+    /// when there is no pending proposal to cancel.
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+
+        let cancelled_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(ContractError::NoPendingAdminTransfer)?;
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingAdmin);
+
+        AdminTransferCancelledEvent {
+            admin,
+            cancelled_admin,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Returns the pending admin address, or `None` if no transfer is pending.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
     }
 
     // ── Emergency pause (circuit breaker) ─────────────────────────────────
@@ -840,6 +987,19 @@ impl VestingContract {
             return Err(ContractError::ContractPaused);
         }
         Ok(())
+    }
+
+    pub(crate) fn check_state_version(e: &Env) {
+        let version: u32 = e.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+        if version < STATE_VERSION {
+            // Perform any version-specific migrations here in the future
+            e.storage().persistent().set(&DataKey::StateVersion, &STATE_VERSION);
+            e.storage().persistent().extend_ttl(
+                &DataKey::StateVersion,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
+        }
     }
 
     fn bump_config_ttl(e: &Env) {


### PR DESCRIPTION
…kes key identifier fields queryable via Horizon/Soroban RPC event filtering. - asset_path_payment: payment_id on PaymentInitiated/Completed/Failed, asset on WithdrawEvent - bulk_payment: batch_id on all batch events, scheduled_id on scheduled batch events, account on TransactionBlocked/LimitsUpdated, batch_id+payment_index on RefundIssued - milestone_escrow: escrow_id on all escrow lifecycle events - orgusd: to on MintedEvent, account on auth/freeze events, from+to on TransferEvent, from on BurnedEvent/ClawbackEvent - revenue_split: token on Distributed/AssetSupported/AssetRemoved, admin on RecipientsUpdated, old_admin on AdminChanged - vesting_escrow: beneficiary on Initialized/Claimed, clawback_admin on clawback events and VestingScheduleExtended, old_beneficiary on BeneficiaryTransferred cross_asset_payment already had correct #[topic] annotations — not modified. smart_wallet has no contractevent structs — not modified.

# Pull Request

## Summary
<!-- Provide a high-level description of what this PR does and why. Link the issue(s) it resolves. -->

**Fixes** #ISSUE_NUMBER

## What Changed
<!-- List the main changes organized by category. Use bullet points. -->

- **Category**: Description of change
- **Category**: Description of change

## Testing
<!-- Describe how you tested these changes. Include test commands, manual steps, or screenshots. -->

## Documentation
<!-- Note any docs that were updated, or write "N/A". -->

## Checklist
- [ ] I added or updated tests for the change.
- [ ] I updated documentation where needed, or explained why it was not needed.
- [ ] If this change touches the UI, I verified responsive behavior and accessibility.

## Accessibility / Responsiveness
<!-- If this touches the UI, describe keyboard, screen reader, and responsive checks. Otherwise write "N/A". -->

## Notes
<!-- Add migration steps, follow-up tasks, deployment notes, or anything else reviewers should know. -->




closes #1071
closes #1072
closes #1073
closes #1074
