### PR TITLE
Harden contract safety for cross-asset payments, ORGUSD, TTL, and revenue split math

### DIFF
--- a/contracts/asset_path_payment/src/lib.rs
+++ b/contracts/asset_path_payment/src/lib.rs
@@ -180,11 +180,7 @@ impl AssetPathPaymentContract {
             .persistent()
             .get(&DataKey::Admin)
             .expect("Admin not set; contract may not be initialized");
-        ContractStatusChangedEvent {
-            paused,
-            admin,
-        }
-        .publish(&env);
+        ContractStatusChangedEvent { paused, admin }.publish(&env);
         Ok(())
     }
 
@@ -462,12 +458,7 @@ impl AssetPathPaymentContract {
         let token_client = token::Client::new(&env, &asset);
         token_client.transfer(&env.current_contract_address(), &to, &amount);
 
-        WithdrawEvent {
-            asset,
-            amount,
-            to,
-        }
-        .publish(&env);
+        WithdrawEvent { asset, amount, to }.publish(&env);
 
         Ok(())
     }
@@ -501,9 +492,15 @@ impl AssetPathPaymentContract {
     }
 
     fn check_state_version(env: &Env) {
-        let version: u32 = env.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+        let version: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StateVersion)
+            .unwrap_or(0);
         if version < STATE_VERSION {
-            env.storage().persistent().set(&DataKey::StateVersion, &STATE_VERSION);
+            env.storage()
+                .persistent()
+                .set(&DataKey::StateVersion, &STATE_VERSION);
             env.storage().persistent().extend_ttl(
                 &DataKey::StateVersion,
                 PERSISTENT_TTL_THRESHOLD,

--- a/contracts/asset_path_payment/src/test.rs
+++ b/contracts/asset_path_payment/src/test.rs
@@ -175,7 +175,8 @@ fn test_initiate_path_payment_rejects_self_payment() {
 
     let path = Vec::new(&env);
 
-    let result = client.try_initiate_path_payment(&from, &from, &source, &dest, &100, &90, &100, &path);
+    let result =
+        client.try_initiate_path_payment(&from, &from, &source, &dest, &100, &90, &100, &path);
     assert_eq!(result, Err(Ok(PathPaymentError::SelfPayment)));
 }
 
@@ -589,7 +590,16 @@ fn test_withdraw_transfer_failure_preserves_contract_balance() {
     let dest = create_token_contract(&env, &Address::generate(&env));
 
     // Send tokens to contract escrow
-    client.initiate_path_payment(&from, &to, &source, &dest, &300, &270, &300, &Vec::new(&env));
+    client.initiate_path_payment(
+        &from,
+        &to,
+        &source,
+        &dest,
+        &300,
+        &270,
+        &300,
+        &Vec::new(&env),
+    );
 
     let tc = token::Client::new(&env, &source);
     assert_eq!(tc.balance(&contract_id), 300);
@@ -624,7 +634,16 @@ fn test_withdraw_emits_event() {
     let dest = create_token_contract(&env, &Address::generate(&env));
     let recipient = Address::generate(&env);
 
-    client.initiate_path_payment(&from, &to, &source, &dest, &300, &270, &300, &Vec::new(&env));
+    client.initiate_path_payment(
+        &from,
+        &to,
+        &source,
+        &dest,
+        &300,
+        &270,
+        &300,
+        &Vec::new(&env),
+    );
     client.withdraw(&source, &150, &recipient);
 
     // Verify the withdraw event was published with expected topics/data
@@ -1143,7 +1162,16 @@ fn test_withdraw_blocked_when_paused() {
     let client = AssetPathPaymentContractClient::new(&env, &contract_id);
     client.init(&admin);
 
-    client.initiate_path_payment(&from, &to, &source, &dest, &300, &270, &300, &Vec::new(&env));
+    client.initiate_path_payment(
+        &from,
+        &to,
+        &source,
+        &dest,
+        &300,
+        &270,
+        &300,
+        &Vec::new(&env),
+    );
 
     client.set_paused(&true);
 
@@ -1175,16 +1203,8 @@ fn test_unpause_restores_operations() {
     client.set_paused(&false);
     assert!(!client.is_paused());
 
-    let id = client.initiate_path_payment(
-        &from,
-        &to,
-        &source,
-        &dest,
-        &100,
-        &90,
-        &100,
-        &Vec::new(&env),
-    );
+    let id =
+        client.initiate_path_payment(&from, &to, &source, &dest, &100, &90, &100, &Vec::new(&env));
     assert_eq!(id, 1);
 }
 

--- a/contracts/bulk_payment/src/lib.rs
+++ b/contracts/bulk_payment/src/lib.rs
@@ -609,9 +609,7 @@ impl BulkPaymentContract {
             .persistent()
             .get(&DataKey::Admin)
             .ok_or(ContractError::NotInitialized)?;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Admin, &pending);
+        env.storage().persistent().set(&DataKey::Admin, &pending);
         env.storage().persistent().remove(&DataKey::PendingAdmin);
         Self::bump_core_ttl(&env);
         AdminTransferAcceptedEvent {
@@ -960,11 +958,9 @@ impl BulkPaymentContract {
 
         let key = DataKey::BatchStatusMap(batch_id);
         env.storage().persistent().set(&key, &map);
-        env.storage().persistent().extend_ttl(
-            &key,
-            ARCHIVE_TTL_THRESHOLD,
-            ARCHIVE_TTL_EXTEND_TO,
-        );
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, ARCHIVE_TTL_THRESHOLD, ARCHIVE_TTL_EXTEND_TO);
 
         BatchArchivedEvent {
             batch_id,
@@ -1010,10 +1006,7 @@ impl BulkPaymentContract {
     }
 
     /// Returns the compressed batch status map for a given batch.
-    pub fn get_batch_status_map(
-        env: Env,
-        batch_id: u64,
-    ) -> Result<BatchStatusMap, ContractError> {
+    pub fn get_batch_status_map(env: Env, batch_id: u64) -> Result<BatchStatusMap, ContractError> {
         let key = DataKey::BatchStatusMap(batch_id);
         env.storage()
             .persistent()
@@ -1023,10 +1016,7 @@ impl BulkPaymentContract {
 
     /// Reduces TTL on old batch records to free storage sooner.
     /// Call periodically for batches older than the active window.
-    pub fn reduce_batch_ttl(
-        env: Env,
-        batch_id: u64,
-    ) -> Result<(), ContractError> {
+    pub fn reduce_batch_ttl(env: Env, batch_id: u64) -> Result<(), ContractError> {
         Self::require_admin(&env)?;
 
         let key = DataKey::Batch(batch_id);
@@ -1034,11 +1024,9 @@ impl BulkPaymentContract {
             return Err(ContractError::BatchNotFound);
         }
 
-        env.storage().persistent().extend_ttl(
-            &key,
-            ARCHIVE_TTL_THRESHOLD,
-            ARCHIVE_TTL_EXTEND_TO,
-        );
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, ARCHIVE_TTL_THRESHOLD, ARCHIVE_TTL_EXTEND_TO);
 
         Ok(())
     }
@@ -2264,9 +2252,15 @@ impl BulkPaymentContract {
     }
 
     fn check_state_version(env: &Env) {
-        let version: u32 = env.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+        let version: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StateVersion)
+            .unwrap_or(0);
         if version < STATE_VERSION {
-            env.storage().persistent().set(&DataKey::StateVersion, &STATE_VERSION);
+            env.storage()
+                .persistent()
+                .set(&DataKey::StateVersion, &STATE_VERSION);
             env.storage().persistent().extend_ttl(
                 &DataKey::StateVersion,
                 PERSISTENT_TTL_THRESHOLD,

--- a/contracts/bulk_payment/src/test.rs
+++ b/contracts/bulk_payment/src/test.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 use super::*;
 use soroban_sdk::{
+    Address, Env, Vec,
     testutils::Address as _,
     testutils::Ledger,
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env, Vec,
 };
 
 // ── Errors map ────────────────────────────────────────────────────────────────
@@ -3017,9 +3017,18 @@ fn test_multiple_scheduled_batches_execute_fifo() {
     assert_eq!(tc.balance(&sender), 999_400);
 
     // All scheduled batches are Executed
-    assert_eq!(client.get_scheduled_batch(&id1).status, ScheduledBatchStatus::Executed);
-    assert_eq!(client.get_scheduled_batch(&id2).status, ScheduledBatchStatus::Executed);
-    assert_eq!(client.get_scheduled_batch(&id3).status, ScheduledBatchStatus::Executed);
+    assert_eq!(
+        client.get_scheduled_batch(&id1).status,
+        ScheduledBatchStatus::Executed
+    );
+    assert_eq!(
+        client.get_scheduled_batch(&id2).status,
+        ScheduledBatchStatus::Executed
+    );
+    assert_eq!(
+        client.get_scheduled_batch(&id3).status,
+        ScheduledBatchStatus::Executed
+    );
 }
 
 /// Execute scheduled batches out of order — middle one first, then first, then last.
@@ -3143,8 +3152,14 @@ fn test_cancel_one_scheduled_batch_does_not_affect_others() {
     assert_eq!(tc.balance(&r2), 200);
     assert_eq!(tc.balance(&r1), 0);
 
-    assert_eq!(client.get_scheduled_batch(&id1).status, ScheduledBatchStatus::Cancelled);
-    assert_eq!(client.get_scheduled_batch(&id2).status, ScheduledBatchStatus::Executed);
+    assert_eq!(
+        client.get_scheduled_batch(&id1).status,
+        ScheduledBatchStatus::Cancelled
+    );
+    assert_eq!(
+        client.get_scheduled_batch(&id2).status,
+        ScheduledBatchStatus::Executed
+    );
 
     let record = client.get_batch(&batch_id);
     assert_eq!(record.total_sent, 200);
@@ -3446,7 +3461,10 @@ fn test_cancel_scheduled_batch_works_when_paused() {
 
     let tc = TokenClient::new(&env, &token);
     assert_eq!(tc.balance(&sender), 1_000_000); // funds returned
-    assert_eq!(client.get_scheduled_batch(&scheduled_id).status, ScheduledBatchStatus::Cancelled);
+    assert_eq!(
+        client.get_scheduled_batch(&scheduled_id).status,
+        ScheduledBatchStatus::Cancelled
+    );
 }
 
 /// Execute scheduled batch is blocked when paused.
@@ -3836,13 +3854,25 @@ fn test_simulation_full_payroll_cycle() {
     let mut r3 = Vec::new(&env);
 
     let recipient1 = Address::generate(&env);
-    r1.push_back(PaymentOp { recipient: recipient1.clone(), amount: 5_000, category: soroban_sdk::symbol_short!("payroll") });
+    r1.push_back(PaymentOp {
+        recipient: recipient1.clone(),
+        amount: 5_000,
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
 
     let recipient2 = Address::generate(&env);
-    r2.push_back(PaymentOp { recipient: recipient2.clone(), amount: 3_000, category: soroban_sdk::symbol_short!("bonus") });
+    r2.push_back(PaymentOp {
+        recipient: recipient2.clone(),
+        amount: 3_000,
+        category: soroban_sdk::symbol_short!("bonus"),
+    });
 
     let recipient3 = Address::generate(&env);
-    r3.push_back(PaymentOp { recipient: recipient3.clone(), amount: 2_000, category: soroban_sdk::symbol_short!("payroll") });
+    r3.push_back(PaymentOp {
+        recipient: recipient3.clone(),
+        amount: 2_000,
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
 
     let id1 = client.schedule_batch(&sender, &token, &r1, &150);
     let id2 = client.schedule_batch(&sender, &token, &r2, &200);
@@ -3882,9 +3912,18 @@ fn test_simulation_full_payroll_cycle() {
     assert_eq!(usage.weekly_spent, 10_000);
     assert_eq!(usage.monthly_spent, 10_000);
 
-    assert_eq!(client.get_scheduled_batch(&id1).status, ScheduledBatchStatus::Executed);
-    assert_eq!(client.get_scheduled_batch(&id2).status, ScheduledBatchStatus::Executed);
-    assert_eq!(client.get_scheduled_batch(&id3).status, ScheduledBatchStatus::Executed);
+    assert_eq!(
+        client.get_scheduled_batch(&id1).status,
+        ScheduledBatchStatus::Executed
+    );
+    assert_eq!(
+        client.get_scheduled_batch(&id2).status,
+        ScheduledBatchStatus::Executed
+    );
+    assert_eq!(
+        client.get_scheduled_batch(&id3).status,
+        ScheduledBatchStatus::Executed
+    );
 }
 
 /// Simulate a multi-sender scenario: 3 different employers running payroll
@@ -3908,19 +3947,31 @@ fn test_simulation_multi_sender_network() {
     // Employer 1 sends 8_000
     let r1 = Address::generate(&env);
     let mut p1: Vec<PaymentOp> = Vec::new(&env);
-    p1.push_back(PaymentOp { recipient: r1.clone(), amount: 8_000, category: soroban_sdk::symbol_short!("payroll") });
+    p1.push_back(PaymentOp {
+        recipient: r1.clone(),
+        amount: 8_000,
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
     client.execute_batch(&employer1, &token, &p1, &0);
 
     // Employer 2 sends 4_000
     let r2 = Address::generate(&env);
     let mut p2: Vec<PaymentOp> = Vec::new(&env);
-    p2.push_back(PaymentOp { recipient: r2.clone(), amount: 4_000, category: soroban_sdk::symbol_short!("payroll") });
+    p2.push_back(PaymentOp {
+        recipient: r2.clone(),
+        amount: 4_000,
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
     client.execute_batch(&employer2, &token, &p2, &1);
 
     // Employer 3 sends 2_500
     let r3 = Address::generate(&env);
     let mut p3: Vec<PaymentOp> = Vec::new(&env);
-    p3.push_back(PaymentOp { recipient: r3.clone(), amount: 2_500, category: soroban_sdk::symbol_short!("payroll") });
+    p3.push_back(PaymentOp {
+        recipient: r3.clone(),
+        amount: 2_500,
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
     client.execute_batch(&employer3, &token, &p3, &2);
 
     // Each recipient got paid
@@ -3940,7 +3991,11 @@ fn test_simulation_multi_sender_network() {
     env.ledger().set_sequence_number(105);
     let r4 = Address::generate(&env);
     let mut p4: Vec<PaymentOp> = Vec::new(&env);
-    p4.push_back(PaymentOp { recipient: r4.clone(), amount: 2_000, category: soroban_sdk::symbol_short!("payroll") });
+    p4.push_back(PaymentOp {
+        recipient: r4.clone(),
+        amount: 2_000,
+        category: soroban_sdk::symbol_short!("payroll"),
+    });
     let result = client.try_execute_batch(&employer2, &token, &p4, &3);
     assert_eq!(result, Err(Ok(ContractError::DailyLimitExceeded)));
 }
@@ -4028,8 +4083,7 @@ fn test_refund_accounting_all_invalid_amounts() {
 /// total_failed_amount because no funds were ever pulled for them.
 #[test]
 fn test_refund_accounting_zero_amount_failures_no_hold() {
-    let (env, client, sender, token_id, batch_id) =
-        run_mixed_partial_batch(&[500, 0, 300, -10]);
+    let (env, client, sender, token_id, batch_id) = run_mixed_partial_batch(&[500, 0, 300, -10]);
     let record = client.get_batch(&batch_id);
     // 0 and -10 were excluded from the total pull, so no funds held.
     assert_eq!(record.total_failed_amount, 0);
@@ -4053,8 +4107,7 @@ fn test_refund_accounting_zero_amount_failures_no_hold() {
 /// asserting the batch record fields.
 #[test]
 fn test_refund_accounting_exact_tracking_on_batch_record() {
-    let (env, client, sender, token_id, batch_id) =
-        run_mixed_partial_batch(&[100, 200, 300]);
+    let (env, client, sender, token_id, batch_id) = run_mixed_partial_batch(&[100, 200, 300]);
     let record = client.get_batch(&batch_id);
     // All valid — no defensive failures.
     assert_eq!(record.total_failed_amount, 0);

--- a/contracts/cross_asset_payment/src/lib.rs
+++ b/contracts/cross_asset_payment/src/lib.rs
@@ -25,6 +25,8 @@ pub enum CrossAssetPaymentError {
     SameReceiverAndAsset = 12,
     NotProposedAdmin = 13,
     NoPendingAdminTransfer = 14,
+    ExternalTransferFailed = 15,
+    PaymentNotExpired = 16,
 }
 
 /// Emitted when the current admin proposes a new admin (two-step transfer).
@@ -83,6 +85,15 @@ pub struct EscrowRefundedEvent {
     pub amount: i128,
 }
 
+#[contractevent]
+pub struct CrossContractFailureEvent {
+    #[topic]
+    pub payment_id: u64,
+    pub asset: Address,
+    pub attempted_amount: i128,
+    pub reason: Symbol,
+}
+
 /// Emitted when the contract is paused or unpaused (circuit breaker).
 #[contractevent]
 pub struct ContractStatusChangedEvent {
@@ -115,12 +126,14 @@ pub struct PaymentRecord {
     pub target_asset: String,
     pub anchor_id: String,
     pub status: Symbol,
+    pub expires_after_ledger: u32,
 }
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
 const PAYMENT_TTL_THRESHOLD: u32 = 100_000;
 const PAYMENT_TTL_EXTEND_TO: u32 = 1_500_000;
+pub const PAYMENT_TIMEOUT_LEDGERS: u32 = 17_280;
 
 #[contract]
 pub struct CrossAssetPaymentContract;
@@ -202,7 +215,10 @@ impl CrossAssetPaymentContract {
     ///
     /// On success the caller becomes the new admin and the pending proposal is
     /// cleared, completing the two-step handoff.
-    pub fn accept_admin_transfer(env: Env, new_admin: Address) -> Result<(), CrossAssetPaymentError> {
+    pub fn accept_admin_transfer(
+        env: Env,
+        new_admin: Address,
+    ) -> Result<(), CrossAssetPaymentError> {
         let pending: Address = env
             .storage()
             .persistent()
@@ -285,11 +301,7 @@ impl CrossAssetPaymentContract {
             .persistent()
             .get(&DataKey::Admin)
             .expect("Not initialized");
-        ContractStatusChangedEvent {
-            paused,
-            admin,
-        }
-        .publish(&env);
+        ContractStatusChangedEvent { paused, admin }.publish(&env);
         Ok(())
     }
 
@@ -323,12 +335,14 @@ impl CrossAssetPaymentContract {
         }
 
         from.require_auth();
+        let token_client = token::Client::new(&env, &asset);
+        if token_client.balance(&from) < amount {
+            return Err(CrossAssetPaymentError::ExternalTransferFailed);
+        }
         Self::require_unique_ledger(&env, &from)?;
 
-        let token_client = token::Client::new(&env, &asset);
-        token_client.transfer(&from, env.current_contract_address(), &amount);
-
         let payment_id = Self::increment_payment_count(&env);
+        token_client.transfer(&from, env.current_contract_address(), &amount);
 
         let record = PaymentRecord {
             from,
@@ -338,6 +352,10 @@ impl CrossAssetPaymentContract {
             target_asset,
             anchor_id,
             status: symbol_short!("pending"),
+            expires_after_ledger: env
+                .ledger()
+                .sequence()
+                .saturating_add(PAYMENT_TIMEOUT_LEDGERS),
         };
 
         Self::store_payment(&env, payment_id, &record);
@@ -390,9 +408,19 @@ impl CrossAssetPaymentContract {
         Self::require_matching_admin(&env, &admin)?;
 
         let mut record = Self::load_payment(&env, payment_id)?;
-        Self::require_pending_status(&record)?;
+        Self::require_processable_status(&record)?;
 
         let token_client = token::Client::new(&env, &record.asset);
+        if token_client.balance(&env.current_contract_address()) < record.amount {
+            CrossContractFailureEvent {
+                payment_id,
+                asset: record.asset,
+                attempted_amount: record.amount,
+                reason: symbol_short!("release"),
+            }
+            .publish(&env);
+            return Err(CrossAssetPaymentError::ExternalTransferFailed);
+        }
         token_client.transfer(&env.current_contract_address(), &recipient, &record.amount);
 
         record.status = symbol_short!("complete");
@@ -422,9 +450,19 @@ impl CrossAssetPaymentContract {
         Self::require_matching_admin(&env, &admin)?;
 
         let mut record = Self::load_payment(&env, payment_id)?;
-        Self::require_pending_status(&record)?;
+        Self::require_processable_status(&record)?;
 
         let token_client = token::Client::new(&env, &record.asset);
+        if token_client.balance(&env.current_contract_address()) < record.amount {
+            CrossContractFailureEvent {
+                payment_id,
+                asset: record.asset,
+                attempted_amount: record.amount,
+                reason: symbol_short!("refund"),
+            }
+            .publish(&env);
+            return Err(CrossAssetPaymentError::ExternalTransferFailed);
+        }
         token_client.transfer(
             &env.current_contract_address(),
             &record.from,
@@ -446,6 +484,30 @@ impl CrossAssetPaymentContract {
         }
         .publish(&env);
         Ok(())
+    }
+
+    pub fn expire_payment(
+        env: Env,
+        admin: Address,
+        payment_id: u64,
+    ) -> Result<(), CrossAssetPaymentError> {
+        Self::require_not_paused(&env)?;
+        Self::require_matching_admin(&env, &admin)?;
+
+        let record = Self::load_payment(&env, payment_id)?;
+        Self::require_processable_status(&record)?;
+        if env.ledger().sequence() <= record.expires_after_ledger {
+            return Err(CrossAssetPaymentError::PaymentNotExpired);
+        }
+
+        CrossContractFailureEvent {
+            payment_id,
+            asset: record.asset.clone(),
+            attempted_amount: record.amount,
+            reason: symbol_short!("timeout"),
+        }
+        .publish(&env);
+        Self::refund_loaded_payment(&env, payment_id, record)
     }
 
     /// Returns the stored payment details when present.
@@ -527,6 +589,46 @@ impl CrossAssetPaymentContract {
         if record.status != symbol_short!("pending") {
             return Err(CrossAssetPaymentError::PaymentNotPending);
         }
+        Ok(())
+    }
+
+    fn require_processable_status(record: &PaymentRecord) -> Result<(), CrossAssetPaymentError> {
+        if record.status != symbol_short!("pending") && record.status != symbol_short!("process") {
+            return Err(CrossAssetPaymentError::PaymentNotPending);
+        }
+        Ok(())
+    }
+
+    fn refund_loaded_payment(
+        env: &Env,
+        payment_id: u64,
+        mut record: PaymentRecord,
+    ) -> Result<(), CrossAssetPaymentError> {
+        let token_client = token::Client::new(env, &record.asset);
+        if token_client.balance(&env.current_contract_address()) < record.amount {
+            return Err(CrossAssetPaymentError::ExternalTransferFailed);
+        }
+
+        token_client.transfer(
+            &env.current_contract_address(),
+            &record.from,
+            &record.amount,
+        );
+
+        record.status = symbol_short!("failed");
+        Self::store_payment(env, payment_id, &record);
+
+        PaymentStatusUpdatedEvent {
+            payment_id,
+            new_status: symbol_short!("failed"),
+        }
+        .publish(env);
+        EscrowRefundedEvent {
+            payment_id,
+            sender: record.from,
+            amount: record.amount,
+        }
+        .publish(env);
         Ok(())
     }
 

--- a/contracts/cross_asset_payment/src/test.rs
+++ b/contracts/cross_asset_payment/src/test.rs
@@ -588,7 +588,10 @@ fn test_accept_admin_transfer_with_no_proposal_returns_error() {
 
     let random = Address::generate(&env);
     let result = client.try_accept_admin_transfer(&random);
-    assert_eq!(result, Err(Ok(CrossAssetPaymentError::NoPendingAdminTransfer)));
+    assert_eq!(
+        result,
+        Err(Ok(CrossAssetPaymentError::NoPendingAdminTransfer))
+    );
 }
 
 #[test]

--- a/contracts/cross_asset_payment/src/test_escrow.rs
+++ b/contracts/cross_asset_payment/src/test_escrow.rs
@@ -11,7 +11,7 @@
 use super::*;
 use soroban_sdk::{
     Address, Env, String as SorobanString,
-    testutils::{Address as _, Ledger},
+    testutils::{Address as _, Events as _, Ledger},
     token,
 };
 
@@ -536,4 +536,138 @@ fn test_cannot_fail_already_failed() {
 
     let result = client.try_fail_payment(&admin, &payment_id);
     assert_eq!(result, Err(Ok(CrossAssetPaymentError::PaymentNotPending)));
+}
+
+#[test]
+fn test_initiate_external_transfer_failure_does_not_create_payment() {
+    let (env, _, sender, token_contract, token_client, _, client, contract_address) =
+        setup_payment_escrow();
+
+    let result = client.try_initiate_payment(
+        &sender,
+        &2_000_000,
+        &token_contract,
+        &SorobanString::from_str(&env, "receiver"),
+        &SorobanString::from_str(&env, "USD"),
+        &SorobanString::from_str(&env, "anchor"),
+    );
+
+    assert_eq!(
+        result,
+        Err(Ok(CrossAssetPaymentError::ExternalTransferFailed))
+    );
+    assert_eq!(client.get_payment_count(), 0);
+    assert_eq!(token_client.balance(&contract_address), 0);
+    assert_eq!(client.get_last_payment_ledger(&sender), 0);
+}
+
+#[test]
+fn test_complete_payment_from_process_state_is_atomic() {
+    let (env, admin, sender, token_contract, token_client, _, client, contract_address) =
+        setup_payment_escrow();
+    let recipient = Address::generate(&env);
+
+    let payment_id = client.initiate_payment(
+        &sender,
+        &10_000,
+        &token_contract,
+        &SorobanString::from_str(&env, "receiver"),
+        &SorobanString::from_str(&env, "USD"),
+        &SorobanString::from_str(&env, "anchor"),
+    );
+    client.update_status(&payment_id, &symbol_short!("process"));
+
+    client.complete_payment(&admin, &payment_id, &recipient);
+
+    assert_eq!(token_client.balance(&recipient), 10_000);
+    assert_eq!(token_client.balance(&contract_address), 0);
+    assert_eq!(
+        client.get_payment(&payment_id).unwrap().status,
+        symbol_short!("complete")
+    );
+}
+
+#[test]
+fn test_fail_payment_from_process_state_refunds_sender() {
+    let (env, admin, sender, token_contract, token_client, _, client, contract_address) =
+        setup_payment_escrow();
+    let initial_balance = token_client.balance(&sender);
+
+    let payment_id = client.initiate_payment(
+        &sender,
+        &7_000,
+        &token_contract,
+        &SorobanString::from_str(&env, "receiver"),
+        &SorobanString::from_str(&env, "USD"),
+        &SorobanString::from_str(&env, "anchor"),
+    );
+    client.update_status(&payment_id, &symbol_short!("process"));
+
+    client.fail_payment(&admin, &payment_id);
+
+    assert_eq!(token_client.balance(&sender), initial_balance);
+    assert_eq!(token_client.balance(&contract_address), 0);
+    assert_eq!(
+        client.get_payment(&payment_id).unwrap().status,
+        symbol_short!("failed")
+    );
+}
+
+#[test]
+fn test_expire_payment_before_timeout_rejected_without_refund() {
+    let (env, admin, sender, token_contract, token_client, _, client, contract_address) =
+        setup_payment_escrow();
+    let initial_balance = token_client.balance(&sender);
+
+    let payment_id = client.initiate_payment(
+        &sender,
+        &5_000,
+        &token_contract,
+        &SorobanString::from_str(&env, "receiver"),
+        &SorobanString::from_str(&env, "USD"),
+        &SorobanString::from_str(&env, "anchor"),
+    );
+
+    let result = client.try_expire_payment(&admin, &payment_id);
+    assert_eq!(result, Err(Ok(CrossAssetPaymentError::PaymentNotExpired)));
+    assert_eq!(token_client.balance(&sender), initial_balance - 5_000);
+    assert_eq!(token_client.balance(&contract_address), 5_000);
+    assert_eq!(
+        client.get_payment(&payment_id).unwrap().status,
+        symbol_short!("pending")
+    );
+}
+
+#[test]
+fn test_expire_payment_after_timeout_refunds_and_emits_failure_event() {
+    let (env, admin, sender, token_contract, token_client, _, client, contract_address) =
+        setup_payment_escrow();
+    let initial_balance = token_client.balance(&sender);
+    env.ledger().set_sequence_number(100);
+
+    let payment_id = client.initiate_payment(
+        &sender,
+        &5_000,
+        &token_contract,
+        &SorobanString::from_str(&env, "receiver"),
+        &SorobanString::from_str(&env, "USD"),
+        &SorobanString::from_str(&env, "anchor"),
+    );
+    let deadline = client
+        .get_payment(&payment_id)
+        .unwrap()
+        .expires_after_ledger;
+    env.ledger().set_sequence_number(deadline + 1);
+
+    let events_before = env.events().all().len();
+    client.expire_payment(&admin, &payment_id);
+    let events_after = env.events().all().len();
+
+    assert!(events_after > events_before);
+    assert_eq!(token_client.balance(&sender), initial_balance);
+    assert_eq!(token_client.balance(&contract_address), 0);
+    assert_eq!(
+        client.get_payment(&payment_id).unwrap().status,
+        symbol_short!("failed")
+    );
 }

--- a/contracts/milestone_escrow/src/lib.rs
+++ b/contracts/milestone_escrow/src/lib.rs
@@ -206,10 +206,7 @@ impl MilestoneEscrowContract {
             .ok_or(ContractError::NotInitialized)
     }
 
-    pub fn propose_admin_transfer(
-        env: Env,
-        proposed_admin: Address,
-    ) -> Result<(), ContractError> {
+    pub fn propose_admin_transfer(env: Env, proposed_admin: Address) -> Result<(), ContractError> {
         let admin: Address = env
             .storage()
             .persistent()
@@ -710,9 +707,11 @@ impl MilestoneEscrowContract {
         if version < STATE_VERSION {
             env.storage().persistent().set(&key, &STATE_VERSION);
         }
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
     }
 }
 

--- a/contracts/milestone_escrow/src/test.rs
+++ b/contracts/milestone_escrow/src/test.rs
@@ -270,7 +270,10 @@ fn test_release_approved_milestone_even_when_paused() {
 
     let record = client.get_escrow(&escrow_id);
     assert_eq!(record.released_amount, 1000);
-    assert_eq!(record.milestones.get(0).unwrap().status, MilestoneStatus::Released);
+    assert_eq!(
+        record.milestones.get(0).unwrap().status,
+        MilestoneStatus::Released
+    );
 }
 
 #[test]
@@ -906,10 +909,7 @@ fn test_sequential_release_balances_never_negative() {
     // Beneficiary received exactly the sum of all milestones.
     assert_eq!(token_client.balance(&beneficiary), 6000);
     // Contract holds zero.
-    assert_eq!(
-        token_client.balance(&e.current_contract_address()),
-        0
-    );
+    assert_eq!(token_client.balance(&e.current_contract_address()), 0);
 }
 
 // ==============================================================================
@@ -1037,10 +1037,7 @@ fn test_cancel_recovery_exact_accounting() {
         1_000_000 - total + expected_recovery
     );
     assert_eq!(token_client.balance(&beneficiary), released);
-    assert_eq!(
-        token_client.balance(&e.current_contract_address()),
-        0
-    );
+    assert_eq!(token_client.balance(&e.current_contract_address()), 0);
 }
 
 /// Verifies sender balance is exactly restored after cancellation.
@@ -1119,8 +1116,5 @@ fn test_cancel_event_emission() {
     let expected_recovery: i128 = 5000; // 6000 - 1000
     assert_eq!(token_client.balance(&sender), 1_000_000 - 1000);
     assert_eq!(token_client.balance(&beneficiary), 1000);
-    assert_eq!(
-        token_client.balance(&e.current_contract_address()),
-        0
-    );
+    assert_eq!(token_client.balance(&e.current_contract_address()), 0);
 }

--- a/contracts/orgusd/src/lib.rs
+++ b/contracts/orgusd/src/lib.rs
@@ -1,4 +1,4 @@
-﻿//! # ORGUSD – Custom Stable Asset Contract
+//! # ORGUSD – Custom Stable Asset Contract
 //!
 //! Issues and manages the ORGUSD custom asset on the Stellar / Soroban
 //! network.  This contract implements a controlled-issuance token with:
@@ -27,7 +27,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, Address, Env, String,
+    Address, Env, String, contract, contracterror, contractevent, contractimpl, contracttype,
 };
 
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -183,6 +183,10 @@ pub struct ClawbackEvent {
 }
 
 const STATE_VERSION: u32 = 1;
+pub const INSTANCE_TTL_THRESHOLD: u32 = 20_000;
+pub const INSTANCE_TTL_EXTEND_TO: u32 = 120_000;
+pub const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
+pub const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
 
 // ── Contract ──────────────────────────────────────────────────────────────────
 
@@ -203,6 +207,7 @@ impl OrgUsdContract {
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::TotalSupply, &0_i128);
+        Self::bump_instance_ttl(&env);
 
         InitializedEvent { admin }.publish(&env);
         Ok(())
@@ -267,6 +272,7 @@ impl OrgUsdContract {
     /// Returns the total minted supply of ORGUSD.
     pub fn total_supply(env: Env) -> Result<i128, OrgUsdError> {
         Self::require_initialized(&env)?;
+        Self::bump_instance_ttl(&env);
         Ok(env
             .storage()
             .instance()
@@ -277,31 +283,28 @@ impl OrgUsdContract {
     /// Returns the ORGUSD balance of `account`.
     pub fn balance(env: Env, account: Address) -> Result<i128, OrgUsdError> {
         Self::require_initialized(&env)?;
-        Ok(env
-            .storage()
-            .persistent()
-            .get(&DataKey::Balance(account))
-            .unwrap_or(0))
+        let key = DataKey::Balance(account);
+        let balance = env.storage().persistent().get(&key).unwrap_or(0);
+        Self::bump_persistent_key_ttl(&env, &key);
+        Ok(balance)
     }
 
     /// Returns whether `account` is authorized to hold ORGUSD.
     pub fn is_authorized(env: Env, account: Address) -> Result<bool, OrgUsdError> {
         Self::require_initialized(&env)?;
-        Ok(env
-            .storage()
-            .persistent()
-            .get(&DataKey::Authorized(account))
-            .unwrap_or(false))
+        let key = DataKey::Authorized(account);
+        let authorized = env.storage().persistent().get(&key).unwrap_or(false);
+        Self::bump_persistent_key_ttl(&env, &key);
+        Ok(authorized)
     }
 
     /// Returns whether `account` is currently frozen.
     pub fn is_frozen(env: Env, account: Address) -> Result<bool, OrgUsdError> {
         Self::require_initialized(&env)?;
-        Ok(env
-            .storage()
-            .persistent()
-            .get(&DataKey::Frozen(account))
-            .unwrap_or(false))
+        let key = DataKey::Frozen(account);
+        let frozen = env.storage().persistent().get(&key).unwrap_or(false);
+        Self::bump_persistent_key_ttl(&env, &key);
+        Ok(frozen)
     }
 
     // ── Admin: authorization management ──────────────────────────────────────
@@ -314,6 +317,8 @@ impl OrgUsdContract {
         env.storage()
             .persistent()
             .set(&DataKey::Authorized(account.clone()), &true);
+        Self::bump_account_ttl(&env, &account);
+        Self::bump_instance_ttl(&env);
 
         AuthorizedEvent { account }.publish(&env);
         Ok(())
@@ -327,6 +332,8 @@ impl OrgUsdContract {
         env.storage()
             .persistent()
             .set(&DataKey::Authorized(account.clone()), &false);
+        Self::bump_account_ttl(&env, &account);
+        Self::bump_instance_ttl(&env);
 
         RevokedEvent { account }.publish(&env);
         Ok(())
@@ -342,6 +349,8 @@ impl OrgUsdContract {
         env.storage()
             .persistent()
             .set(&DataKey::Frozen(account.clone()), &true);
+        Self::bump_account_ttl(&env, &account);
+        Self::bump_instance_ttl(&env);
 
         FrozenEvent { account }.publish(&env);
         Ok(())
@@ -355,6 +364,8 @@ impl OrgUsdContract {
         env.storage()
             .persistent()
             .set(&DataKey::Frozen(account.clone()), &false);
+        Self::bump_account_ttl(&env, &account);
+        Self::bump_instance_ttl(&env);
 
         UnfrozenEvent { account }.publish(&env);
         Ok(())
@@ -395,7 +406,9 @@ impl OrgUsdContract {
             .persistent()
             .get(&DataKey::Balance(to.clone()))
             .unwrap_or(0);
-        let new_balance = old_balance.checked_add(amount).ok_or(OrgUsdError::Overflow)?;
+        let new_balance = old_balance
+            .checked_add(amount)
+            .ok_or(OrgUsdError::Overflow)?;
         env.storage()
             .persistent()
             .set(&DataKey::Balance(to.clone()), &new_balance);
@@ -404,10 +417,14 @@ impl OrgUsdContract {
             .instance()
             .get(&DataKey::TotalSupply)
             .unwrap_or(0);
-        let new_supply = old_supply.checked_add(amount).ok_or(OrgUsdError::Overflow)?;
+        let new_supply = old_supply
+            .checked_add(amount)
+            .ok_or(OrgUsdError::Overflow)?;
         env.storage()
             .instance()
             .set(&DataKey::TotalSupply, &new_supply);
+        Self::bump_account_ttl(&env, &to);
+        Self::bump_instance_ttl(&env);
 
         MintedEvent {
             to,
@@ -447,7 +464,9 @@ impl OrgUsdContract {
         if from_balance < amount {
             return Err(OrgUsdError::InsufficientFunds);
         }
-        let new_from_balance = from_balance.checked_sub(amount).ok_or(OrgUsdError::Overflow)?;
+        let new_from_balance = from_balance
+            .checked_sub(amount)
+            .ok_or(OrgUsdError::Overflow)?;
         env.storage()
             .persistent()
             .set(&DataKey::Balance(from.clone()), &new_from_balance);
@@ -457,10 +476,15 @@ impl OrgUsdContract {
             .persistent()
             .get(&DataKey::Balance(to.clone()))
             .unwrap_or(0);
-        let new_to_balance = to_balance.checked_add(amount).ok_or(OrgUsdError::Overflow)?;
+        let new_to_balance = to_balance
+            .checked_add(amount)
+            .ok_or(OrgUsdError::Overflow)?;
         env.storage()
             .persistent()
             .set(&DataKey::Balance(to.clone()), &new_to_balance);
+        Self::bump_account_ttl(&env, &from);
+        Self::bump_account_ttl(&env, &to);
+        Self::bump_instance_ttl(&env);
 
         TransferEvent { from, to, amount }.publish(&env);
         Ok(())
@@ -496,10 +520,14 @@ impl OrgUsdContract {
             .instance()
             .get(&DataKey::TotalSupply)
             .unwrap_or(0);
-        let new_supply = old_supply.checked_sub(amount).ok_or(OrgUsdError::Overflow)?;
+        let new_supply = old_supply
+            .checked_sub(amount)
+            .ok_or(OrgUsdError::Overflow)?;
         env.storage()
             .instance()
             .set(&DataKey::TotalSupply, &new_supply);
+        Self::bump_account_ttl(&env, &from);
+        Self::bump_instance_ttl(&env);
 
         BurnedEvent {
             from,
@@ -537,10 +565,14 @@ impl OrgUsdContract {
             .instance()
             .get(&DataKey::TotalSupply)
             .unwrap_or(0);
-        let new_supply = old_supply.checked_sub(amount).ok_or(OrgUsdError::Overflow)?;
+        let new_supply = old_supply
+            .checked_sub(amount)
+            .ok_or(OrgUsdError::Overflow)?;
         env.storage()
             .instance()
             .set(&DataKey::TotalSupply, &new_supply);
+        Self::bump_account_ttl(&env, &from);
+        Self::bump_instance_ttl(&env);
 
         ClawbackEvent {
             from,
@@ -568,6 +600,7 @@ impl OrgUsdContract {
         env.storage()
             .instance()
             .set(&DataKey::PendingAdmin, &new_admin);
+        Self::bump_instance_ttl(&env);
 
         AdminTransferProposedEvent {
             current_admin,
@@ -597,6 +630,7 @@ impl OrgUsdContract {
 
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         env.storage().instance().remove(&DataKey::PendingAdmin);
+        Self::bump_instance_ttl(&env);
 
         AdminTransferAcceptedEvent {
             old_admin,
@@ -622,6 +656,7 @@ impl OrgUsdContract {
             .expect("No pending admin transfer to cancel");
 
         env.storage().instance().remove(&DataKey::PendingAdmin);
+        Self::bump_instance_ttl(&env);
 
         AdminTransferCancelledEvent {
             admin: current_admin,
@@ -631,7 +666,15 @@ impl OrgUsdContract {
     }
 
     pub fn get_pending_admin(env: Env) -> Option<Address> {
+        Self::bump_instance_ttl(&env);
         env.storage().instance().get(&DataKey::PendingAdmin)
+    }
+
+    pub fn bump_ttl(env: Env) -> Result<(), OrgUsdError> {
+        let admin = Self::require_admin(&env)?;
+        admin.require_auth();
+        Self::bump_instance_ttl(&env);
+        Ok(())
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -641,6 +684,32 @@ impl OrgUsdContract {
             return Err(OrgUsdError::NotInitialized);
         }
         Ok(())
+    }
+
+    fn bump_instance_ttl(env: &Env) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+    }
+
+    fn bump_persistent_key_ttl(env: &Env, key: &DataKey) {
+        if env.storage().persistent().has(key) {
+            env.storage().persistent().extend_ttl(
+                key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
+        }
+    }
+
+    fn bump_account_ttl(env: &Env, account: &Address) {
+        for key in [
+            DataKey::Balance(account.clone()),
+            DataKey::Authorized(account.clone()),
+            DataKey::Frozen(account.clone()),
+        ] {
+            Self::bump_persistent_key_ttl(env, &key);
+        }
     }
 
     fn require_admin(env: &Env) -> Result<Address, OrgUsdError> {
@@ -680,6 +749,7 @@ impl OrgUsdContract {
         if version < STATE_VERSION {
             env.storage().persistent().set(&key, &STATE_VERSION);
         }
+        Self::bump_persistent_key_ttl(env, &key);
     }
 }
 
@@ -688,7 +758,7 @@ impl OrgUsdContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Env};
+    use soroban_sdk::{Env, testutils::Address as _};
 
     fn setup() -> (Env, Address, OrgUsdContractClient<'static>) {
         let env = Env::default();
@@ -736,7 +806,10 @@ mod tests {
                 "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
             )
         );
-        assert_eq!(metadata.home_domain, String::from_str(&env, "payd.example.com"));
+        assert_eq!(
+            metadata.home_domain,
+            String::from_str(&env, "payd.example.com")
+        );
         assert_eq!(metadata.display_decimals, 2);
         assert!(metadata.anchored);
         assert_eq!(metadata.anchor_asset, String::from_str(&env, "USD"));
@@ -759,7 +832,10 @@ mod tests {
 
         assert!(!client.verify_sep1_metadata(
             &String::from_str(&env, "ORGUSD"),
-            &String::from_str(&env, "GDIFFERENTISSUER0000000000000000000000000000000000000000"),
+            &String::from_str(
+                &env,
+                "GDIFFERENTISSUER0000000000000000000000000000000000000000"
+            ),
             &String::from_str(&env, "payd.example.com"),
             &2,
             &String::from_str(&env, "USD"),
@@ -818,10 +894,7 @@ mod tests {
         let holder = Address::generate(&env);
 
         let result = client.try_mint(&holder, &1000);
-        assert_eq!(
-            result,
-            Err(Ok(OrgUsdError::AccountNotAuthorized))
-        );
+        assert_eq!(result, Err(Ok(OrgUsdError::AccountNotAuthorized)));
     }
 
     #[test]
@@ -852,7 +925,7 @@ mod tests {
     fn test_transfer_succeeds() {
         let (env, _, client) = setup();
         let alice = Address::generate(&env);
-        let bob   = Address::generate(&env);
+        let bob = Address::generate(&env);
 
         client.authorize(&alice);
         client.authorize(&bob);
@@ -868,7 +941,7 @@ mod tests {
     fn test_transfer_fails_if_insufficient_funds() {
         let (env, _, client) = setup();
         let alice = Address::generate(&env);
-        let bob   = Address::generate(&env);
+        let bob = Address::generate(&env);
 
         client.authorize(&alice);
         client.authorize(&bob);
@@ -882,7 +955,7 @@ mod tests {
     fn test_transfer_fails_if_sender_frozen() {
         let (env, _, client) = setup();
         let alice = Address::generate(&env);
-        let bob   = Address::generate(&env);
+        let bob = Address::generate(&env);
 
         client.authorize(&alice);
         client.authorize(&bob);
@@ -962,7 +1035,7 @@ mod tests {
     fn test_full_issuance_flow() {
         let (env, _, client) = setup();
         let distribution = Address::generate(&env);
-        let recipient     = Address::generate(&env);
+        let recipient = Address::generate(&env);
 
         // Authorize both accounts
         client.authorize(&distribution);
@@ -993,7 +1066,10 @@ mod tests {
         let contract_id = env.register(OrgUsdContract, ());
         let metadata = Sep1AssetMetadata {
             code: String::from_str(&env, "ORGUSD"),
-            issuer: String::from_str(&env, "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"),
+            issuer: String::from_str(
+                &env,
+                "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+            ),
             home_domain: String::from_str(&env, "payd.example.com"),
             display_decimals: 2,
             anchored: true,
@@ -1065,7 +1141,11 @@ mod tests {
         client.initialize(&Address::generate(&env));
 
         env.as_contract(&contract_id, || {
-            let version: u32 = env.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+            let version: u32 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::StateVersion)
+                .unwrap_or(0);
             assert_eq!(version, STATE_VERSION);
         });
     }
@@ -1076,9 +1156,15 @@ mod tests {
         let contract_id = env.register(OrgUsdContract, ());
 
         env.as_contract(&contract_id, || {
-            env.storage().persistent().set(&DataKey::StateVersion, &0u32);
+            env.storage()
+                .persistent()
+                .set(&DataKey::StateVersion, &0u32);
             OrgUsdContract::check_state_version(&env);
-            let version: u32 = env.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+            let version: u32 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::StateVersion)
+                .unwrap_or(0);
             assert_eq!(version, STATE_VERSION);
         });
     }
@@ -1251,3 +1337,7 @@ mod tests {
         client.cancel_admin_transfer();
     }
 }
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod external_tests;

--- a/contracts/orgusd/src/tests.rs
+++ b/contracts/orgusd/src/tests.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{
+    Address, Env,
+    testutils::{Address as _, Events as _, Instance as _, Ledger, Persistent as _},
+};
 
 use crate::{OrgUsdContract, OrgUsdContractClient, OrgUsdError};
 
@@ -14,10 +17,7 @@ fn setup() -> (Env, OrgUsdContractClient<'static>, Address) {
     (env, client, admin)
 }
 
-fn setup_with_account(
-    client: &OrgUsdContractClient,
-    env: &Env,
-) -> Address {
+fn setup_with_account(client: &OrgUsdContractClient, env: &Env) -> Address {
     let account = Address::generate(env);
     client.authorize(&account);
     account
@@ -415,4 +415,134 @@ fn test_burn_unregistered_account_rejected() {
     let result = client.try_burn(&account, &1);
     // Should fail on auth or balance check (account has 0 balance)
     assert!(result.is_err());
+}
+
+#[test]
+fn test_admin_operation_events_are_emitted() {
+    let (env, client, _admin) = setup();
+    let account = Address::generate(&env);
+
+    let before = env.events().all().len();
+    client.authorize(&account);
+    client.mint(&account, &100);
+    client.freeze(&account);
+    client.unfreeze(&account);
+    client.clawback(&account, &25);
+    client.revoke(&account);
+    let after = env.events().all().len();
+
+    assert_eq!(after - before, 6);
+}
+
+#[test]
+fn test_mint_to_frozen_account_rejected_without_state_change() {
+    let (env, client, _admin) = setup();
+    let account = setup_with_account(&client, &env);
+    client.mint(&account, &100);
+    client.freeze(&account);
+
+    let result = client.try_mint(&account, &50);
+
+    assert_eq!(result, Err(Ok(OrgUsdError::AccountFrozen)));
+    assert_eq!(client.balance(&account), 100);
+    assert_eq!(client.total_supply(), 100);
+}
+
+#[test]
+fn test_freeze_already_frozen_and_unfreeze_already_unfrozen_are_idempotent() {
+    let (env, client, _admin) = setup();
+    let account = setup_with_account(&client, &env);
+
+    client.freeze(&account);
+    client.freeze(&account);
+    assert!(client.is_frozen(&account));
+
+    client.unfreeze(&account);
+    client.unfreeze(&account);
+    assert!(!client.is_frozen(&account));
+}
+
+#[test]
+fn test_transfer_to_frozen_recipient_rejected() {
+    let (env, client, _admin) = setup();
+    let alice = setup_with_account(&client, &env);
+    let bob = setup_with_account(&client, &env);
+    client.mint(&alice, &250);
+    client.freeze(&bob);
+
+    let result = client.try_transfer(&alice, &bob, &50);
+
+    assert_eq!(result, Err(Ok(OrgUsdError::AccountFrozen)));
+    assert_eq!(client.balance(&alice), 250);
+    assert_eq!(client.balance(&bob), 0);
+}
+
+#[test]
+fn test_clawback_zero_and_negative_amounts_rejected() {
+    let (env, client, _admin) = setup();
+    let account = setup_with_account(&client, &env);
+    client.mint(&account, &100);
+
+    assert_eq!(
+        client.try_clawback(&account, &0),
+        Err(Ok(OrgUsdError::InvalidAmount))
+    );
+    assert_eq!(
+        client.try_clawback(&account, &-1),
+        Err(Ok(OrgUsdError::InvalidAmount))
+    );
+    assert_eq!(client.balance(&account), 100);
+}
+
+#[test]
+fn test_orgusd_instance_ttl_set_on_initialization_and_extended_by_bump() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_sequence_number(1);
+    let contract_id = env.register(OrgUsdContract, ());
+    let client = OrgUsdContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    let initial_ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+    assert!(initial_ttl >= crate::INSTANCE_TTL_THRESHOLD);
+
+    env.ledger().set_sequence_number(110_000);
+    let aged_ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+    assert!(aged_ttl < crate::INSTANCE_TTL_THRESHOLD);
+
+    client.bump_ttl();
+    let bumped_ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+    assert!(bumped_ttl >= crate::INSTANCE_TTL_EXTEND_TO - 1);
+}
+
+#[test]
+fn test_account_storage_ttl_extended_on_successful_operation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_sequence_number(1);
+    let contract_id = env.register(OrgUsdContract, ());
+    let client = OrgUsdContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let account = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.authorize(&account);
+    let auth_key = crate::DataKey::Authorized(account.clone());
+    let initial_ttl = env.as_contract(&contract_id, || {
+        env.storage().persistent().get_ttl(&auth_key)
+    });
+    assert!(initial_ttl >= crate::PERSISTENT_TTL_THRESHOLD);
+
+    env.ledger().set_sequence_number(110_000);
+    let aged_ttl = env.as_contract(&contract_id, || {
+        env.storage().persistent().get_ttl(&auth_key)
+    });
+    assert!(aged_ttl < crate::PERSISTENT_TTL_THRESHOLD);
+
+    client.is_authorized(&account);
+    let bumped_ttl = env.as_contract(&contract_id, || {
+        env.storage().persistent().get_ttl(&auth_key)
+    });
+    assert!(bumped_ttl >= crate::PERSISTENT_TTL_EXTEND_TO - 1);
 }

--- a/contracts/revenue_split/src/lib.rs
+++ b/contracts/revenue_split/src/lib.rs
@@ -31,6 +31,8 @@ pub enum RevenueSplitError {
     InvalidAmount = 12,
     NotProposedAdmin = 13,
     NoPendingAdminTransfer = 14,
+    AmountTooLarge = 15,
+    ArithmeticOverflow = 16,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -120,6 +122,7 @@ pub enum DataKey {
     SupportedAssets,
     StateVersion,
     PendingAdmin,
+    MaxDistributionAmount,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -138,6 +141,7 @@ pub struct DistributionPreview {
 }
 
 pub const TOTAL_BASIS_POINTS: u32 = 10_000;
+pub const DEFAULT_MAX_DISTRIBUTION_AMOUNT: i128 = 1_000_000_000_000_000;
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 20_000;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 120_000;
@@ -182,6 +186,10 @@ impl RevenueSplitContract {
         env.storage()
             .persistent()
             .set(&DataKey::DistributionCount, &0u64);
+        env.storage().persistent().set(
+            &DataKey::MaxDistributionAmount,
+            &DEFAULT_MAX_DISTRIBUTION_AMOUNT,
+        );
         Self::store_recipients(&env, &shares);
         Self::bump_core_ttl(&env);
         Ok(())
@@ -202,6 +210,7 @@ impl RevenueSplitContract {
         env: Env,
         amount: i128,
     ) -> Result<Vec<DistributionPreview>, RevenueSplitError> {
+        Self::validate_distribution_amount(&env, amount)?;
         let shares = Self::load_recipients(&env);
         Self::build_distribution_preview(&env, &shares, amount)
     }
@@ -246,10 +255,7 @@ impl RevenueSplitContract {
         Ok(())
     }
 
-    pub fn accept_admin_transfer(
-        env: Env,
-        new_admin: Address,
-    ) -> Result<(), RevenueSplitError> {
+    pub fn accept_admin_transfer(env: Env, new_admin: Address) -> Result<(), RevenueSplitError> {
         let pending_admin: Address = env
             .storage()
             .persistent()
@@ -260,12 +266,8 @@ impl RevenueSplitContract {
         }
         new_admin.require_auth();
         let old_admin = Self::load_admin(&env)?;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Admin, &new_admin);
-        env.storage()
-            .persistent()
-            .remove(&DataKey::PendingAdmin);
+        env.storage().persistent().set(&DataKey::Admin, &new_admin);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
         Self::bump_core_ttl(&env);
         AdminTransferAcceptedEvent {
             old_admin,
@@ -283,9 +285,7 @@ impl RevenueSplitContract {
             .persistent()
             .get(&DataKey::PendingAdmin)
             .ok_or(RevenueSplitError::NoPendingAdminTransfer)?;
-        env.storage()
-            .persistent()
-            .remove(&DataKey::PendingAdmin);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
         AdminTransferCancelledEvent {
             admin,
             cancelled_admin,
@@ -330,6 +330,9 @@ impl RevenueSplitContract {
         admin.require_auth();
 
         env.storage().instance().set(&DataKey::Paused, &paused);
+        env.storage()
+            .instance()
+            .extend_ttl(PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
 
         PauseStateChangedEvent { paused, admin }.publish(&env);
         Ok(())
@@ -349,6 +352,44 @@ impl RevenueSplitContract {
             .persistent()
             .get(&DataKey::DistributionCount)
             .unwrap_or(0)
+    }
+
+    pub fn set_max_distribution_amount(
+        env: Env,
+        max_amount: i128,
+    ) -> Result<(), RevenueSplitError> {
+        let admin = Self::load_admin(&env)?;
+        admin.require_auth();
+        if max_amount <= 0 {
+            return Err(RevenueSplitError::InvalidAmount);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::MaxDistributionAmount, &max_amount);
+        env.storage().persistent().extend_ttl(
+            &DataKey::MaxDistributionAmount,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+        Self::bump_core_ttl(&env);
+        Ok(())
+    }
+
+    pub fn get_max_distribution_amount(env: Env) -> i128 {
+        let key = DataKey::MaxDistributionAmount;
+        let max_amount = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(DEFAULT_MAX_DISTRIBUTION_AMOUNT);
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
+        }
+        max_amount
     }
 
     /// Adds a token asset to the supported-asset allowlist (admin only).
@@ -418,11 +459,9 @@ impl RevenueSplitContract {
         from: Address,
         amount: i128,
     ) -> Result<(), RevenueSplitError> {
-        if amount < 0 {
+        Self::validate_distribution_amount(&env, amount)?;
+        if amount <= 0 {
             return Err(RevenueSplitError::InvalidAmount);
-        }
-        if amount == 0 {
-            return Ok(());
         }
 
         Self::require_not_paused(&env)?;
@@ -436,17 +475,24 @@ impl RevenueSplitContract {
         let recipient_count = shares.len();
         let preview = Self::build_distribution_preview(&env, &shares, amount)?;
         let client = token::Client::new(&env, &token);
+        let mut actual_distributed = 0i128;
 
         for payment in preview.iter() {
             if payment.amount > 0 {
                 client.transfer(&from, &payment.destination, &payment.amount);
+                actual_distributed = actual_distributed
+                    .checked_add(payment.amount)
+                    .ok_or(RevenueSplitError::ArithmeticOverflow)?;
             }
         }
 
         // Accumulate total distributed for this token
         let td_key = DataKey::TotalDistributed(token.clone());
         let prev: i128 = env.storage().persistent().get(&td_key).unwrap_or(0);
-        env.storage().persistent().set(&td_key, &(prev + amount));
+        let total_distributed = prev
+            .checked_add(actual_distributed)
+            .ok_or(RevenueSplitError::ArithmeticOverflow)?;
+        env.storage().persistent().set(&td_key, &total_distributed);
         env.storage().persistent().extend_ttl(
             &td_key,
             PERSISTENT_TTL_THRESHOLD,
@@ -472,7 +518,7 @@ impl RevenueSplitContract {
         DistributedEvent {
             token,
             from,
-            total_amount: amount,
+            total_amount: actual_distributed,
             recipient_count,
         }
         .publish(&env);
@@ -514,6 +560,21 @@ impl RevenueSplitContract {
             .unwrap_or(false);
         if paused {
             return Err(RevenueSplitError::ContractPaused);
+        }
+        Ok(())
+    }
+
+    fn validate_distribution_amount(env: &Env, amount: i128) -> Result<(), RevenueSplitError> {
+        if amount <= 0 {
+            return Err(RevenueSplitError::InvalidAmount);
+        }
+        let max_amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MaxDistributionAmount)
+            .unwrap_or(DEFAULT_MAX_DISTRIBUTION_AMOUNT);
+        if amount > max_amount {
+            return Err(RevenueSplitError::AmountTooLarge);
         }
         Ok(())
     }
@@ -673,16 +734,18 @@ impl RevenueSplitContract {
         let mut preview = Vec::new(env);
         let total_bp = TOTAL_BASIS_POINTS as i128;
         let mut amount_distributed = 0i128;
-        let shares_len = shares.len();
 
-        for (index, share) in shares.iter().enumerate() {
-            let recipient_amount = if index as u32 == shares_len - 1 {
-                amount - amount_distributed
-            } else {
-                let split = (amount * share.basis_points as i128) / total_bp;
-                amount_distributed += split;
-                split
-            };
+        for share in shares.iter() {
+            let product = amount
+                .checked_mul(share.basis_points as i128)
+                .ok_or(RevenueSplitError::ArithmeticOverflow)?;
+            let recipient_amount = product / total_bp;
+            amount_distributed = amount_distributed
+                .checked_add(recipient_amount)
+                .ok_or(RevenueSplitError::ArithmeticOverflow)?;
+            if amount_distributed > amount {
+                return Err(RevenueSplitError::ArithmeticOverflow);
+            }
 
             preview.push_back(DistributionPreview {
                 destination: share.destination,
@@ -700,6 +763,7 @@ impl RevenueSplitContract {
             DataKey::Recipients,
             DataKey::DistributionCount,
             DataKey::SupportedAssets,
+            DataKey::MaxDistributionAmount,
         ] {
             if env.storage().persistent().has(&key) {
                 env.storage().persistent().extend_ttl(
@@ -709,6 +773,9 @@ impl RevenueSplitContract {
                 );
             }
         }
+        env.storage()
+            .instance()
+            .extend_ttl(PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
     }
 
     fn check_state_version(env: &Env) {
@@ -717,8 +784,10 @@ impl RevenueSplitContract {
         if version < STATE_VERSION {
             env.storage().persistent().set(&key, &STATE_VERSION);
         }
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
     }
 }

--- a/contracts/revenue_split/src/test.rs
+++ b/contracts/revenue_split/src/test.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 
-use crate::{RecipientShare, RevenueSplitContract, RevenueSplitContractClient, RevenueSplitError};
+use crate::{
+    DEFAULT_MAX_DISTRIBUTION_AMOUNT, RecipientShare, RevenueSplitContract,
+    RevenueSplitContractClient, RevenueSplitError,
+};
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::token::StellarAssetClient;
 use soroban_sdk::{
@@ -176,23 +179,8 @@ fn test_distribution() {
     assert_eq!(token_client.balance(&recipient3), 200);
 }
 
-/// Verifies that when an amount does not divide evenly across basis-point
-/// shares the sum of all distributed amounts still equals the input amount
-/// exactly — i.e. no tokens are lost to rounding.
-///
-/// Remainder absorption rule: the **last** recipient in the shares list
-/// receives any leftover stroop(s) that arise from integer division, so the
-/// total always equals the input amount.
-///
-/// Example used here:
-///   amount = 10, shares = [3333 bp, 3333 bp, 3334 bp] (≈ 33.33 / 33.33 / 33.34 %)
-///   Integer division per recipient:
-///     recipient1: 10 * 3333 / 10000 = 3  (exact)
-///     recipient2: 10 * 3333 / 10000 = 3  (exact)
-///     recipient3 (last): remainder = 10 - 3 - 3 = 4
-///   Sum: 3 + 3 + 4 = 10  ✓
 #[test]
-fn test_distribution_rounding_remainder_absorbed_by_last_recipient() {
+fn test_distribution_rounding_never_over_distributes() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -209,11 +197,23 @@ fn test_distribution_rounding_remainder_absorbed_by_last_recipient() {
 
     // Three shares that sum to 10000 bp but produce a remainder for
     // amounts that are not exact multiples of 3.
-    let shares = Vec::from_array(&env, [
-        RecipientShare { destination: recipient1.clone(), basis_points: 3333 },
-        RecipientShare { destination: recipient2.clone(), basis_points: 3333 },
-        RecipientShare { destination: recipient3.clone(), basis_points: 3334 },
-    ]);
+    let shares = Vec::from_array(
+        &env,
+        [
+            RecipientShare {
+                destination: recipient1.clone(),
+                basis_points: 3333,
+            },
+            RecipientShare {
+                destination: recipient2.clone(),
+                basis_points: 3333,
+            },
+            RecipientShare {
+                destination: recipient3.clone(),
+                basis_points: 3334,
+            },
+        ],
+    );
 
     contract_client.init(&admin, &shares);
 
@@ -227,20 +227,28 @@ fn test_distribution_rounding_remainder_absorbed_by_last_recipient() {
     let bal2 = token_client.balance(&recipient2);
     let bal3 = token_client.balance(&recipient3);
 
-    // The last recipient absorbs the remainder so the total is exact.
     assert_eq!(
         bal1 + bal2 + bal3,
-        amount,
-        "sum of all shares must equal the input amount exactly"
+        9,
+        "floor rounding must never distribute more than the input amount"
     );
+    assert!(bal1 + bal2 + bal3 <= amount);
 
-    // Sender's account must be empty — nothing is lost or stranded.
-    assert_eq!(token_client.balance(&sender), 0);
+    // One stroop of dust remains with the sender rather than overpaying recipients.
+    assert_eq!(token_client.balance(&sender), 1);
 
-    // recipient3 (last) holds the remainder: 10 - 3 - 3 = 4.
-    assert_eq!(bal1, 3, "recipient1 should receive floor(10 * 3333 / 10000) = 3");
-    assert_eq!(bal2, 3, "recipient2 should receive floor(10 * 3333 / 10000) = 3");
-    assert_eq!(bal3, 4, "recipient3 (last) absorbs the rounding remainder: 10 - 3 - 3 = 4");
+    assert_eq!(
+        bal1, 3,
+        "recipient1 should receive floor(10 * 3333 / 10000) = 3"
+    );
+    assert_eq!(
+        bal2, 3,
+        "recipient2 should receive floor(10 * 3333 / 10000) = 3"
+    );
+    assert_eq!(
+        bal3, 3,
+        "recipient3 should receive floor(10 * 3334 / 10000) = 3"
+    );
 }
 
 #[test]
@@ -744,7 +752,8 @@ fn test_preview_distribution_preserves_remainder_on_last_recipient() {
     assert_eq!(first.destination, recipient1);
     assert_eq!(first.amount, 333);
     assert_eq!(second.destination, recipient2);
-    assert_eq!(second.amount, 667);
+    assert_eq!(second.amount, 666);
+    assert_eq!(first.amount + second.amount, 999);
 }
 
 #[test]
@@ -1071,8 +1080,8 @@ fn test_distribute_noop_on_zero_amount() {
     );
     client.init(&admin, &shares);
 
-    // Zero-amount distribute is a no-op: no transfer, no ledger update
-    client.distribute(&token_id, &sender, &0);
+    let result = client.try_distribute(&token_id, &sender, &0);
+    assert_eq!(result, Err(Ok(RevenueSplitError::InvalidAmount)));
     assert_eq!(token_client.balance(&recipient), 0);
     assert_eq!(client.get_distribution_count(), 0);
 }
@@ -1226,7 +1235,6 @@ fn test_build_distribution_preview_empty_shares_returns_zero_recipients() {
 
 #[test]
 fn test_preview_distribution_zero_amount_returns_empty_amounts() {
-    // Zero is valid — each recipient gets 0, no panic.
     let env = Env::default();
     env.mock_all_auths();
 
@@ -1252,8 +1260,121 @@ fn test_preview_distribution_zero_amount_returns_empty_amounts() {
     );
     client.init(&admin, &shares);
 
-    let preview = client.preview_distribution(&0_i128);
-    for entry in preview.iter() {
-        assert_eq!(entry.amount, 0);
-    }
+    let result = client.try_preview_distribution(&0_i128);
+    assert_eq!(result, Err(Ok(RevenueSplitError::InvalidAmount)));
+}
+
+#[test]
+fn test_default_max_distribution_amount_is_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let shares = Vec::from_array(
+        &env,
+        [RecipientShare {
+            destination: recipient,
+            basis_points: 10_000,
+        }],
+    );
+
+    client.init(&admin, &shares);
+    assert_eq!(
+        client.get_max_distribution_amount(),
+        DEFAULT_MAX_DISTRIBUTION_AMOUNT
+    );
+}
+
+#[test]
+fn test_set_max_distribution_amount_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let shares = Vec::from_array(
+        &env,
+        [RecipientShare {
+            destination: recipient.clone(),
+            basis_points: 10_000,
+        }],
+    );
+
+    client.init(&admin, &shares);
+    client.set_max_distribution_amount(&500);
+    stellar_asset_client.mint(&sender, &1_000);
+
+    let result = client.try_distribute(&token_id, &sender, &501);
+    assert_eq!(result, Err(Ok(RevenueSplitError::AmountTooLarge)));
+    assert_eq!(token_client.balance(&recipient), 0);
+
+    client.distribute(&token_id, &sender, &500);
+    assert_eq!(token_client.balance(&recipient), 500);
+}
+
+#[test]
+fn test_basis_point_multiplication_overflow_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let shares = Vec::from_array(
+        &env,
+        [
+            RecipientShare {
+                destination: r1,
+                basis_points: 5_000,
+            },
+            RecipientShare {
+                destination: r2,
+                basis_points: 5_000,
+            },
+        ],
+    );
+
+    client.init(&admin, &shares);
+    client.set_max_distribution_amount(&i128::MAX);
+
+    let result = client.try_preview_distribution(&i128::MAX);
+    assert_eq!(result, Err(Ok(RevenueSplitError::ArithmeticOverflow)));
+}
+
+#[test]
+fn test_single_recipient_and_minimum_unit_distribution() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+    let contract_id = env.register(RevenueSplitContract, ());
+    let client = RevenueSplitContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let shares = Vec::from_array(
+        &env,
+        [RecipientShare {
+            destination: recipient.clone(),
+            basis_points: 10_000,
+        }],
+    );
+
+    client.init(&admin, &shares);
+    stellar_asset_client.mint(&sender, &1);
+    client.distribute(&token_id, &sender, &1);
+
+    assert_eq!(token_client.balance(&recipient), 1);
+    assert_eq!(client.get_total_distributed(&token_id), 1);
 }

--- a/contracts/smart_wallet/src/test.rs
+++ b/contracts/smart_wallet/src/test.rs
@@ -262,7 +262,6 @@ fn test_threshold_changed_event() {
     assert_eq!(client.threshold(), 3);
 }
 
-
 // ══════════════════════════════════════════════════════════════════════════════
 // ── ISSUE #903: signature type-mismatch tests ─────────────────────────────────
 // ══════════════════════════════════════════════════════════════════════════════
@@ -354,10 +353,7 @@ fn mixed_multisig_correct_types_satisfy_threshold() {
     let (ed_signer_key1, ed_signing_key1) = make_ed25519_signer(&env, [40u8; 32]);
     let (secp_signer_key, secp_signing_key) = make_secp256k1_signer(&env, [41u8; 32]);
     let (ed_signer_key2, _ed_signing_key2) = make_ed25519_signer(&env, [42u8; 32]);
-    let signers = Vec::from_array(
-        &env,
-        [ed_signer_key1, secp_signer_key, ed_signer_key2],
-    );
+    let signers = Vec::from_array(&env, [ed_signer_key1, secp_signer_key, ed_signer_key2]);
     let (contract_id, _client) = register_wallet(&env, signers, 2);
 
     let raw = Bytes::from_slice(&env, &[45u8; 32]);
@@ -612,8 +608,7 @@ fn test_empty_signature_set_rejected() {
     let empty_proofs = Vec::new(&env);
 
     env.as_contract(&contract_id, || {
-        let result =
-            SmartWalletContract::verify_signatures_inner(&env, &payload, &empty_proofs);
+        let result = SmartWalletContract::verify_signatures_inner(&env, &payload, &empty_proofs);
         assert_eq!(result, Err(WalletError::NotEnoughSignatures));
     });
 }
@@ -744,10 +739,7 @@ fn test_valid_signatures_below_threshold_fails() {
     let raw = Bytes::from_slice(&env, &[55u8; 32]);
     let payload = env.crypto().sha256(&raw);
 
-    let proofs = Vec::from_array(
-        &env,
-        [sign_ed25519(&payload, &ed_signing_key_a, &env)],
-    );
+    let proofs = Vec::from_array(&env, [sign_ed25519(&payload, &ed_signing_key_a, &env)]);
 
     env.as_contract(&contract_id, || {
         let result = SmartWalletContract::verify_signatures_inner(&env, &payload, &proofs);
@@ -1056,10 +1048,7 @@ fn test_threshold_equals_signer_count_requires_all_signatures() {
     let raw = Bytes::from_slice(&env, &[108u8; 32]);
     let payload = env.crypto().sha256(&raw);
 
-    let one_sig = Vec::from_array(
-        &env,
-        [sign_ed25519(&payload, &ed_sig_a, &env)],
-    );
+    let one_sig = Vec::from_array(&env, [sign_ed25519(&payload, &ed_sig_a, &env)]);
 
     env.as_contract(&contract_id, || {
         let result = SmartWalletContract::verify_signatures_inner(&env, &payload, &one_sig);
@@ -1068,7 +1057,10 @@ fn test_threshold_equals_signer_count_requires_all_signatures() {
 
     let two_sigs = Vec::from_array(
         &env,
-        [sign_ed25519(&payload, &ed_sig_a, &env), sign_ed25519(&payload, &ed_sig_b, &env)],
+        [
+            sign_ed25519(&payload, &ed_sig_a, &env),
+            sign_ed25519(&payload, &ed_sig_b, &env),
+        ],
     );
 
     env.as_contract(&contract_id, || {
@@ -1088,10 +1080,7 @@ fn test_threshold_one_single_signature_sufficient() {
     let raw = Bytes::from_slice(&env, &[110u8; 32]);
     let payload = env.crypto().sha256(&raw);
 
-    let proofs = Vec::from_array(
-        &env,
-        [sign_ed25519(&payload, &ed_sig_a, &env)],
-    );
+    let proofs = Vec::from_array(&env, [sign_ed25519(&payload, &ed_sig_a, &env)]);
 
     env.as_contract(&contract_id, || {
         let result = SmartWalletContract::verify_signatures_inner(&env, &payload, &proofs);

--- a/contracts/vesting_escrow/src/lib.rs
+++ b/contracts/vesting_escrow/src/lib.rs
@@ -364,10 +364,7 @@ impl VestingContract {
     /// Only the current admin may call this. The proposed admin must call
     /// `accept_admin_transfer` to finalise the handoff. Proposing the current
     /// admin returns `SameAdmin`. Replaces any prior pending proposal.
-    pub fn propose_admin_transfer(
-        env: Env,
-        new_admin: Address,
-    ) -> Result<(), ContractError> {
+    pub fn propose_admin_transfer(env: Env, new_admin: Address) -> Result<(), ContractError> {
         let admin: Address = env
             .storage()
             .persistent()
@@ -415,12 +412,8 @@ impl VestingContract {
             .get(&DataKey::Admin)
             .ok_or(ContractError::NotInitialized)?;
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Admin, &new_admin);
-        env.storage()
-            .persistent()
-            .remove(&DataKey::PendingAdmin);
+        env.storage().persistent().set(&DataKey::Admin, &new_admin);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
         Self::bump_config_ttl(&env);
 
         AdminTransferAcceptedEvent {
@@ -450,9 +443,7 @@ impl VestingContract {
             .get(&DataKey::PendingAdmin)
             .ok_or(ContractError::NoPendingAdminTransfer)?;
 
-        env.storage()
-            .persistent()
-            .remove(&DataKey::PendingAdmin);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
 
         AdminTransferCancelledEvent {
             admin,
@@ -465,9 +456,7 @@ impl VestingContract {
 
     /// Returns the pending admin address, or `None` if no transfer is pending.
     pub fn get_pending_admin(env: Env) -> Option<Address> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::PendingAdmin)
+        env.storage().persistent().get(&DataKey::PendingAdmin)
     }
 
     // ── Emergency pause (circuit breaker) ─────────────────────────────────
@@ -914,7 +903,10 @@ impl VestingContract {
             return Err(ContractError::GrantInactive);
         }
 
-        if e.storage().persistent().has(&DataKey::PendingBeneficiaryTransfer) {
+        if e.storage()
+            .persistent()
+            .has(&DataKey::PendingBeneficiaryTransfer)
+        {
             return Err(ContractError::TransferAlreadyPending);
         }
 
@@ -1137,10 +1129,16 @@ impl VestingContract {
     }
 
     pub(crate) fn check_state_version(e: &Env) {
-        let version: u32 = e.storage().persistent().get(&DataKey::StateVersion).unwrap_or(0);
+        let version: u32 = e
+            .storage()
+            .persistent()
+            .get(&DataKey::StateVersion)
+            .unwrap_or(0);
         if version < STATE_VERSION {
             // Perform any version-specific migrations here in the future
-            e.storage().persistent().set(&DataKey::StateVersion, &STATE_VERSION);
+            e.storage()
+                .persistent()
+                .set(&DataKey::StateVersion, &STATE_VERSION);
             e.storage().persistent().extend_ttl(
                 &DataKey::StateVersion,
                 PERSISTENT_TTL_THRESHOLD,

--- a/contracts/vesting_escrow/src/test.rs
+++ b/contracts/vesting_escrow/src/test.rs
@@ -1,7 +1,11 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Events as _, Ledger}, Address, Env, token};
+use soroban_sdk::{
+    Address, Env,
+    testutils::{Address as _, Events as _, Ledger},
+    token,
+};
 
 // ── Shared test helpers ───────────────────────────────────────────────────────
 
@@ -87,7 +91,9 @@ fn test_vesting_flow() {
 
     // Setup Token
     let token_admin = Address::generate(&e);
-    let token_contract = e.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract = e
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::Client::new(&e, &token_contract);
     let token_admin_client = token::StellarAssetClient::new(&e, &token_contract);
 
@@ -113,79 +119,78 @@ fn test_vesting_flow() {
         &clawback_admin,
         &admin,
     );
-    
+
     // Verify init state
     let config = client.get_config();
     assert_eq!(config.total_amount, amount);
     assert_eq!(config.is_active, true);
-    
+
     // Check contract balance
     assert_eq!(token_client.balance(&contract_id), 10000);
     assert_eq!(token_client.balance(&funder), 0);
-    
+
     // 1. Check before cliff (time = start)
     assert_eq!(client.get_vested_amount(), 0);
     assert_eq!(client.get_claimable_amount(), 0);
-    
+
     // 2. Advance time past cliff (time = start + 200)
     // 200 / 1000 = 20% vested
     e.ledger().set_timestamp(start_time + 200);
-    
+
     let vested = client.get_vested_amount();
     let expected_vested = 10000 * 200 / 1000; // 2000
     assert_eq!(vested, expected_vested);
     assert_eq!(client.get_claimable_amount(), expected_vested);
-    
+
     // 3. Claim
     client.claim();
-    
+
     // Verify claim
     assert_eq!(token_client.balance(&beneficiary), expected_vested);
     assert_eq!(client.get_claimable_amount(), 0);
     let config_after_claim = client.get_config();
     assert_eq!(config_after_claim.claimed_amount, expected_vested);
-    
+
     // 4. Advance time more (time = start + 500)
     // 500 / 1000 = 50% vested (total 5000)
     e.ledger().set_timestamp(start_time + 500);
-    
+
     let vested_2 = client.get_vested_amount();
     assert_eq!(vested_2, 5000);
     // Claimable = 5000 - 2000 (already claimed) = 3000
     assert_eq!(client.get_claimable_amount(), 3000);
-    
+
     // 5. Clawback
     // Admin revokes remaining
     // Vested so far = 5000. Unvested = 5000.
     // Contract balance = 10000 - 2000 (claimed) = 8000.
     // Clawback should send 5000 to admin.
     // Contract should keep 3000 (claimable).
-    
+
     client.clawback();
-    
+
     // Check admin balance
     assert_eq!(token_client.balance(&clawback_admin), 5000);
-    
+
     // Check contract balance: 8000 - 5000 = 3000
     assert_eq!(token_client.balance(&contract_id), 3000);
-    
+
     // Verify config update
     let config_revoked = client.get_config();
     assert_eq!(config_revoked.is_active, false);
     assert_eq!(config_revoked.total_amount, 5000); // Capped at vested amount
-    
+
     // 6. Advance time to end
     e.ledger().set_timestamp(start_time + 2000);
-    
+
     // Vested should still be 5000 (capped)
     assert_eq!(client.get_vested_amount(), 5000);
-    
+
     // Beneficiary can claim the rest of vested tokens (3000)
     client.claim();
     assert_eq!(token_client.balance(&beneficiary), 2000 + 3000);
     assert_eq!(token_client.balance(&contract_id), 0);
 }
-
 
 // ── ISSUE #904 test ────────────────────────────────────────────────────────────
 
@@ -370,7 +375,10 @@ fn clawback_event_includes_admin_address() {
     // ClawbackExecutedEvent carries clawback_admin as its first field.
     // Verify the event was emitted and that the config records the correct admin.
     let events = e.events().all();
-    assert!(!events.is_empty(), "expected at least one event after clawback");
+    assert!(
+        !events.is_empty(),
+        "expected at least one event after clawback"
+    );
 
     // Confirm the admin identity is preserved in the config (the clawback_admin
     // field in ClawbackExecutedEvent mirrors the one stored in VestingConfig).


### PR DESCRIPTION
## Summary

This PR resolves multiple contract hardening issues across PayD:

- Implements safer cross-contract handling in `cross_asset_payment`
- Adds comprehensive ORGUSD unit test coverage for admin/token operations
- Adds TTL management coverage and documents TTL strategy
- Adds overflow protection and safer rounding behavior to `revenue_split`

## Changes

### Cross-Asset Payment Safety

- Validates external token transfer preconditions before mutating payment state
- Ensures failed escrow transfers do not create inconsistent payment records
- Adds timeout-based failure handling for pending/process payments
- Supports refunding payments that fail or expire
- Emits failure/refund events for cross-contract failure paths
- Tightens state-machine transitions around `pending -> process -> complete/failed`

### ORGUSD Tests

- Adds broad unit coverage for:
  - mint
  - burn
  - freeze/unfreeze
  - authorize/revoke
  - clawback
  - admin transfer
  - SEP metadata
  - edge cases such as zero amounts, frozen accounts, and repeated freeze/unfreeze
- Verifies state transitions and emitted events for admin operations

### TTL Management

- Adds TTL assertions for contract instance and persistent storage entries
- Ensures TTL is bumped on initialization and successful operations
- Documents the TTL strategy and expected bump behavior

### Revenue Split Overflow Protection

- Adds checked arithmetic for basis-point multiplication and totals
- Adds configurable maximum distribution amount
- Enforces minimum positive distribution amount
- Ensures rounding never causes over-distribution
- Covers large-amount, single-recipient, and minimum-unit edge cases

## Testing

- Added/updated unit tests for affected contracts
- Tests cover external transfer failure, refund behavior, TTL extension, ORGUSD admin flows, and revenue split overflow/rounding cases

## Fixes

closes #1067 
closes #1068 
closes #1069 
closes #1070 