### PR TITLE
feat: enhance accessibility and testing for fee estimation and employee list components

### DIFF
--- a/frontend/src/__tests__/BulkPayrollUpload.test.tsx
+++ b/frontend/src/__tests__/BulkPayrollUpload.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../components/CSVUploader', () => ({
               currency: 'USDC',
             },
             errors: [],
+            fieldErrors: [],
             isValid: true,
           },
         ])

--- a/frontend/src/components/BulkPaymentStatusTracker.tsx
+++ b/frontend/src/components/BulkPaymentStatusTracker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { List } from 'react-window';
 import { useNotification } from '../hooks/useNotification';
@@ -6,6 +6,7 @@ import { useSocket } from '../hooks/useSocket';
 import { useWallet } from '../hooks/useWallet';
 import { useWalletSigning } from '../hooks/useWalletSigning';
 import { contractService } from '../services/contracts';
+import { ConnectionStatus } from './ConnectionStatus';
 import { SkeletonLoader } from './SkeletonLoader';
 import {
   fetchPayrollRunOnChainState,
@@ -23,8 +24,18 @@ interface BulkPaymentStatusTrackerProps {
   organizationId: number;
 }
 
-type ConfirmationMap = Record<string, number>;
+interface BulkSocketUpdate {
+  batchId: string;
+  status: string | null;
+  progress: number | null;
+  completedCount: number | null;
+  totalItems: number | null;
+  lastTxHash: string | null;
+}
+type BulkSocketUpdateMap = Record<string, BulkSocketUpdate>;
 type OnChainStateMap = Record<number, OnChainBatchState>;
+
+const STATUS_FLASH_DURATION_MS = 1200;
 
 function toRecipientStatus(
   status: PayrollRecipientStatus['status']
@@ -50,13 +61,17 @@ function findRunTxHash(summary?: PayrollRunSummary): string | null {
   return txHash || null;
 }
 
-function normalizeConfirmationPayload(payload: unknown): {
-  batchId: string | null;
-  confirmations: number | null;
-} {
-  if (!payload || typeof payload !== 'object') {
-    return { batchId: null, confirmations: null };
+function toNumberOrNull(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
   }
+  return null;
+}
+
+function normalizeBulkUpdatePayload(payload: unknown): BulkSocketUpdate | null {
+  if (!payload || typeof payload !== 'object') return null;
 
   const record = payload as Record<string, unknown>;
   const batchId =
@@ -65,19 +80,21 @@ function normalizeConfirmationPayload(payload: unknown): {
     (record.runId as string | undefined) ||
     null;
 
-  const countRaw =
-    record.confirmations ?? record.confirmationCount ?? record.confirmed ?? record.count ?? null;
+  if (!batchId) return null;
 
-  const count =
-    typeof countRaw === 'number'
-      ? countRaw
-      : typeof countRaw === 'string'
-        ? Number.parseInt(countRaw, 10)
-        : null;
+  // The worker emits `completedCount`; the legacy aliases below are kept for
+  // compatibility with older/alternate event shapes.
+  const completedCount = toNumberOrNull(
+    record.completedCount ?? record.confirmations ?? record.confirmationCount ?? record.confirmed ?? record.count
+  );
 
   return {
     batchId,
-    confirmations: Number.isFinite(count) ? count : null,
+    status: typeof record.status === 'string' ? record.status : null,
+    progress: toNumberOrNull(record.progress),
+    completedCount,
+    totalItems: toNumberOrNull(record.totalItems ?? record.total),
+    lastTxHash: typeof record.lastTxHash === 'string' ? record.lastTxHash : null,
   };
 }
 
@@ -87,7 +104,11 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
   const [summaries, setSummaries] = useState<Record<number, PayrollRunSummary>>({});
   const [onChainStates, setOnChainStates] = useState<OnChainStateMap>({});
   const [expandedRunId, setExpandedRunId] = useState<number | null>(null);
-  const [confirmations, setConfirmations] = useState<ConfirmationMap>({});
+  const [socketUpdates, setSocketUpdates] = useState<BulkSocketUpdateMap>({});
+  const [recentlyUpdatedItemIds, setRecentlyUpdatedItemIds] = useState<Set<number>>(
+    () => new Set()
+  );
+  const [recentlyUpdatedRunIds, setRecentlyUpdatedRunIds] = useState<Set<number>>(() => new Set());
   const [isLoading, setIsLoading] = useState(false);
   const [isRetryingKey, setIsRetryingKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -95,10 +116,91 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
     'All'
   );
 
-  const { notifyError, notifyPaymentSuccess, notifyApiError } = useNotification();
+  const { notifyError, notifyPaymentSuccess, notifySuccess, notifyApiError } = useNotification();
   const { socket } = useSocket();
   const { address, requireWallet } = useWallet();
   const { sign } = useWalletSigning();
+
+  // Refs used by the socket handler so it can read the latest values without
+  // re-subscribing to the socket on every render.
+  const summariesRef = useRef(summaries);
+  useEffect(() => {
+    summariesRef.current = summaries;
+  }, [summaries]);
+
+  const lastKnownCountRef = useRef<Record<string, number>>({});
+  const lastKnownStatusRef = useRef<Record<string, string>>({});
+  const notifiedCompleteRef = useRef<Set<string>>(new Set());
+  const itemFlashTimeoutsRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+  const runFlashTimeoutsRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+
+  useEffect(() => {
+    const itemTimeouts = itemFlashTimeoutsRef.current;
+    const runTimeouts = runFlashTimeoutsRef.current;
+    return () => {
+      itemTimeouts.forEach((timeout) => clearTimeout(timeout));
+      itemTimeouts.clear();
+      runTimeouts.forEach((timeout) => clearTimeout(timeout));
+      runTimeouts.clear();
+    };
+  }, []);
+
+  const flashItem = useCallback((itemId: number) => {
+    setRecentlyUpdatedItemIds((prev) => new Set(prev).add(itemId));
+    const existingTimeout = itemFlashTimeoutsRef.current.get(itemId);
+    if (existingTimeout) clearTimeout(existingTimeout);
+    const timeout = setTimeout(() => {
+      setRecentlyUpdatedItemIds((prev) => {
+        const next = new Set(prev);
+        next.delete(itemId);
+        return next;
+      });
+      itemFlashTimeoutsRef.current.delete(itemId);
+    }, STATUS_FLASH_DURATION_MS);
+    itemFlashTimeoutsRef.current.set(itemId, timeout);
+  }, []);
+
+  const flashRun = useCallback((runId: number) => {
+    setRecentlyUpdatedRunIds((prev) => new Set(prev).add(runId));
+    const existingTimeout = runFlashTimeoutsRef.current.get(runId);
+    if (existingTimeout) clearTimeout(existingTimeout);
+    const timeout = setTimeout(() => {
+      setRecentlyUpdatedRunIds((prev) => {
+        const next = new Set(prev);
+        next.delete(runId);
+        return next;
+      });
+      runFlashTimeoutsRef.current.delete(runId);
+    }, STATUS_FLASH_DURATION_MS);
+    runFlashTimeoutsRef.current.set(runId, timeout);
+  }, []);
+
+  // Re-fetches a run's recipient-level statuses after a socket update so
+  // individual payment rows can animate their pending -> confirmed/failed
+  // transition. The aggregate progress bar already updates from the socket
+  // payload alone; this is only needed for the expanded per-recipient view.
+  const refreshSummaryForAnimation = useCallback(
+    async (runId: number) => {
+      const previousItems = summariesRef.current[runId]?.items;
+      try {
+        const refreshed = await fetchPayrollRunSummary(runId);
+        setSummaries((prev) => ({ ...prev, [runId]: refreshed }));
+
+        if (previousItems) {
+          const previousStatusById = new Map(previousItems.map((item) => [item.id, item.status]));
+          refreshed.items.forEach((item) => {
+            const prevStatus = previousStatusById.get(item.id);
+            if (prevStatus && prevStatus !== item.status) {
+              flashItem(item.id);
+            }
+          });
+        }
+      } catch {
+        // Best-effort refresh; the aggregate progress bar still reflects the socket update.
+      }
+    },
+    [flashItem]
+  );
 
   const loadRuns = useCallback(async () => {
     setIsLoading(true);
@@ -160,30 +262,73 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
   useEffect(() => {
     if (!socket) return;
 
-    const onBulkConfirmation = (payload: unknown) => {
-      const normalized = normalizeConfirmationPayload(payload);
-      if (!normalized.batchId || normalized.confirmations === null) return;
-      setConfirmations((prev) => ({
-        ...prev,
-        [normalized.batchId as string]: normalized.confirmations as number,
-      }));
+    const onBulkUpdate = (payload: unknown) => {
+      const normalized = normalizeBulkUpdatePayload(payload);
+      if (!normalized) return;
+      const { batchId } = normalized;
+
+      // De-dupe: only treat this as new progress if the confirmed count
+      // actually moved. A rapid reconnect can cause the same event to be
+      // observed twice (e.g. a late 'connect' racing a queued handler); this
+      // guard keeps that from re-triggering refetches/animations/toasts.
+      const previousCount = lastKnownCountRef.current[batchId];
+      const countChanged =
+        normalized.completedCount !== null && normalized.completedCount !== previousCount;
+      if (normalized.completedCount !== null) {
+        lastKnownCountRef.current[batchId] = normalized.completedCount;
+      }
+
+      setSocketUpdates((prev) => {
+        const existing = prev[batchId];
+        // Ignore out-of-order updates that would move the count backwards.
+        if (
+          existing?.completedCount != null &&
+          normalized.completedCount != null &&
+          normalized.completedCount < existing.completedCount
+        ) {
+          return prev;
+        }
+        return { ...prev, [batchId]: normalized };
+      });
+
+      const run = runs.find((entry) => entry.batch_id === batchId);
+      if (normalized.status) {
+        const previousStatus = lastKnownStatusRef.current[batchId] ?? run?.status ?? null;
+        if (run && normalized.status !== previousStatus) {
+          flashRun(run.id);
+        }
+        lastKnownStatusRef.current[batchId] = normalized.status;
+      }
+
+      if (normalized.status === 'completed' && !notifiedCompleteRef.current.has(batchId)) {
+        notifiedCompleteRef.current.add(batchId);
+        const total = normalized.totalItems ?? normalized.completedCount ?? 0;
+        notifySuccess(
+          t('bulkPaymentTracker.batchCompleteTitle'),
+          t('bulkPaymentTracker.batchCompleteBody', { batchId, count: total })
+        );
+      }
+
+      if (countChanged && run && summariesRef.current[run.id]) {
+        void refreshSummaryForAnimation(run.id);
+      }
     };
 
-    socket.on('bulk:confirmation', onBulkConfirmation);
-    socket.on('bulk_payment:confirmation', onBulkConfirmation);
+    socket.on('bulk:confirmation', onBulkUpdate);
+    socket.on('bulk_payment:confirmation', onBulkUpdate);
 
     runs.forEach((run) => {
       socket.emit('subscribe:bulk', { batchId: run.batch_id });
     });
 
     return () => {
-      socket.off('bulk:confirmation', onBulkConfirmation);
-      socket.off('bulk_payment:confirmation', onBulkConfirmation);
+      socket.off('bulk:confirmation', onBulkUpdate);
+      socket.off('bulk_payment:confirmation', onBulkUpdate);
       runs.forEach((run) => {
         socket.emit('unsubscribe:bulk', { batchId: run.batch_id });
       });
     };
-  }, [runs, socket]);
+  }, [runs, socket, notifySuccess, t, flashRun, refreshSummaryForAnimation]);
 
   const handleToggleExpand = async (runId: number) => {
     if (expandedRunId === runId) {
@@ -247,9 +392,21 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
       .map((run) => {
         const summary = summaries[run.id];
         const onChainState = onChainStates[run.id];
+        const socketUpdate = socketUpdates[run.batch_id];
         const employeeCount = summary?.summary.total_employees ?? summary?.items.length ?? 0;
         const txHash = findRunTxHash(summary);
-        const confirmationCount = confirmations[run.batch_id] ?? onChainState?.successCount ?? 0;
+        const confirmationCount =
+          socketUpdate?.completedCount ?? onChainState?.successCount ?? 0;
+        const totalCount = socketUpdate?.totalItems ?? employeeCount;
+        const pendingCount = Math.max(totalCount - confirmationCount, 0);
+        // Prefer the live socket status over the last REST-fetched run status
+        // so the badge reflects the real-time state without a manual refresh.
+        const liveStatus = socketUpdate?.status ?? run.status;
+        // Prefer the worker's own computed progress; fall back to deriving it
+        // from counts (e.g. before any socket event has arrived for this run).
+        const progressPercent =
+          socketUpdate?.progress ??
+          (employeeCount > 0 ? Math.round((confirmationCount / employeeCount) * 100) : 0);
         const hasFailedRecipients =
           summary?.items.some((item) => item.status === 'failed') ?? false;
 
@@ -260,20 +417,24 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
           employeeCount,
           txHash,
           confirmationCount,
+          pendingCount,
+          liveStatus,
+          progressPercent,
           hasFailedRecipients,
         };
       })
       .filter((row) => {
         if (statusFilter === 'All') return true;
-        return row.run.status.toLowerCase() === statusFilter.toLowerCase();
+        return row.liveStatus.toLowerCase() === statusFilter.toLowerCase();
       });
-  }, [confirmations, onChainStates, runs, summaries, statusFilter]);
+  }, [onChainStates, runs, socketUpdates, summaries, statusFilter]);
 
   return (
     <div className="card glass noise mt-8">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-bold">{t('bulkPaymentTracker.title')}</h3>
         <div className="flex items-center gap-4">
+          <ConnectionStatus />
           <select
             value={statusFilter}
             onChange={(e) =>
@@ -333,19 +494,27 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
                   employeeCount,
                   txHash,
                   confirmationCount,
+                  pendingCount,
+                  liveStatus,
+                  progressPercent,
                   hasFailedRecipients,
                 }) => (
                   <FragmentRow
                     key={run.id}
                     run={run}
+                    liveStatus={liveStatus}
                     summary={summary}
                     onChainState={onChainState}
                     employeeCount={employeeCount}
                     txHash={txHash}
                     confirmationCount={confirmationCount}
+                    pendingCount={pendingCount}
+                    progressPercent={progressPercent}
                     expanded={expandedRunId === run.id}
                     retryingKey={isRetryingKey}
                     hasFailedRecipients={hasFailedRecipients}
+                    justUpdated={recentlyUpdatedRunIds.has(run.id)}
+                    recentlyUpdatedItemIds={recentlyUpdatedItemIds}
                     onToggleExpand={() => {
                       void handleToggleExpand(run.id);
                     }}
@@ -365,34 +534,42 @@ export function BulkPaymentStatusTracker({ organizationId }: BulkPaymentStatusTr
 
 interface FragmentRowProps {
   run: PayrollRunRecord;
+  liveStatus: string;
   summary?: PayrollRunSummary;
   onChainState?: OnChainBatchState;
   employeeCount: number;
   txHash: string | null;
   confirmationCount: number;
+  pendingCount: number;
+  progressPercent: number;
   expanded: boolean;
   retryingKey: string | null;
   hasFailedRecipients: boolean;
+  justUpdated: boolean;
+  recentlyUpdatedItemIds: Set<number>;
   onToggleExpand: () => void;
   onRetry: (paymentIndex: number) => void;
 }
 
 function FragmentRow({
   run,
+  liveStatus,
   summary,
   onChainState,
   employeeCount,
   txHash,
   confirmationCount,
+  pendingCount,
+  progressPercent,
   expanded,
   retryingKey,
   hasFailedRecipients,
+  justUpdated,
+  recentlyUpdatedItemIds,
   onToggleExpand,
   onRetry,
 }: FragmentRowProps) {
   const { t } = useTranslation();
-  const progressPercent =
-    employeeCount > 0 ? Math.round((confirmationCount / employeeCount) * 100) : 0;
 
   return (
     <>
@@ -400,7 +577,7 @@ function FragmentRow({
         <td className="py-3 pr-4 font-mono">{run.batch_id}</td>
         <td className="py-3 pr-4 capitalize">
           <div className="flex flex-col">
-            <span>{run.status}</span>
+            <span className={justUpdated ? 'status-flash' : ''}>{liveStatus}</span>
             {onChainState?.status ? (
               <span className="text-[11px] uppercase tracking-wide text-muted">
                 {t('bulkPaymentTracker.onChainStatus', { status: onChainState.status })}
@@ -409,7 +586,7 @@ function FragmentRow({
           </div>
         </td>
         <td className="py-3 pr-4">
-          {run.status === 'processing' || run.status === 'pending' ? (
+          {liveStatus === 'processing' || liveStatus === 'pending' ? (
             <div className="flex flex-col gap-1 min-w-[100px]">
               <div className="w-full bg-surface-hi rounded-full h-1.5 overflow-hidden">
                 <div
@@ -418,6 +595,10 @@ function FragmentRow({
                 />
               </div>
               <span className="text-[10px] text-muted">{progressPercent}%</span>
+              <span className="text-[10px] text-muted">
+                {t('bulkPaymentTracker.liveConfirmed', { count: confirmationCount })} ·{' '}
+                {t('bulkPaymentTracker.livePending', { count: pendingCount })}
+              </span>
             </div>
           ) : (
             <span className="text-muted">-</span>
@@ -498,6 +679,7 @@ function FragmentRow({
                       onChainState,
                       retryingKey,
                       onRetry,
+                      recentlyUpdatedItemIds,
                       // index and style are injected per-row by List at render time
                     }}
                     style={{ height: 400, width: '100%' }}
@@ -513,6 +695,7 @@ function FragmentRow({
                         onChainState={onChainState}
                         retryingKey={retryingKey}
                         onRetry={onRetry}
+                        justUpdated={recentlyUpdatedItemIds.has(recipient.id)}
                       />
                     ))}
                   </div>
@@ -532,6 +715,7 @@ interface RecipientRowProps {
   onChainState?: OnChainBatchState;
   retryingKey: string | null;
   onRetry: (paymentIndex: number) => void;
+  justUpdated?: boolean;
   style?: React.CSSProperties;
 }
 
@@ -542,6 +726,7 @@ function RecipientRow({
   onChainState,
   retryingKey,
   onRetry,
+  justUpdated,
   style,
 }: RecipientRowProps) {
   const { t } = useTranslation();
@@ -574,7 +759,7 @@ function RecipientRow({
         </div>
         <div>
           <p className="text-muted">{t('bulkPaymentTracker.columnStatus')}</p>
-          <p className="capitalize">{status}</p>
+          <p className={`capitalize ${justUpdated ? 'status-flash' : ''}`}>{status}</p>
         </div>
         <div className="flex items-center justify-end">
           {status === 'failed' ? (
@@ -599,6 +784,7 @@ interface VirtualizedRowData {
   onChainState?: OnChainBatchState;
   retryingKey: string | null;
   onRetry: (paymentIndex: number) => void;
+  recentlyUpdatedItemIds: Set<number>;
 }
 
 const VirtualizedRecipientRow = ({
@@ -615,6 +801,7 @@ const VirtualizedRecipientRow = ({
       onChainState={data.onChainState}
       retryingKey={data.retryingKey}
       onRetry={data.onRetry}
+      justUpdated={data.recentlyUpdatedItemIds.has(recipient.id)}
       style={style}
     />
   );

--- a/frontend/src/components/CSVUploader.tsx
+++ b/frontend/src/components/CSVUploader.tsx
@@ -11,12 +11,21 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useNotification } from '../hooks/useNotification';
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
+// Rows are validated in chunks with a yield to the event loop in between, so
+// large files (up to MAX_FILE_SIZE) don't block the UI thread while parsing.
+const CHUNK_SIZE = 500;
+
+export interface CSVFieldError {
+  field: string;
+  message: string;
+}
 
 export interface CSVRow {
   rowNumber: number;
   data: Record<string, string>;
   errors: string[];
+  fieldErrors: CSVFieldError[];
   isValid: boolean;
 }
 
@@ -84,6 +93,7 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
   const [parsedData, setParsedData] = useState<CSVRow[]>([]);
   const [fileName, setFileName] = useState<string | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
+  const [parseProgress, setParseProgress] = useState<number>(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const uploadZoneRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
@@ -92,7 +102,10 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
   const descriptionId = useId();
 
   const parseCSV = useCallback(
-    (content: string): CSVRow[] | null => {
+    async (
+      content: string,
+      onProgress?: (processed: number, total: number) => void
+    ): Promise<CSVRow[] | null> => {
       const lines = content.trim().split('\n');
       if (lines.length < 2) {
         setParseError(t('csvUploader.errorMissingHeaderOrData'));
@@ -141,11 +154,13 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
       }
 
       const rows: CSVRow[] = [];
+      const totalDataRows = lines.length - 1;
 
       for (let i = 1; i < lines.length; i++) {
         const values = parseCSVLine(lines[i]).map((v) => v.trim());
         const row: Record<string, string> = {};
         const errors: string[] = [];
+        const fieldErrors: CSVFieldError[] = [];
 
         headers.forEach((header, idx) => {
           row[header.toLowerCase()] = values[idx] || '';
@@ -153,7 +168,9 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
 
         requiredColumns.forEach((col) => {
           if (!row[col]) {
-            errors.push(t('csvUploader.errorMissingField', { field: col }));
+            const message = t('csvUploader.errorMissingField', { field: col });
+            errors.push(message);
+            fieldErrors.push({ field: col, message });
           }
         });
 
@@ -162,6 +179,7 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
             const error = validator(row[field]);
             if (error) {
               errors.push(error);
+              fieldErrors.push({ field, message: error });
             }
           }
         });
@@ -170,13 +188,22 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
           rowNumber: i + 1,
           data: row,
           errors,
+          fieldErrors,
           isValid: errors.length === 0,
         });
+
+        const processed = i;
+        if (processed % CHUNK_SIZE === 0 && processed < totalDataRows) {
+          onProgress?.(processed, totalDataRows);
+          // Yield to the browser so it can paint/respond to input before the next chunk.
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
       }
 
+      onProgress?.(totalDataRows, totalDataRows);
       return rows;
     },
-    [requiredColumns, validators, strictHeaderValidation]
+    [requiredColumns, validators, strictHeaderValidation, t]
   );
 
   const handleFileParse = useCallback(
@@ -198,12 +225,15 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
 
       setFileName(file.name);
       setIsLoading(true);
+      setParseProgress(0);
       const reader = new FileReader();
 
-      reader.onload = (e) => {
+      reader.onload = async (e) => {
         try {
           const content = e.target?.result as string;
-          const rows = parseCSV(content);
+          const rows = await parseCSV(content, (processed, total) => {
+            setParseProgress(total > 0 ? Math.round((processed / total) * 100) : 100);
+          });
 
           if (rows === null) {
             setIsLoading(false);
@@ -358,6 +388,22 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
           <div className="flex flex-col items-center gap-3">
             <Loader2 className="w-10 h-10 text-[var(--accent)] animate-spin" aria-hidden="true" />
             <p className="text-sm font-medium text-[var(--text)]">{t('csvUploader.parsingFile')}</p>
+            <div
+              className="w-full max-w-xs"
+              role="progressbar"
+              aria-valuenow={parseProgress}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={t('csvUploader.parsingFile')}
+            >
+              <div className="h-1.5 w-full rounded-full bg-[var(--surface-hi)] overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-[var(--accent)] transition-[width] duration-150"
+                  style={{ width: `${parseProgress}%` }}
+                />
+              </div>
+              <p className="text-xs text-[var(--muted)] mt-1">{parseProgress}%</p>
+            </div>
           </div>
         ) : (
           <>
@@ -433,7 +479,10 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
           <div className="mt-3 flex flex-wrap gap-3 text-sm">
             <span className="inline-flex items-center gap-1.5 rounded-full bg-[rgba(63,185,80,0.1)] px-3 py-1 text-xs font-medium text-[var(--success)]">
               <CheckCircle className="w-3.5 h-3.5" aria-hidden="true" />
-              {t('csvUploader.validRowsCount', { count: validRowsCount })}
+              {t('csvUploader.summaryValidOfTotal', {
+                valid: validRowsCount,
+                total: parsedData.length,
+              })}
             </span>
             {invalidRowsCount > 0 && (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-[rgba(255,123,114,0.1)] px-3 py-1 text-xs font-medium text-[var(--danger)]">
@@ -441,6 +490,73 @@ export const CSVUploader: React.FC<CSVUploaderProps> = ({
                 {t('csvUploader.rowsWithErrorsCount', { count: invalidRowsCount })}
               </span>
             )}
+          </div>
+        </div>
+      )}
+
+      {invalidRowsCount > 0 && (
+        <div className="mt-6">
+          <h3 className="text-base font-bold text-[var(--danger)] mb-4" id="row-errors-heading">
+            {t('csvUploader.rowErrorsHeading', { count: invalidRowsCount })}
+          </h3>
+          <div
+            className="overflow-x-auto rounded-xl border border-[rgba(255,123,114,0.28)] max-h-80 overflow-y-auto"
+            role="table"
+            aria-label={t('csvUploader.rowErrorsAriaLabel')}
+            aria-describedby="row-errors-heading"
+          >
+            <table className="min-w-full text-left border-collapse">
+              <thead>
+                <tr className="border-b border-[var(--border-hi)] bg-[rgba(255,123,114,0.06)] sticky top-0">
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted)]">
+                    {t('csvUploader.columnRowNumber')}
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted)]">
+                    {t('csvUploader.columnField')}
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted)]">
+                    {t('csvUploader.columnErrorMessage')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--border)]">
+                {parsedData
+                  .filter((row) => !row.isValid)
+                  .flatMap((row) =>
+                    row.fieldErrors.length > 0
+                      ? row.fieldErrors.map((fieldError) => (
+                          <tr
+                            key={`${row.rowNumber}-${fieldError.field}-${fieldError.message}`}
+                            className="bg-[rgba(255,123,114,0.04)]"
+                          >
+                            <td className="px-4 py-3 font-mono text-sm text-[var(--muted)]">
+                              {row.rowNumber}
+                            </td>
+                            <td className="px-4 py-3 text-sm font-medium text-[var(--text)]">
+                              {fieldError.field}
+                            </td>
+                            <td className="px-4 py-3 text-sm text-[var(--danger)]">
+                              {fieldError.message}
+                            </td>
+                          </tr>
+                        ))
+                      : [
+                          <tr
+                            key={`${row.rowNumber}-general`}
+                            className="bg-[rgba(255,123,114,0.04)]"
+                          >
+                            <td className="px-4 py-3 font-mono text-sm text-[var(--muted)]">
+                              {row.rowNumber}
+                            </td>
+                            <td className="px-4 py-3 text-sm text-[var(--muted)]">—</td>
+                            <td className="px-4 py-3 text-sm text-[var(--danger)]">
+                              {row.errors.join('; ')}
+                            </td>
+                          </tr>,
+                        ]
+                  )}
+              </tbody>
+            </table>
           </div>
         </div>
       )}

--- a/frontend/src/components/ConnectionStatus.tsx
+++ b/frontend/src/components/ConnectionStatus.tsx
@@ -11,7 +11,7 @@ import { useSocket } from '../hooks/useSocket';
  */
 export function ConnectionStatus() {
   const { t } = useTranslation();
-  const { connected, isPollingFallback } = useSocket();
+  const { connected, isPollingFallback, isReconnecting } = useSocket();
   const [showTooltip, setShowTooltip] = useState(false);
 
   const getStatusInfo = () => {
@@ -23,6 +23,17 @@ export function ConnectionStatus() {
         textClass: 'text-success',
         borderClass: 'border-success/20',
         dotClass: 'bg-success',
+        animate: 'animate-pulse',
+      };
+    }
+    if (!connected && !isPollingFallback && isReconnecting) {
+      return {
+        label: t('connectionStatus.reconnecting'),
+        description: t('connectionStatus.reconnectingDescription'),
+        bgClass: 'bg-yellow-500/10',
+        textClass: 'text-yellow-400',
+        borderClass: 'border-yellow-500/20',
+        dotClass: 'bg-yellow-400',
         animate: 'animate-pulse',
       };
     }

--- a/frontend/src/components/EmployeeList.tsx
+++ b/frontend/src/components/EmployeeList.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import type { DropResult } from '@hello-pangea/dnd';
+import { List, useListRef } from 'react-window';
 import { useDebounce } from '../hooks/useDebounce';
 import { useNotification } from '../hooks/useNotification';
 import { Avatar } from './Avatar';
@@ -116,6 +117,440 @@ function copyWithFallback(text: string): Promise<void> {
   document.body.removeChild(textArea);
   return Promise.resolve();
 }
+
+// ---------------------------------------------------------------------------
+// Virtualization
+// ---------------------------------------------------------------------------
+
+/** Row height (px) for the virtualized desktop table — matches the padding
+ * and content height of the previous native <tr>/<td> layout. */
+const TABLE_ROW_HEIGHT = 88;
+/** Row height (px) for the virtualized mobile card list. */
+const CARD_ROW_HEIGHT = 328;
+/** Height of the scrollable virtualization viewport. Responsive: caps out on
+ * large screens, shrinks on small ones, but never collapses to unusable size. */
+const LIST_VIEWPORT_CLASS = 'h-[min(70vh,640px)] min-h-[280px]';
+/** Matches the previous table's column width ratios (28/18/18/14/rest) plus a
+ * fixed-width actions column. */
+const TABLE_GRID_TEMPLATE = '28% 18% 18% 14% 1fr 96px';
+
+/**
+ * Roving-tabindex keyboard navigation for a virtualized react-window list.
+ * Arrow keys move focus by one row, Home/End jump to the ends, and
+ * PageUp/PageDown move by a full viewport of rows (derived from the range
+ * react-window last reported as rendered).
+ */
+function useVirtualizedRowNavigation(rowCount: number) {
+  const listRef = useListRef(null);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const [viewportRowCount, setViewportRowCount] = useState(1);
+  const rowElementsRef = useRef<Map<number, HTMLElement>>(new Map());
+
+  useEffect(() => {
+    setFocusedIndex((prev) => Math.min(prev, Math.max(rowCount - 1, 0)));
+  }, [rowCount]);
+
+  const handleRowsRendered = useCallback((visible: { startIndex: number; stopIndex: number }) => {
+    setViewportRowCount(Math.max(visible.stopIndex - visible.startIndex + 1, 1));
+  }, []);
+
+  const registerRowElement = useCallback((index: number, el: HTMLElement | null) => {
+    if (el) {
+      rowElementsRef.current.set(index, el);
+    } else {
+      rowElementsRef.current.delete(index);
+    }
+  }, []);
+
+  const focusRow = useCallback(
+    (index: number) => {
+      setFocusedIndex(index);
+      listRef.current?.scrollToRow({ index, align: 'auto' });
+      requestAnimationFrame(() => {
+        rowElementsRef.current.get(index)?.focus();
+      });
+    },
+    [listRef]
+  );
+
+  const handleRowKeyDown = useCallback(
+    (event: React.KeyboardEvent, index: number) => {
+      let nextIndex: number | null = null;
+      switch (event.key) {
+        case 'ArrowDown':
+          nextIndex = Math.min(index + 1, rowCount - 1);
+          break;
+        case 'ArrowUp':
+          nextIndex = Math.max(index - 1, 0);
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = rowCount - 1;
+          break;
+        case 'PageDown':
+          nextIndex = Math.min(index + viewportRowCount, rowCount - 1);
+          break;
+        case 'PageUp':
+          nextIndex = Math.max(index - viewportRowCount, 0);
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      focusRow(nextIndex);
+    },
+    [rowCount, viewportRowCount, focusRow]
+  );
+
+  return { listRef, focusedIndex, handleRowKeyDown, handleRowsRendered, registerRowElement };
+}
+
+interface EmployeeRowSharedProps {
+  employees: Employee[];
+  focusedIndex: number;
+  onRowKeyDown: (event: React.KeyboardEvent, index: number) => void;
+  registerRowElement: (index: number, el: HTMLElement | null) => void;
+  onEmployeeClick?: (employee: Employee) => void;
+  onAvatarClick: (employee: Employee) => void;
+  onEditClick?: (employee: Employee) => void;
+  onDeleteClick?: (employee: Employee) => void;
+  onCopyWallet: (employee: Employee) => void;
+  copiedId: string | null;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  language: string;
+}
+
+/** A single row of the virtualized desktop table (ARIA grid semantics via divs,
+ * since react-window positions rows absolutely — incompatible with native
+ * <table> layout, which requires all rows to participate in normal flow). */
+const VirtualizedEmployeeTableRow: React.FC<
+  {
+    index: number;
+    style: React.CSSProperties;
+    ariaAttributes: Record<string, unknown>;
+  } & EmployeeRowSharedProps
+> = ({
+  index,
+  style,
+  ariaAttributes,
+  employees,
+  focusedIndex,
+  onRowKeyDown,
+  registerRowElement,
+  onEmployeeClick,
+  onAvatarClick,
+  onEditClick,
+  onDeleteClick,
+  onCopyWallet,
+  copiedId,
+  t,
+  language,
+}) => {
+  const employee = employees[index];
+  if (!employee) return null;
+
+  return (
+    <div
+      {...ariaAttributes}
+      role="row"
+      data-testid="employee-table-row"
+      ref={(el) => registerRowElement(index, el)}
+      tabIndex={focusedIndex === index ? 0 : -1}
+      onKeyDown={(event) => onRowKeyDown(event, index)}
+      style={{ ...style, display: 'grid', gridTemplateColumns: TABLE_GRID_TEMPLATE }}
+      className="group items-center gap-4 border-b border-hi/40 px-6 transition hover:bg-white/5 hover:bg-accent/[0.03] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
+    >
+      <div role="cell" className="flex items-center gap-4 overflow-hidden pr-2">
+        <button
+          type="button"
+          onClick={() => onAvatarClick(employee)}
+          className="relative rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+          aria-label={t('employeeList.updatePhotoFor', { name: employee.name })}
+        >
+          <Avatar
+            email={employee.email}
+            name={employee.name}
+            imageUrl={employee.imageUrl}
+            size="md"
+          />
+          <span
+            aria-hidden="true"
+            className={`absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-[var(--bg)] ${
+              employee.status === 'Inactive' ? 'bg-[var(--danger)]' : 'bg-[var(--success)]'
+            }`}
+          />
+        </button>
+
+        <div className="min-w-0 flex flex-col">
+          <button
+            type="button"
+            onClick={() => onEmployeeClick?.(employee)}
+            className="truncate text-left text-sm font-bold text-[var(--text)] transition-colors group-hover:text-[var(--accent)]"
+            title={employee.name}
+          >
+            {employee.name}
+          </button>
+          <span className="truncate text-xs text-[var(--muted)]" title={employee.email}>
+            {employee.email}
+          </span>
+        </div>
+      </div>
+
+      <div role="cell" className="flex flex-col overflow-hidden pr-2">
+        <span className="truncate text-sm font-medium text-[var(--text)]">{employee.position}</span>
+        <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+          {t('employeeList.role')}
+        </span>
+      </div>
+
+      <div role="cell" className="flex items-center gap-2 overflow-hidden pr-2">
+        <code className="max-w-[10rem] truncate rounded-lg border border-[var(--border)] bg-[var(--surface-hi)] px-2 py-1 text-[10px] font-mono text-[var(--muted)]">
+          {employee.wallet
+            ? shortenWallet(employee.wallet, t('employeeList.noWalletAssigned'))
+            : t('employeeList.noWallet')}
+        </code>
+        {employee.wallet ? (
+          <button
+            type="button"
+            onClick={() => onCopyWallet(employee)}
+            className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border transition ${
+              copiedId === employee.id
+                ? 'border-[var(--success)] text-[var(--success)]'
+                : 'border-transparent text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)]'
+            }`}
+            aria-label={t('employeeList.copyWalletAddressFor', { name: employee.name })}
+          >
+            {copiedId === employee.id ? (
+              <Check className="h-4 w-4" aria-hidden />
+            ) : (
+              <Copy className="h-4 w-4" aria-hidden />
+            )}
+          </button>
+        ) : null}
+      </div>
+
+      <div role="cell" className="flex flex-col items-start overflow-hidden pr-2">
+        {onEditClick ? (
+          <button
+            type="button"
+            className="text-sm font-bold text-[var(--text)] transition-colors hover:text-[var(--accent)]"
+            aria-label={t('employeeList.editSalaryForWithAmount', {
+              name: employee.name,
+              amount: (employee.salary ?? 0).toLocaleString(language),
+            })}
+            onClick={() => onEditClick(employee)}
+          >
+            ${(employee.salary ?? 0).toLocaleString(language)}
+          </button>
+        ) : (
+          <span className="text-sm font-bold text-[var(--text)]">
+            ${(employee.salary ?? 0).toLocaleString(language)}
+          </span>
+        )}
+        <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+          {t('employeeList.perMonth')}
+        </span>
+      </div>
+
+      <div role="cell" className="flex items-center overflow-hidden pr-2">
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${
+            employee.status === 'Inactive'
+              ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
+              : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
+          }`}
+        >
+          {employee.status
+            ? employee.status === 'Active'
+              ? t('employeeList.active')
+              : t('employeeList.inactive')
+            : t('employeeList.active')}
+        </span>
+      </div>
+
+      <div role="cell" className="flex items-center gap-1">
+        {onEditClick ? (
+          <button
+            type="button"
+            className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(74,240,184,0.10)] hover:text-[var(--accent)]"
+            aria-label={t('employeeList.editSalaryFor', { name: employee.name })}
+            onClick={() => onEditClick(employee)}
+          >
+            <Pencil className="h-4 w-4" aria-hidden />
+          </button>
+        ) : null}
+        {onDeleteClick ? (
+          <button
+            type="button"
+            className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(255,123,114,0.10)] hover:text-[var(--danger)]"
+            aria-label={t('employeeList.removeEmployee', { name: employee.name })}
+            onClick={() => onDeleteClick(employee)}
+          >
+            <Trash2 className="h-4 w-4" aria-hidden />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+/** A single card of the virtualized mobile list. */
+const VirtualizedEmployeeCard: React.FC<
+  {
+    index: number;
+    style: React.CSSProperties;
+    ariaAttributes: Record<string, unknown>;
+  } & EmployeeRowSharedProps
+> = ({
+  index,
+  style,
+  ariaAttributes,
+  employees,
+  focusedIndex,
+  onRowKeyDown,
+  registerRowElement,
+  onEmployeeClick,
+  onAvatarClick,
+  onEditClick,
+  onDeleteClick,
+  onCopyWallet,
+  copiedId,
+  t,
+  language,
+}) => {
+  const employee = employees[index];
+  if (!employee) return null;
+
+  return (
+    <div style={{ ...style, padding: '0.5rem 0' }}>
+      <article
+        {...ariaAttributes}
+        data-testid="employee-card-row"
+        ref={(el) => registerRowElement(index, el)}
+        tabIndex={focusedIndex === index ? 0 : -1}
+        onKeyDown={(event) => onRowKeyDown(event, index)}
+        className="h-full rounded-3xl border border-hi bg-[var(--surface-hi)]/70 p-5 shadow-[var(--shadow-card)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+      >
+        <div className="flex items-start gap-3">
+          <button
+            type="button"
+            onClick={() => onAvatarClick(employee)}
+            className="rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+            aria-label={t('employeeList.updatePhotoFor', { name: employee.name })}
+          >
+            <Avatar
+              email={employee.email}
+              name={employee.name}
+              imageUrl={employee.imageUrl}
+              size="md"
+            />
+          </button>
+
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start justify-between gap-3">
+              <button
+                type="button"
+                onClick={() => onEmployeeClick?.(employee)}
+                className="min-w-0 text-left"
+              >
+                <p className="truncate text-base font-bold text-[var(--text)]">{employee.name}</p>
+                <p className="truncate text-sm text-[var(--muted)]">{employee.email}</p>
+              </button>
+              <span
+                className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.2em] ${
+                  employee.status === 'Inactive'
+                    ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
+                    : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
+                }`}
+              >
+                {employee.status
+                  ? employee.status === 'Active'
+                    ? t('employeeList.active')
+                    : t('employeeList.inactive')
+                  : t('employeeList.active')}
+              </span>
+            </div>
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
+                <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
+                  {t('employeeList.role')}
+                </p>
+                <p className="mt-1 text-sm font-semibold text-[var(--text)]">{employee.position}</p>
+              </div>
+              <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
+                <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
+                  {t('employeeList.salary')}
+                </p>
+                <p className="mt-1 text-sm font-semibold text-[var(--text)]">
+                  {t('employeeList.salaryPerMonth', {
+                    amount: (employee.salary ?? 0).toLocaleString(language),
+                  })}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-4 rounded-2xl border border-[var(--border)] bg-[var(--surface)]/80 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
+                    {t('employeeList.wallet')}
+                  </p>
+                  <code className="mt-1 block truncate text-xs font-medium text-[var(--text)]">
+                    {employee.wallet || t('employeeList.noWalletAssigned')}
+                  </code>
+                </div>
+                {employee.wallet ? (
+                  <button
+                    type="button"
+                    onClick={() => onCopyWallet(employee)}
+                    className={`inline-flex h-10 w-10 items-center justify-center rounded-xl border transition ${
+                      copiedId === employee.id
+                        ? 'border-[var(--success)] text-[var(--success)]'
+                        : 'border-hi text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)]'
+                    }`}
+                    aria-label={t('employeeList.copyWalletFor', { name: employee.name })}
+                  >
+                    {copiedId === employee.id ? (
+                      <Check className="h-4 w-4" aria-hidden />
+                    ) : (
+                      <Copy className="h-4 w-4" aria-hidden />
+                    )}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              {onEditClick ? (
+                <button
+                  type="button"
+                  onClick={() => onEditClick(employee)}
+                  className="inline-flex items-center gap-2 rounded-xl border border-hi px-3 py-2 text-sm font-semibold text-[var(--text)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                >
+                  <Pencil className="h-4 w-4" aria-hidden />
+                  {t('employeeList.editSalary')}
+                </button>
+              ) : null}
+              {onDeleteClick ? (
+                <button
+                  type="button"
+                  onClick={() => onDeleteClick(employee)}
+                  className="inline-flex items-center gap-2 rounded-xl border border-[color:rgba(255,123,114,0.22)] px-3 py-2 text-sm font-semibold text-[var(--danger)] transition hover:bg-[color:rgba(255,123,114,0.08)]"
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden />
+                  {t('employeeList.remove')}
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+};
 
 export const EmployeeList: React.FC<EmployeeListProps> = ({
   employees,
@@ -286,6 +721,51 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
 
   const showEmptyState = !isLoading && sortedEmployees.length === 0;
 
+  // Virtualized (non-reorder) rendering: keyboard navigation + shared row props.
+  const tableNav = useVirtualizedRowNavigation(displayedEmployees.length);
+  const cardNav = useVirtualizedRowNavigation(displayedEmployees.length);
+
+  const handleAvatarClick = useCallback((employee: Employee) => {
+    setShowAvatarModal({ open: true, employee });
+  }, []);
+
+  const handleEditClick = onEditEmployee
+    ? (employee: Employee) => {
+        setEditSalary(employee.salary || 0);
+        setShowEditModal({ open: true, employee });
+      }
+    : undefined;
+
+  const handleDeleteClick = onRemoveEmployee
+    ? (employee: Employee) => {
+        setShowDeleteConfirm({ open: true, employee });
+      }
+    : undefined;
+
+  const rowSharedProps: EmployeeRowSharedProps = {
+    employees: displayedEmployees,
+    focusedIndex: tableNav.focusedIndex,
+    onRowKeyDown: tableNav.handleRowKeyDown,
+    registerRowElement: tableNav.registerRowElement,
+    onEmployeeClick,
+    onAvatarClick: handleAvatarClick,
+    onEditClick: handleEditClick,
+    onDeleteClick: handleDeleteClick,
+    onCopyWallet: (employee) => {
+      void handleCopyWallet(employee);
+    },
+    copiedId,
+    t,
+    language: i18n.language,
+  };
+
+  const cardSharedProps: EmployeeRowSharedProps = {
+    ...rowSharedProps,
+    focusedIndex: cardNav.focusedIndex,
+    onRowKeyDown: cardNav.handleRowKeyDown,
+    registerRowElement: cardNav.registerRowElement,
+  };
+
   return (
     <div className="w-full overflow-hidden rounded-[28px] border border-hi bg-[var(--surface)]/95 shadow-[var(--shadow-card)]">
       <div className="border-b border-hi px-5 py-6 sm:px-6">
@@ -379,7 +859,9 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                 className="inline-flex items-center gap-2 rounded-2xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-sm font-semibold text-[var(--text)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]"
               >
                 <Upload className="h-4 w-4" aria-hidden />
-                {showCSVUploader ? t('employeeList.hideCsvImport') : t('employeeList.importRosterCsv')}
+                {showCSVUploader
+                  ? t('employeeList.hideCsvImport')
+                  : t('employeeList.importRosterCsv')}
               </button>
               <button
                 type="button"
@@ -446,7 +928,7 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
               <EmployeeSkeletonCard key={index} />
             ))}
           </div>
-        ) : (
+        ) : reorderMode ? (
           <DragDropContext onDragEnd={handleDragEnd}>
             <Droppable droppableId="employee-cards">
               {(provided) => (
@@ -457,12 +939,7 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                   aria-label={t('employeeList.dragToReorderAriaLabel')}
                 >
                   {displayedEmployees.map((employee, index) => (
-                    <Draggable
-                      key={employee.id}
-                      draggableId={employee.id}
-                      index={index}
-                      isDragDisabled={!reorderMode}
-                    >
+                    <Draggable key={employee.id} draggableId={employee.id} index={index}>
                       {(dragProvided, dragSnapshot) => (
                         <article
                           key={employee.id}
@@ -470,15 +947,15 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                           {...dragProvided.draggableProps}
                           className={`rounded-3xl border border-hi bg-[var(--surface-hi)]/70 p-5 shadow-[var(--shadow-card)] ${dragSnapshot.isDragging ? 'shadow-[0_8px_32px_rgba(74,240,184,0.15)] ring-1 ring-[var(--accent)]' : ''}`}
                         >
-                          {reorderMode && (
-                            <div
-                              {...dragProvided.dragHandleProps}
-                              className="flex items-center justify-center pb-3 cursor-grab active:cursor-grabbing"
-                              aria-label={t('employeeList.dragToReorderEmployee', { name: employee.name })}
-                            >
-                              <GripVertical className="h-5 w-5 text-[var(--muted)]" aria-hidden />
-                            </div>
-                          )}
+                          <div
+                            {...dragProvided.dragHandleProps}
+                            className="flex items-center justify-center pb-3 cursor-grab active:cursor-grabbing"
+                            aria-label={t('employeeList.dragToReorderEmployee', {
+                              name: employee.name,
+                            })}
+                          >
+                            <GripVertical className="h-5 w-5 text-[var(--muted)]" aria-hidden />
+                          </div>
                           <div className="flex items-start gap-3">
                             <button
                               type="button"
@@ -563,7 +1040,9 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                                           ? 'border-[var(--success)] text-[var(--success)]'
                                           : 'border-hi text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)]'
                                       }`}
-                                      aria-label={t('employeeList.copyWalletFor', { name: employee.name })}
+                                      aria-label={t('employeeList.copyWalletFor', {
+                                        name: employee.name,
+                                      })}
                                     >
                                       {copiedId === employee.id ? (
                                         <Check className="h-4 w-4" aria-hidden />
@@ -611,252 +1090,351 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
               )}
             </Droppable>
           </DragDropContext>
+        ) : (
+          <div
+            className={LIST_VIEWPORT_CLASS}
+            role="list"
+            aria-label={t('employeeList.employeeDirectory')}
+          >
+            <List
+              listRef={cardNav.listRef}
+              rowComponent={VirtualizedEmployeeCard}
+              rowCount={displayedEmployees.length}
+              rowHeight={CARD_ROW_HEIGHT}
+              rowProps={cardSharedProps}
+              onRowsRendered={cardNav.handleRowsRendered}
+              overscanCount={5}
+              style={{ height: '100%', width: '100%' }}
+            />
+          </div>
         )}
       </div>
 
       <div className={`hidden overflow-x-auto lg:block ${showEmptyState ? 'lg:hidden' : ''}`}>
-        <DragDropContext onDragEnd={handleDragEnd}>
-          <table className="w-full table-fixed border-collapse text-left">
-            <thead>
-              <tr className="border-b border-hi">
-                {reorderMode && <th className="w-10 p-6" aria-label={t('employeeList.dragHandleColumn')} />}
+        {isLoading || reorderMode ? (
+          <DragDropContext onDragEnd={handleDragEnd}>
+            <table className="w-full table-fixed border-collapse text-left">
+              <thead>
+                <tr className="border-b border-hi">
+                  {reorderMode && (
+                    <th className="w-10 p-6" aria-label={t('employeeList.dragHandleColumn')} />
+                  )}
+                  {[
+                    { key: 'name' as const, label: t('employeeList.columnName'), width: 'w-[28%]' },
+                    {
+                      key: 'position' as const,
+                      label: t('employeeList.role'),
+                      width: 'w-[18%]',
+                    },
+                    { key: 'wallet' as const, label: t('employeeList.wallet'), width: 'w-[18%]' },
+                    { key: 'salary' as const, label: t('employeeList.salary'), width: 'w-[14%]' },
+                    { key: 'status' as const, label: t('employeeList.columnStatus'), width: '' },
+                  ].map((column) => (
+                    <th
+                      key={column.key}
+                      className={`${column.width} p-6`}
+                      aria-sort={
+                        !reorderMode && sortKey === column.key
+                          ? sortAsc
+                            ? 'ascending'
+                            : 'descending'
+                          : 'none'
+                      }
+                    >
+                      <button
+                        type="button"
+                        disabled={reorderMode}
+                        className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[var(--muted)] disabled:cursor-default"
+                        onClick={() => !reorderMode && handleSort(column.key)}
+                        aria-label={t('employeeList.sortByColumn', { column: column.label })}
+                      >
+                        {column.label}
+                        {!reorderMode && <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />}
+                        {!reorderMode && sortKey === column.key ? (
+                          <span className="text-[var(--accent)]" aria-hidden>
+                            {sortAsc ? '▲' : '▼'}
+                          </span>
+                        ) : null}
+                      </button>
+                    </th>
+                  ))}
+                  <th className="p-6 text-xs font-bold uppercase tracking-widest text-[var(--muted)]">
+                    {t('bulkPaymentTracker.columnActions')}
+                  </th>
+                </tr>
+              </thead>
+              <Droppable droppableId="employee-table" direction="vertical">
+                {(provided) => (
+                  <tbody
+                    className="divide-y divide-gray-200/5"
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                  >
+                    {isLoading
+                      ? Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+                          <EmployeeSkeletonRow key={index} />
+                        ))
+                      : displayedEmployees.map((employee, index) => (
+                          <Draggable
+                            key={employee.id}
+                            draggableId={`table-${employee.id}`}
+                            index={index}
+                            isDragDisabled={!reorderMode}
+                          >
+                            {(dragProvided, dragSnapshot) => (
+                              <tr
+                                ref={dragProvided.innerRef}
+                                {...dragProvided.draggableProps}
+                                className={`group transition hover:bg-white/5 hover:bg-accent/[0.03] ${dragSnapshot.isDragging ? 'bg-[var(--surface-hi)] shadow-[0_8px_32px_rgba(74,240,184,0.15)]' : ''}`}
+                              >
+                                {reorderMode && (
+                                  <td className="p-6 w-10">
+                                    <div
+                                      {...dragProvided.dragHandleProps}
+                                      className="flex items-center justify-center cursor-grab active:cursor-grabbing text-[var(--muted)] hover:text-[var(--accent)]"
+                                      aria-label={t('employeeList.dragToReorderEmployee', {
+                                        name: employee.name,
+                                      })}
+                                    >
+                                      <GripVertical className="h-4 w-4" aria-hidden />
+                                    </div>
+                                  </td>
+                                )}
+                                <td className="p-6">
+                                  <div className="flex items-center gap-4">
+                                    <button
+                                      type="button"
+                                      onClick={() => setShowAvatarModal({ open: true, employee })}
+                                      className="relative rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
+                                      aria-label={t('employeeList.updatePhotoFor', {
+                                        name: employee.name,
+                                      })}
+                                    >
+                                      <Avatar
+                                        email={employee.email}
+                                        name={employee.name}
+                                        imageUrl={employee.imageUrl}
+                                        size="md"
+                                      />
+                                      <span
+                                        aria-hidden="true"
+                                        className={`absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-[var(--bg)] ${
+                                          employee.status === 'Inactive'
+                                            ? 'bg-[var(--danger)]'
+                                            : 'bg-[var(--success)]'
+                                        }`}
+                                      />
+                                    </button>
+
+                                    <div className="min-w-0 flex flex-col">
+                                      <button
+                                        type="button"
+                                        onClick={() => onEmployeeClick?.(employee)}
+                                        className="truncate text-left text-sm font-bold text-[var(--text)] transition-colors group-hover:text-[var(--accent)]"
+                                        title={employee.name}
+                                      >
+                                        {employee.name}
+                                      </button>
+                                      <span
+                                        className="truncate text-xs text-[var(--muted)]"
+                                        title={employee.email}
+                                      >
+                                        {employee.email}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td className="p-6">
+                                  <div className="flex flex-col">
+                                    <span className="truncate text-sm font-medium text-[var(--text)]">
+                                      {employee.position}
+                                    </span>
+                                    <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+                                      {t('employeeList.role')}
+                                    </span>
+                                  </div>
+                                </td>
+                                <td className="p-6">
+                                  <div className="flex items-center gap-2">
+                                    <code className="max-w-[10rem] truncate rounded-lg border border-[var(--border)] bg-[var(--surface-hi)] px-2 py-1 text-[10px] font-mono text-[var(--muted)]">
+                                      {employee.wallet
+                                        ? shortenWallet(
+                                            employee.wallet,
+                                            t('employeeList.noWalletAssigned')
+                                          )
+                                        : t('employeeList.noWallet')}
+                                    </code>
+                                    {employee.wallet ? (
+                                      <button
+                                        type="button"
+                                        onClick={() => void handleCopyWallet(employee)}
+                                        className={`inline-flex h-8 w-8 items-center justify-center rounded-lg border transition ${
+                                          copiedId === employee.id
+                                            ? 'border-[var(--success)] text-[var(--success)]'
+                                            : 'border-transparent text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)]'
+                                        }`}
+                                        aria-label={t('employeeList.copyWalletAddressFor', {
+                                          name: employee.name,
+                                        })}
+                                      >
+                                        {copiedId === employee.id ? (
+                                          <Check className="h-4 w-4" aria-hidden />
+                                        ) : (
+                                          <Copy className="h-4 w-4" aria-hidden />
+                                        )}
+                                      </button>
+                                    ) : null}
+                                  </div>
+                                </td>
+                                <td className="p-6">
+                                  <div className="flex flex-col items-start">
+                                    {onEditEmployee ? (
+                                      <button
+                                        type="button"
+                                        className="text-sm font-bold text-[var(--text)] transition-colors hover:text-[var(--accent)]"
+                                        aria-label={t('employeeList.editSalaryForWithAmount', {
+                                          name: employee.name,
+                                          amount: (employee.salary ?? 0).toLocaleString(
+                                            i18n.language
+                                          ),
+                                        })}
+                                        onClick={() => {
+                                          setEditSalary(employee.salary || 0);
+                                          setShowEditModal({ open: true, employee });
+                                        }}
+                                      >
+                                        ${(employee.salary ?? 0).toLocaleString(i18n.language)}
+                                      </button>
+                                    ) : (
+                                      <span className="text-sm font-bold text-[var(--text)]">
+                                        ${(employee.salary ?? 0).toLocaleString(i18n.language)}
+                                      </span>
+                                    )}
+                                    <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+                                      {t('employeeList.perMonth')}
+                                    </span>
+                                  </div>
+                                </td>
+                                <td className="p-6">
+                                  <span
+                                    className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${
+                                      employee.status === 'Inactive'
+                                        ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
+                                        : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
+                                    }`}
+                                  >
+                                    {employee.status
+                                      ? employee.status === 'Active'
+                                        ? t('employeeList.active')
+                                        : t('employeeList.inactive')
+                                      : t('employeeList.active')}
+                                  </span>
+                                </td>
+                                <td className="p-6">
+                                  <div className="flex items-center gap-1 opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100">
+                                    {onEditEmployee ? (
+                                      <button
+                                        type="button"
+                                        className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(74,240,184,0.10)] hover:text-[var(--accent)]"
+                                        aria-label={t('employeeList.editSalaryFor', {
+                                          name: employee.name,
+                                        })}
+                                        onClick={() => {
+                                          setEditSalary(employee.salary || 0);
+                                          setShowEditModal({ open: true, employee });
+                                        }}
+                                      >
+                                        <Pencil className="h-4 w-4" aria-hidden />
+                                      </button>
+                                    ) : null}
+                                    {onRemoveEmployee ? (
+                                      <button
+                                        type="button"
+                                        className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(255,123,114,0.10)] hover:text-[var(--danger)]"
+                                        aria-label={t('employeeList.removeEmployee', {
+                                          name: employee.name,
+                                        })}
+                                        onClick={() =>
+                                          setShowDeleteConfirm({ open: true, employee })
+                                        }
+                                      >
+                                        <Trash2 className="h-4 w-4" aria-hidden />
+                                      </button>
+                                    ) : null}
+                                  </div>
+                                </td>
+                              </tr>
+                            )}
+                          </Draggable>
+                        ))}
+                    {provided.placeholder}
+                  </tbody>
+                )}
+              </Droppable>
+            </table>
+          </DragDropContext>
+        ) : (
+          <div role="table" aria-label={t('employeeList.employeeDirectory')}>
+            <div role="rowgroup">
+              <div
+                role="row"
+                style={{ display: 'grid', gridTemplateColumns: TABLE_GRID_TEMPLATE }}
+                className="border-b border-hi"
+              >
                 {[
-                  { key: 'name' as const, label: t('employeeList.columnName'), width: 'w-[28%]' },
-                  {
-                    key: 'position' as const,
-                    label: t('employeeList.role'),
-                    width: 'w-[18%]',
-                  },
-                  { key: 'wallet' as const, label: t('employeeList.wallet'), width: 'w-[18%]' },
-                  { key: 'salary' as const, label: t('employeeList.salary'), width: 'w-[14%]' },
-                  { key: 'status' as const, label: t('employeeList.columnStatus'), width: '' },
+                  { key: 'name' as const, label: t('employeeList.columnName') },
+                  { key: 'position' as const, label: t('employeeList.role') },
+                  { key: 'wallet' as const, label: t('employeeList.wallet') },
+                  { key: 'salary' as const, label: t('employeeList.salary') },
+                  { key: 'status' as const, label: t('employeeList.columnStatus') },
                 ].map((column) => (
-                  <th
+                  <div
                     key={column.key}
-                    className={`${column.width} p-6`}
+                    role="columnheader"
+                    className="p-6"
                     aria-sort={
-                      !reorderMode && sortKey === column.key
-                        ? sortAsc
-                          ? 'ascending'
-                          : 'descending'
-                        : 'none'
+                      sortKey === column.key ? (sortAsc ? 'ascending' : 'descending') : 'none'
                     }
                   >
                     <button
                       type="button"
-                      disabled={reorderMode}
-                      className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[var(--muted)] disabled:cursor-default"
-                      onClick={() => !reorderMode && handleSort(column.key)}
+                      className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[var(--muted)]"
+                      onClick={() => handleSort(column.key)}
                       aria-label={t('employeeList.sortByColumn', { column: column.label })}
                     >
                       {column.label}
-                      {!reorderMode && <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />}
-                      {!reorderMode && sortKey === column.key ? (
+                      <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />
+                      {sortKey === column.key ? (
                         <span className="text-[var(--accent)]" aria-hidden>
                           {sortAsc ? '▲' : '▼'}
                         </span>
                       ) : null}
                     </button>
-                  </th>
+                  </div>
                 ))}
-                <th className="p-6 text-xs font-bold uppercase tracking-widest text-[var(--muted)]">
-                  {t('bulkPaymentTracker.columnActions')}
-                </th>
-              </tr>
-            </thead>
-            <Droppable droppableId="employee-table" direction="vertical">
-              {(provided) => (
-                <tbody
-                  className="divide-y divide-gray-200/5"
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
+                <div
+                  role="columnheader"
+                  className="p-6 text-xs font-bold uppercase tracking-widest text-[var(--muted)]"
                 >
-                  {isLoading
-                    ? Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
-                        <EmployeeSkeletonRow key={index} />
-                      ))
-                    : displayedEmployees.map((employee, index) => (
-                        <Draggable
-                          key={employee.id}
-                          draggableId={`table-${employee.id}`}
-                          index={index}
-                          isDragDisabled={!reorderMode}
-                        >
-                          {(dragProvided, dragSnapshot) => (
-                            <tr
-                              ref={dragProvided.innerRef}
-                              {...dragProvided.draggableProps}
-                              className={`group transition hover:bg-white/5 hover:bg-accent/[0.03] ${dragSnapshot.isDragging ? 'bg-[var(--surface-hi)] shadow-[0_8px_32px_rgba(74,240,184,0.15)]' : ''}`}
-                            >
-                              {reorderMode && (
-                                <td className="p-6 w-10">
-                                  <div
-                                    {...dragProvided.dragHandleProps}
-                                    className="flex items-center justify-center cursor-grab active:cursor-grabbing text-[var(--muted)] hover:text-[var(--accent)]"
-                                    aria-label={t('employeeList.dragToReorderEmployee', { name: employee.name })}
-                                  >
-                                    <GripVertical className="h-4 w-4" aria-hidden />
-                                  </div>
-                                </td>
-                              )}
-                              <td className="p-6">
-                                <div className="flex items-center gap-4">
-                                  <button
-                                    type="button"
-                                    onClick={() => setShowAvatarModal({ open: true, employee })}
-                                    className="relative rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent)]"
-                                    aria-label={t('employeeList.updatePhotoFor', { name: employee.name })}
-                                  >
-                                    <Avatar
-                                      email={employee.email}
-                                      name={employee.name}
-                                      imageUrl={employee.imageUrl}
-                                      size="md"
-                                    />
-                                    <span
-                                      aria-hidden="true"
-                                      className={`absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-[var(--bg)] ${
-                                        employee.status === 'Inactive'
-                                          ? 'bg-[var(--danger)]'
-                                          : 'bg-[var(--success)]'
-                                      }`}
-                                    />
-                                  </button>
+                  {t('bulkPaymentTracker.columnActions')}
+                </div>
+              </div>
+            </div>
 
-                                  <div className="min-w-0 flex flex-col">
-                                    <button
-                                      type="button"
-                                      onClick={() => onEmployeeClick?.(employee)}
-                                      className="truncate text-left text-sm font-bold text-[var(--text)] transition-colors group-hover:text-[var(--accent)]"
-                                      title={employee.name}
-                                    >
-                                      {employee.name}
-                                    </button>
-                                    <span
-                                      className="truncate text-xs text-[var(--muted)]"
-                                      title={employee.email}
-                                    >
-                                      {employee.email}
-                                    </span>
-                                  </div>
-                                </div>
-                              </td>
-                              <td className="p-6">
-                                <div className="flex flex-col">
-                                  <span className="truncate text-sm font-medium text-[var(--text)]">
-                                    {employee.position}
-                                  </span>
-                                  <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
-                                    {t('employeeList.role')}
-                                  </span>
-                                </div>
-                              </td>
-                              <td className="p-6">
-                                <div className="flex items-center gap-2">
-                                  <code className="max-w-[10rem] truncate rounded-lg border border-[var(--border)] bg-[var(--surface-hi)] px-2 py-1 text-[10px] font-mono text-[var(--muted)]">
-                                    {employee.wallet
-                                      ? shortenWallet(employee.wallet, t('employeeList.noWalletAssigned'))
-                                      : t('employeeList.noWallet')}
-                                  </code>
-                                  {employee.wallet ? (
-                                    <button
-                                      type="button"
-                                      onClick={() => void handleCopyWallet(employee)}
-                                      className={`inline-flex h-8 w-8 items-center justify-center rounded-lg border transition ${
-                                        copiedId === employee.id
-                                          ? 'border-[var(--success)] text-[var(--success)]'
-                                          : 'border-transparent text-[var(--muted)] hover:border-[var(--accent)] hover:text-[var(--accent)]'
-                                      }`}
-                                      aria-label={t('employeeList.copyWalletAddressFor', { name: employee.name })}
-                                    >
-                                      {copiedId === employee.id ? (
-                                        <Check className="h-4 w-4" aria-hidden />
-                                      ) : (
-                                        <Copy className="h-4 w-4" aria-hidden />
-                                      )}
-                                    </button>
-                                  ) : null}
-                                </div>
-                              </td>
-                              <td className="p-6">
-                                <div className="flex flex-col items-start">
-                                  {onEditEmployee ? (
-                                    <button
-                                      type="button"
-                                      className="text-sm font-bold text-[var(--text)] transition-colors hover:text-[var(--accent)]"
-                                      aria-label={t('employeeList.editSalaryForWithAmount', {
-                                        name: employee.name,
-                                        amount: (employee.salary ?? 0).toLocaleString(i18n.language),
-                                      })}
-                                      onClick={() => {
-                                        setEditSalary(employee.salary || 0);
-                                        setShowEditModal({ open: true, employee });
-                                      }}
-                                    >
-                                      ${(employee.salary ?? 0).toLocaleString(i18n.language)}
-                                    </button>
-                                  ) : (
-                                    <span className="text-sm font-bold text-[var(--text)]">
-                                      ${(employee.salary ?? 0).toLocaleString(i18n.language)}
-                                    </span>
-                                  )}
-                                  <span className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
-                                    {t('employeeList.perMonth')}
-                                  </span>
-                                </div>
-                              </td>
-                              <td className="p-6">
-                                <span
-                                  className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-bold uppercase tracking-widest ${
-                                    employee.status === 'Inactive'
-                                      ? 'border-[color:rgba(255,123,114,0.22)] bg-[color:rgba(255,123,114,0.08)] text-[var(--danger)]'
-                                      : 'border-[color:rgba(63,185,80,0.22)] bg-[color:rgba(63,185,80,0.08)] text-[var(--success)]'
-                                  }`}
-                                >
-                                  {employee.status
-                                    ? employee.status === 'Active'
-                                      ? t('employeeList.active')
-                                      : t('employeeList.inactive')
-                                    : t('employeeList.active')}
-                                </span>
-                              </td>
-                              <td className="p-6">
-                                <div className="flex items-center gap-1 opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100 lg:group-focus-within:opacity-100">
-                                  {onEditEmployee ? (
-                                    <button
-                                      type="button"
-                                      className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(74,240,184,0.10)] hover:text-[var(--accent)]"
-                                      aria-label={t('employeeList.editSalaryFor', { name: employee.name })}
-                                      onClick={() => {
-                                        setEditSalary(employee.salary || 0);
-                                        setShowEditModal({ open: true, employee });
-                                      }}
-                                    >
-                                      <Pencil className="h-4 w-4" aria-hidden />
-                                    </button>
-                                  ) : null}
-                                  {onRemoveEmployee ? (
-                                    <button
-                                      type="button"
-                                      className="rounded-lg p-2 text-[var(--muted)] transition-all hover:bg-[color:rgba(255,123,114,0.10)] hover:text-[var(--danger)]"
-                                      aria-label={t('employeeList.removeEmployee', { name: employee.name })}
-                                      onClick={() => setShowDeleteConfirm({ open: true, employee })}
-                                    >
-                                      <Trash2 className="h-4 w-4" aria-hidden />
-                                    </button>
-                                  ) : null}
-                                </div>
-                              </td>
-                            </tr>
-                          )}
-                        </Draggable>
-                      ))}
-                  {provided.placeholder}
-                </tbody>
-              )}
-            </Droppable>
-          </table>
-        </DragDropContext>
+            <div className={LIST_VIEWPORT_CLASS} role="rowgroup">
+              <List
+                listRef={tableNav.listRef}
+                rowComponent={VirtualizedEmployeeTableRow}
+                rowCount={displayedEmployees.length}
+                rowHeight={TABLE_ROW_HEIGHT}
+                rowProps={rowSharedProps}
+                onRowsRendered={tableNav.handleRowsRendered}
+                overscanCount={5}
+                style={{ height: '100%', width: '100%' }}
+              />
+            </div>
+          </div>
+        )}
       </div>
 
       {showEditModal.open && showEditModal.employee ? (

--- a/frontend/src/components/FeeEstimationConfirmModal.tsx
+++ b/frontend/src/components/FeeEstimationConfirmModal.tsx
@@ -16,7 +16,7 @@
  * Issue: https://github.com/Gildado/PayD/issues/166
  */
 
-import React, { useMemo, useCallback, useRef, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, AlertTriangle, TrendingUp, Clock, DollarSign, Info } from 'lucide-react';
 import { Button } from '@stellar/design-system';
@@ -147,9 +147,20 @@ interface FeeRowProps {
   subtext?: string;
   icon?: React.ReactNode;
   highlight?: boolean;
+  /** Longer explanation announced to screen readers via aria-describedby on the value. */
+  description?: string;
+  descriptionId?: string;
 }
 
-const FeeRow: React.FC<FeeRowProps> = ({ label, value, subtext, icon, highlight }) => (
+const FeeRow: React.FC<FeeRowProps> = ({
+  label,
+  value,
+  subtext,
+  icon,
+  highlight,
+  description,
+  descriptionId,
+}) => (
   <div className={`${styles.feeRow} ${highlight ? styles.feeRowHighlight : ''}`}>
     <div className={styles.feeRowLabel}>
       {icon && <span className={styles.feeRowIcon}>{icon}</span>}
@@ -158,7 +169,14 @@ const FeeRow: React.FC<FeeRowProps> = ({ label, value, subtext, icon, highlight 
         {subtext && <p className={styles.feeSubtext}>{subtext}</p>}
       </div>
     </div>
-    <p className={styles.feeValue}>{value}</p>
+    <p className={styles.feeValue} aria-describedby={description ? descriptionId : undefined}>
+      {value}
+    </p>
+    {description && descriptionId && (
+      <span id={descriptionId} className="sr-only">
+        {description}
+      </span>
+    )}
   </div>
 );
 
@@ -223,6 +241,12 @@ export const FeeEstimationConfirmModal: React.FC<FeeEstimationConfirmModalProps>
   const { t } = useTranslation();
   const { feeRecommendation, isLoading, isError, error, refetch } = useFeeEstimation();
   const modalRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  const idPrefix = useId();
+  const baseFeeDescId = `${idPrefix}-base-fee-desc`;
+  const recommendedFeeDescId = `${idPrefix}-recommended-fee-desc`;
+  const totalFeeDescId = `${idPrefix}-total-fee-desc`;
 
   // Estimate transaction count: 1 main transfer + N recipient transfers
   // We use a conservative estimate of N+1 transactions
@@ -253,19 +277,70 @@ export const FeeEstimationConfirmModal: React.FC<FeeEstimationConfirmModalProps>
     };
   }, [feeRecommendation, estimatedTransactionCount]);
 
-  // Keyboard event handler for Escape key
+  // Focus management: move focus into the dialog when it opens, and restore
+  // focus to whatever was focused beforehand when it closes.
+  useEffect(() => {
+    if (isOpen) {
+      previouslyFocusedElementRef.current = document.activeElement as HTMLElement | null;
+      modalRef.current?.focus();
+    } else if (previouslyFocusedElementRef.current) {
+      previouslyFocusedElementRef.current.focus();
+      previouslyFocusedElementRef.current = null;
+    }
+  }, [isOpen]);
+
+  // Keyboard event handler for Escape (close) and Tab (focus trap)
   useEffect(() => {
     if (!isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         onCancel();
+        return;
+      }
+
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusable = modalRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), textarea, input:not([disabled]), select, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, onCancel]);
+
+  // Screen-reader status announcement for the current step of the modal:
+  // loading fees -> ready with the estimate -> or an error.
+  const srStatusMessage = isLoading
+    ? t('feeEstimation.confirmModal.srLoadingFee', 'Loading fee estimate…')
+    : isError
+      ? t('feeEstimation.confirmModal.srFeeError', 'Fee estimate failed: {{message}}', {
+          message:
+            error?.message || t('feeEstimation.confirmModal.srFeeErrorFallback', 'Unknown error'),
+        })
+      : batchEstimate
+        ? t(
+            'feeEstimation.confirmModal.srFeeReady',
+            'Fee estimate ready: {{total}} XLM total for {{count}} transactions.',
+            {
+              total: batchEstimate.totalBudgetXLM.value,
+              count: batchEstimate.transactionCount,
+            }
+          )
+        : '';
 
   const handleConfirm = useCallback(() => {
     onConfirm();
@@ -297,7 +372,16 @@ export const FeeEstimationConfirmModal: React.FC<FeeEstimationConfirmModalProps>
         aria-modal="true"
         aria-labelledby="fee-estimation-title"
         aria-describedby="fee-estimation-description"
+        aria-busy={isLoading}
+        tabIndex={-1}
       >
+        {/* Persistent live region: announces loading -> ready/error transitions.
+            (No role="status" here — the congestion badge below already owns
+            that role, and duplicating it would make role queries ambiguous.) */}
+        <div className="sr-only" aria-live="polite" aria-atomic="true">
+          {srStatusMessage}
+        </div>
+
         {/* Header */}
         <div className={styles.header}>
           <div className={styles.headerContent}>
@@ -377,6 +461,11 @@ export const FeeEstimationConfirmModal: React.FC<FeeEstimationConfirmModalProps>
                     label={t('feeEstimation.confirmModal.baseFee', 'Base Fee')}
                     value={`${stroopsToXLM(feeRecommendation.baseFee).value} XLM`}
                     subtext={`${feeRecommendation.baseFee} stroops`}
+                    description={t(
+                      'feeEstimation.confirmModal.baseFeeDescription',
+                      'The minimum fee required for a transaction to be included in the ledger.'
+                    )}
+                    descriptionId={baseFeeDescId}
                   />
 
                   <FeeRow
@@ -384,6 +473,11 @@ export const FeeEstimationConfirmModal: React.FC<FeeEstimationConfirmModalProps>
                     label={t('feeEstimation.confirmModal.recommendedFee', 'Recommended Fee')}
                     value={`${stroopsToXLM(feeRecommendation.recommendedFee).value} XLM`}
                     subtext={`${feeRecommendation.recommendedFee} stroops per transaction`}
+                    description={t(
+                      'feeEstimation.confirmModal.recommendedFeeDescription',
+                      'The fee recommended for reliable, timely processing based on current network conditions.'
+                    )}
+                    descriptionId={recommendedFeeDescId}
                   />
 
                   {feeRecommendation.congestionLevel !== 'low' && (
@@ -421,8 +515,16 @@ export const FeeEstimationConfirmModal: React.FC<FeeEstimationConfirmModalProps>
                     <p className={styles.estimateLabel}>
                       {t('feeEstimation.confirmModal.totalFee', 'Total Fee')}
                     </p>
-                    <p className={styles.estimateValue}>{batchEstimate.totalBudgetXLM.value} XLM</p>
+                    <p className={styles.estimateValue} aria-describedby={totalFeeDescId}>
+                      {batchEstimate.totalBudgetXLM.value} XLM
+                    </p>
                     <p className={styles.estimateSubtext}>({batchEstimate.totalBudget} stroops)</p>
+                    <span id={totalFeeDescId} className="sr-only">
+                      {t(
+                        'feeEstimation.confirmModal.totalFeeDescription',
+                        'Total estimated cost to process this batch, including a buffer for network congestion.'
+                      )}
+                    </span>
                   </div>
 
                   <div className={styles.estimateFine}>

--- a/frontend/src/components/FeeEstimationPanel.tsx
+++ b/frontend/src/components/FeeEstimationPanel.tsx
@@ -7,7 +7,7 @@
  * Issue: https://github.com/Gildado/PayD/issues/42
  */
 
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import { useFeeEstimation } from '../hooks/useFeeEstimation';
 import type { BatchBudgetEstimate } from '../services/feeEstimation';
 import styles from './FeeEstimationPanel.module.css';
@@ -41,6 +41,11 @@ export const FeeEstimationPanel: React.FC = () => {
   const [txCount, setTxCount] = useState<string>('');
   const [batchResult, setBatchResult] = useState<BatchBudgetEstimate | null>(null);
   const [batchLoading, setBatchLoading] = useState(false);
+
+  const idPrefix = useId();
+  const baseFeeDescId = `${idPrefix}-base-fee-desc`;
+  const recommendedFeeDescId = `${idPrefix}-recommended-fee-desc`;
+  const maxFeeDescId = `${idPrefix}-max-fee-desc`;
 
   const handleEstimateBatch = async () => {
     const count = parseInt(txCount, 10);
@@ -87,6 +92,21 @@ export const FeeEstimationPanel: React.FC = () => {
     return '#ef4444';
   };
 
+  // Screen-reader-only status message describing the current loading/error/ready
+  // state. This lives in a single persistent aria-live region so assistive
+  // technology announces each transition (loading -> ready/error) as it happens.
+  const srStatusMessage = isLoading
+    ? t('feeEstimation.srLoadingFee')
+    : isError
+      ? t('feeEstimation.srFeeError', { message: error?.message || t('feeEstimation.error') })
+      : feeRecommendation
+        ? t('feeEstimation.srFeeReady', {
+            fee: feeRecommendation.recommendedFee.toLocaleString(i18n.language),
+            xlm: feeRecommendation.recommendedFeeXLM.value,
+            congestion: congestionLabel(feeRecommendation.congestionLevel),
+          })
+        : '';
+
   // ---- Render ----
   return (
     <div className={styles.panel}>
@@ -101,7 +121,12 @@ export const FeeEstimationPanel: React.FC = () => {
         )}
       </div>
 
-      <div className={styles.grid}>
+      {/* Persistent live region: announces loading/ready/error transitions */}
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {srStatusMessage}
+      </div>
+
+      <div className={styles.grid} aria-busy={isLoading}>
         {/* ---- Loading State ---- */}
         {isLoading && (
           <>
@@ -112,7 +137,7 @@ export const FeeEstimationPanel: React.FC = () => {
 
         {/* ---- Error State ---- */}
         {isError && (
-          <div className={`${styles.card} ${styles.errorCard}`}>
+          <div className={`${styles.card} ${styles.errorCard}`} role="alert">
             <p>{error?.message || t('feeEstimation.error')}</p>
             <button
               className={styles.retryBtn}
@@ -180,7 +205,7 @@ export const FeeEstimationPanel: React.FC = () => {
 
               <div className={styles.statRow}>
                 <span className={styles.statLabel}>{t('feeEstimation.baseFee')}</span>
-                <span className={styles.statValue}>
+                <span className={styles.statValue} aria-describedby={baseFeeDescId}>
                   {feeRecommendation.baseFee.toLocaleString(i18n.language)} stroops
                   <span className={styles.statSub}>
                     {t('feeEstimation.feeInXlm', {
@@ -188,11 +213,14 @@ export const FeeEstimationPanel: React.FC = () => {
                     })}
                   </span>
                 </span>
+                <span id={baseFeeDescId} className="sr-only">
+                  {t('feeEstimation.baseFeeExplanation')}
+                </span>
               </div>
 
               <div className={styles.statRow}>
                 <span className={styles.statLabel}>{t('feeEstimation.recommendedFee')}</span>
-                <span className={styles.statValue}>
+                <span className={styles.statValue} aria-describedby={recommendedFeeDescId}>
                   {feeRecommendation.recommendedFee.toLocaleString(i18n.language)} stroops
                   <span className={styles.statSub}>
                     {t('feeEstimation.feeInXlm', {
@@ -200,17 +228,23 @@ export const FeeEstimationPanel: React.FC = () => {
                     })}
                   </span>
                 </span>
+                <span id={recommendedFeeDescId} className="sr-only">
+                  {t('feeEstimation.recommendedFeeExplanation')}
+                </span>
               </div>
 
               <div className={styles.statRow}>
                 <span className={styles.statLabel}>{t('feeEstimation.maxFee')}</span>
-                <span className={styles.statValue}>
+                <span className={styles.statValue} aria-describedby={maxFeeDescId}>
                   {feeRecommendation.maxFee.toLocaleString(i18n.language)} stroops
                   <span className={styles.statSub}>
                     {t('feeEstimation.feeInXlm', {
                       amount: feeRecommendation.maxFeeXLM,
                     })}
                   </span>
+                </span>
+                <span id={maxFeeDescId} className="sr-only">
+                  {t('feeEstimation.maxFeeExplanation')}
                 </span>
               </div>
             </div>

--- a/frontend/src/components/__tests__/BulkPaymentStatusTracker.test.tsx
+++ b/frontend/src/components/__tests__/BulkPaymentStatusTracker.test.tsx
@@ -1,0 +1,274 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { BulkPaymentStatusTracker } from '../BulkPaymentStatusTracker';
+import type { PayrollRunRecord, PayrollRunSummary } from '../../services/bulkPaymentStatus';
+import '../../i18n';
+
+const mockNotifySuccess = vi.fn();
+const mockNotifyError = vi.fn();
+const mockNotifyPaymentSuccess = vi.fn();
+const mockNotifyApiError = vi.fn();
+
+vi.mock('../../hooks/useNotification', () => ({
+  useNotification: () => ({
+    notify: vi.fn(),
+    notifySuccess: mockNotifySuccess,
+    notifyError: mockNotifyError,
+    notifyPaymentSuccess: mockNotifyPaymentSuccess,
+    notifyPaymentFailure: vi.fn(),
+    notifyWalletEvent: vi.fn(),
+    notifyApiError: mockNotifyApiError,
+  }),
+}));
+
+vi.mock('../../hooks/useWallet', () => ({
+  useWallet: () => ({
+    address: null,
+    requireWallet: vi.fn().mockResolvedValue(null),
+    signTransaction: vi.fn(),
+  }),
+}));
+
+vi.mock('../../hooks/useWalletSigning', () => ({
+  useWalletSigning: () => ({ sign: vi.fn() }),
+}));
+
+vi.mock('../../services/contracts', () => ({
+  contractService: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getContractId: vi.fn().mockReturnValue('CMOCK'),
+  },
+}));
+
+const mockFetchPayrollRuns = vi.fn();
+const mockFetchPayrollRunSummary = vi.fn();
+const mockFetchPayrollRunOnChainState = vi.fn();
+const mockRetryFailedPayment = vi.fn();
+
+vi.mock('../../services/bulkPaymentStatus', () => ({
+  fetchPayrollRuns: (...args: unknown[]) => mockFetchPayrollRuns(...args),
+  fetchPayrollRunSummary: (...args: unknown[]) => mockFetchPayrollRunSummary(...args),
+  fetchPayrollRunOnChainState: (...args: unknown[]) => mockFetchPayrollRunOnChainState(...args),
+  retryFailedPayment: (...args: unknown[]) => mockRetryFailedPayment(...args),
+  getTxExplorerUrl: (txHash: string) => `https://stellar.expert/explorer/testnet/tx/${txHash}`,
+}));
+
+// A minimal fake matching the slice of the socket.io-client `Socket` API this
+// component actually uses (on/off/emit), plus a `trigger` helper so tests can
+// simulate the server pushing an event.
+function createFakeSocket() {
+  const listeners: Record<string, Array<(payload: unknown) => void>> = {};
+  return {
+    on: vi.fn((event: string, cb: (payload: unknown) => void) => {
+      (listeners[event] ||= []).push(cb);
+    }),
+    off: vi.fn((event: string, cb: (payload: unknown) => void) => {
+      listeners[event] = (listeners[event] || []).filter((fn) => fn !== cb);
+    }),
+    emit: vi.fn(),
+    trigger(event: string, payload: unknown) {
+      (listeners[event] || []).forEach((cb) => cb(payload));
+    },
+  };
+}
+
+let socketState: {
+  socket: ReturnType<typeof createFakeSocket> | null;
+  connected: boolean;
+  isPollingFallback: boolean;
+  isReconnecting: boolean;
+};
+
+vi.mock('../../hooks/useSocket', () => ({
+  useSocket: () => socketState,
+}));
+
+const baseRun: PayrollRunRecord = {
+  id: 1,
+  batch_id: 'batch-1',
+  status: 'processing',
+  total_amount: '1000',
+  asset_code: 'USDC',
+  created_at: '2024-01-01T00:00:00Z',
+};
+
+describe('BulkPaymentStatusTracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketState = {
+      socket: createFakeSocket(),
+      connected: true,
+      isPollingFallback: false,
+      isReconnecting: false,
+    };
+    mockFetchPayrollRuns.mockResolvedValue({ data: [baseRun], total: 1 });
+  });
+
+  test('subscribes to the bulk channel for each loaded run and unsubscribes on unmount', async () => {
+    const { unmount } = render(<BulkPaymentStatusTracker organizationId={1} />);
+
+    await screen.findByText('batch-1');
+
+    await waitFor(() => {
+      expect(socketState.socket!.emit).toHaveBeenCalledWith('subscribe:bulk', {
+        batchId: 'batch-1',
+      });
+    });
+
+    unmount();
+
+    expect(socketState.socket!.emit).toHaveBeenCalledWith('unsubscribe:bulk', {
+      batchId: 'batch-1',
+    });
+  });
+
+  test('updates the progress bar and confirmed/pending counts from a live bulk:confirmation event', async () => {
+    render(<BulkPaymentStatusTracker organizationId={1} />);
+    await screen.findByText('batch-1');
+
+    act(() => {
+      socketState.socket!.trigger('bulk:confirmation', {
+        batchId: 'batch-1',
+        status: 'processing',
+        progress: 40,
+        completedCount: 4,
+        totalItems: 10,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('40%')).toBeInTheDocument();
+    });
+    expect(screen.getByText('4 confirmed · 6 pending')).toBeInTheDocument();
+  });
+
+  test('reflects the live socket status without needing a manual refresh', async () => {
+    render(<BulkPaymentStatusTracker organizationId={1} />);
+    await screen.findByText('batch-1');
+    expect(screen.getByText('processing')).toBeInTheDocument();
+
+    act(() => {
+      socketState.socket!.trigger('bulk:confirmation', {
+        batchId: 'batch-1',
+        status: 'completed',
+        completedCount: 10,
+        totalItems: 10,
+        progress: 100,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('completed')).toBeInTheDocument();
+    });
+  });
+
+  test('shows a completion toast once when the batch reaches 100%, even if the event repeats', async () => {
+    render(<BulkPaymentStatusTracker organizationId={1} />);
+    await screen.findByText('batch-1');
+
+    const completedPayload = {
+      batchId: 'batch-1',
+      status: 'completed',
+      completedCount: 10,
+      totalItems: 10,
+      progress: 100,
+    };
+
+    act(() => {
+      socketState.socket!.trigger('bulk:confirmation', completedPayload);
+    });
+
+    await waitFor(() => {
+      expect(mockNotifySuccess).toHaveBeenCalledTimes(1);
+    });
+    expect(mockNotifySuccess).toHaveBeenCalledWith(
+      'Payroll batch complete',
+      '10 payments confirmed for batch batch-1'
+    );
+
+    // Simulate the same event arriving again, e.g. after a rapid reconnect.
+    act(() => {
+      socketState.socket!.trigger('bulk:confirmation', completedPayload);
+    });
+
+    expect(mockNotifySuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows the Live connection indicator when the socket is connected', async () => {
+    render(<BulkPaymentStatusTracker organizationId={1} />);
+    await screen.findByText('batch-1');
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
+
+  test('shows the Reconnecting connection indicator while retrying a dropped connection', async () => {
+    socketState = {
+      socket: createFakeSocket(),
+      connected: false,
+      isPollingFallback: false,
+      isReconnecting: true,
+    };
+    render(<BulkPaymentStatusTracker organizationId={1} />);
+    await screen.findByText('batch-1');
+    expect(screen.getByText('Reconnecting')).toBeInTheDocument();
+  });
+
+  test('shows the Polling connection indicator once reconnection attempts are exhausted', async () => {
+    socketState = {
+      socket: null,
+      connected: false,
+      isPollingFallback: true,
+      isReconnecting: false,
+    };
+    render(<BulkPaymentStatusTracker organizationId={1} />);
+    await screen.findByText('batch-1');
+    expect(screen.getByText('Polling')).toBeInTheDocument();
+  });
+
+  test('flashes an individual recipient row when its status changes after a socket update', async () => {
+    const pendingSummary: PayrollRunSummary = {
+      payroll_run: baseRun,
+      items: [
+        {
+          id: 1,
+          employee_id: 1,
+          employee_first_name: 'Ada',
+          employee_last_name: 'Lovelace',
+          amount: '100',
+          status: 'pending',
+        },
+      ],
+      summary: { total_employees: 1, total_amount: '100' },
+    };
+    const confirmedSummary: PayrollRunSummary = {
+      ...pendingSummary,
+      items: [{ ...pendingSummary.items[0], status: 'completed' }],
+    };
+
+    mockFetchPayrollRunSummary
+      .mockResolvedValueOnce(pendingSummary)
+      .mockResolvedValueOnce(confirmedSummary);
+
+    render(<BulkPaymentStatusTracker organizationId={1} />);
+    await screen.findByText('batch-1');
+
+    fireEvent.click(screen.getByRole('button', { name: /details/i }));
+
+    await screen.findByText('Ada Lovelace');
+    expect(screen.getByText('pending')).toBeInTheDocument();
+
+    act(() => {
+      socketState.socket!.trigger('bulk:confirmation', {
+        batchId: 'batch-1',
+        status: 'processing',
+        completedCount: 1,
+        totalItems: 1,
+        progress: 100,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('confirmed')).toBeInTheDocument();
+    });
+    expect(screen.getByText('confirmed').className).toContain('status-flash');
+  });
+});

--- a/frontend/src/components/__tests__/CSVUploader.test.tsx
+++ b/frontend/src/components/__tests__/CSVUploader.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { CSVUploader } from '../CSVUploader';
+import '../../i18n';
 
 const mockNotifySuccess = vi.fn();
 const mockNotifyError = vi.fn();
@@ -203,7 +204,7 @@ describe('CSVUploader', () => {
 
     await waitFor(() => {
       expect(screen.getByText('test.csv')).toBeTruthy();
-      expect(screen.getByText(/2 valid rows/i)).toBeTruthy();
+      expect(screen.getByText(/2 of 2 rows valid/i)).toBeTruthy();
     });
   });
 
@@ -236,5 +237,161 @@ describe('CSVUploader', () => {
       expect(screen.getByRole('alert')).toBeTruthy();
       expect(screen.getByText(/duplicate columns found/i)).toBeTruthy();
     });
+  });
+
+  test('exposes structured field-level errors for invalid rows', async () => {
+    const onDataParsed = vi.fn();
+    const csvContent = createCSVContent(
+      ['name', 'email', 'amount'],
+      [['John', '', '50']]
+    );
+    const file = createMockFile(csvContent);
+    const validators = {
+      amount: (value: string) => (Number(value) < 100 ? 'Amount must be at least 100' : null),
+    };
+
+    render(
+      <CSVUploader
+        requiredColumns={['name', 'email', 'amount']}
+        onDataParsed={onDataParsed}
+        validators={validators}
+      />
+    );
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(onDataParsed).toHaveBeenCalled();
+    });
+
+    const data = onDataParsed.mock.calls[0][0];
+    expect(data[0].isValid).toBe(false);
+    expect(data[0].fieldErrors).toEqual(
+      expect.arrayContaining([
+        { field: 'email', message: 'Missing required field: email' },
+        { field: 'amount', message: 'Amount must be at least 100' },
+      ])
+    );
+  });
+
+  test('renders a dedicated row error table with row number, field, and message', async () => {
+    const csvContent = createCSVContent(
+      ['name', 'email'],
+      [
+        ['John', 'john@test.com'],
+        ['', 'jane@test.com'],
+      ]
+    );
+    const file = createMockFile(csvContent);
+
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 row error/i)).toBeTruthy();
+    });
+
+    const table = screen.getByRole('table', { name: /table of validation errors/i });
+    expect(table.textContent).toContain('3'); // row number (header + 2 data rows -> row 3)
+    expect(table.textContent).toContain('name');
+    expect(table.textContent).toContain('Missing required field: name');
+  });
+
+  test('summary bar shows X of Y rows valid and Z rows with errors', async () => {
+    const csvContent = createCSVContent(
+      ['name', 'email'],
+      [
+        ['John', 'john@test.com'],
+        ['', 'jane@test.com'],
+      ]
+    );
+    const file = createMockFile(csvContent);
+
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 of 2 rows valid/i)).toBeTruthy();
+      expect(screen.getByText(/1 row with errors/i)).toBeTruthy();
+    });
+  });
+
+  test('download errors button exports only the failed rows as CSV', async () => {
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+
+    const csvContent = createCSVContent(
+      ['name', 'email'],
+      [
+        ['John', 'john@test.com'],
+        ['', 'jane@test.com'],
+      ]
+    );
+    const file = createMockFile(csvContent);
+
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    const exportButton = await screen.findByRole('button', { name: /export errors/i });
+    fireEvent.click(exportButton);
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    const blobText = await new Promise<string>((resolve, reject) => {
+      const fileReader = new FileReader();
+      fileReader.onload = () => resolve(fileReader.result as string);
+      fileReader.onerror = () => reject(new Error('Failed to read blob in test'));
+      fileReader.readAsText(blob);
+    });
+    expect(blobText).toContain('jane@test.com');
+    expect(blobText).not.toContain('john@test.com');
+
+    createObjectURL.mockRestore();
+  });
+
+  test('rejects files larger than the 50MB limit', async () => {
+    const file = createMockFile('name,email\nJohn,john@test.com');
+    Object.defineProperty(file, 'size', { value: 51 * 1024 * 1024 });
+
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={vi.fn()} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy();
+      expect(screen.getByText(/50\.0MB limit/i)).toBeTruthy();
+    });
+  });
+
+  test('parses large files in chunks without dropping rows', async () => {
+    const onDataParsed = vi.fn();
+    const rowCount = 1200; // spans multiple CHUNK_SIZE (500) batches
+    const rows = Array.from({ length: rowCount }, (_, i) => [`User${i}`, `user${i}@test.com`]);
+    const csvContent = createCSVContent(['name', 'email'], rows);
+    const file = createMockFile(csvContent);
+
+    render(<CSVUploader requiredColumns={['name', 'email']} onDataParsed={onDataParsed} />);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(
+      () => {
+        expect(onDataParsed).toHaveBeenCalled();
+      },
+      { timeout: 10000 }
+    );
+
+    const data = onDataParsed.mock.calls[0][0];
+    expect(data).toHaveLength(rowCount);
+    expect(data.every((row: { isValid: boolean }) => row.isValid)).toBe(true);
   });
 });

--- a/frontend/src/components/__tests__/EmployeeList.test.tsx
+++ b/frontend/src/components/__tests__/EmployeeList.test.tsx
@@ -1,6 +1,28 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { EmployeeList } from '../EmployeeList';
+import '../../i18n';
+
+// react-window virtualizes based on real layout measurements, which jsdom
+// doesn't provide (everything reports zero size), so a real <List> would
+// render zero rows in tests. We stub it to render every row directly —
+// the recommended approach for testing react-window consumers.
+vi.mock('react-window', () => ({
+  List: ({ rowComponent: RowComponent, rowCount, rowProps }: any) => (
+    <>
+      {Array.from({ length: rowCount }, (_, index) => (
+        <RowComponent
+          key={index}
+          index={index}
+          style={{}}
+          ariaAttributes={{ 'aria-posinset': index + 1, 'aria-setsize': rowCount, role: 'listitem' }}
+          {...rowProps}
+        />
+      ))}
+    </>
+  ),
+  useListRef: () => ({ current: null }),
+}));
 
 vi.mock('../Avatar', () => ({
   Avatar: () => <div data-testid="avatar" />,

--- a/frontend/src/components/__tests__/EmployeeListHover.test.tsx
+++ b/frontend/src/components/__tests__/EmployeeListHover.test.tsx
@@ -1,6 +1,25 @@
 import { render } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { EmployeeList } from '../EmployeeList';
+import '../../i18n';
+
+// See EmployeeList.test.tsx for why react-window needs stubbing under jsdom.
+vi.mock('react-window', () => ({
+  List: ({ rowComponent: RowComponent, rowCount, rowProps }: any) => (
+    <>
+      {Array.from({ length: rowCount }, (_, index) => (
+        <RowComponent
+          key={index}
+          index={index}
+          style={{}}
+          ariaAttributes={{ 'aria-posinset': index + 1, 'aria-setsize': rowCount, role: 'listitem' }}
+          {...rowProps}
+        />
+      ))}
+    </>
+  ),
+  useListRef: () => ({ current: null }),
+}));
 
 vi.mock('../Avatar', () => ({
   Avatar: ({ name }: { name: string }) => <div data-testid="avatar">{name}</div>,
@@ -30,7 +49,7 @@ describe('EmployeeList row hover effects', () => {
   test('data rows include hover background class', () => {
     const { container } = render(<EmployeeList employees={[employee]} onAddEmployee={vi.fn()} />);
 
-    const rows = container.querySelectorAll('tbody tr');
+    const rows = container.querySelectorAll('[data-testid="employee-table-row"]');
     expect(rows.length).toBeGreaterThan(0);
 
     rows.forEach((row) => {
@@ -41,7 +60,7 @@ describe('EmployeeList row hover effects', () => {
   test('data rows include transition class for smooth hover animation', () => {
     const { container } = render(<EmployeeList employees={[employee]} onAddEmployee={vi.fn()} />);
 
-    const rows = container.querySelectorAll('tbody tr');
+    const rows = container.querySelectorAll('[data-testid="employee-table-row"]');
     rows.forEach((row) => {
       expect(row.className).toMatch(/transition/);
     });

--- a/frontend/src/components/__tests__/EmployeeListVirtualization.test.tsx
+++ b/frontend/src/components/__tests__/EmployeeListVirtualization.test.tsx
@@ -1,0 +1,160 @@
+import { useEffect } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { EmployeeList, type Employee } from '../EmployeeList';
+import '../../i18n';
+
+// This mock renders every row directly (jsdom has no real layout, so a real
+// <List> would measure zero height and render nothing) and simulates
+// react-window reporting "the whole list is visible" via onRowsRendered, so
+// PageUp/PageDown (which derive their jump size from that callback) can be
+// exercised deterministically.
+vi.mock('react-window', () => ({
+  List: ({ rowComponent: RowComponent, rowCount, rowProps, onRowsRendered }: any) => {
+    useEffect(() => {
+      onRowsRendered?.({ startIndex: 0, stopIndex: Math.max(rowCount - 1, 0) });
+    }, [rowCount, onRowsRendered]);
+
+    return (
+      <>
+        {Array.from({ length: rowCount }, (_, index) => (
+          <RowComponent
+            key={index}
+            index={index}
+            style={{}}
+            ariaAttributes={{
+              'aria-posinset': index + 1,
+              'aria-setsize': rowCount,
+              role: 'listitem',
+            }}
+            {...rowProps}
+          />
+        ))}
+      </>
+    );
+  },
+  useListRef: () => ({ current: null }),
+}));
+
+vi.mock('../Avatar', () => ({
+  Avatar: () => <div data-testid="avatar" />,
+}));
+vi.mock('../AvatarUpload', () => ({ AvatarUpload: () => null }));
+vi.mock('../../hooks/useNotification', () => ({
+  useNotification: () => ({ notifySuccess: vi.fn() }),
+}));
+vi.mock('../CSVUploader', () => ({ CSVUploader: () => null }));
+vi.mock('../EmployeeRemovalConfirmModal', () => ({
+  EmployeeRemovalConfirmModal: () => null,
+}));
+
+function makeEmployees(count: number): Employee[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `emp-${i}`,
+    name: `Employee ${i}`,
+    email: `employee${i}@example.com`,
+    position: 'Engineer',
+    status: 'Active' as const,
+  }));
+}
+
+describe('EmployeeList virtualization', () => {
+  test(
+    'renders the correct total row count for a large dataset',
+    () => {
+      // Our test stub deliberately renders every row (real virtualization is
+      // exactly what avoids this cost in production — see the react-window
+      // mock above), so this is slower than the real component but still
+      // verifies rowCount reaches react-window correctly at scale.
+      const employees = makeEmployees(1000);
+      render(<EmployeeList employees={employees} onAddEmployee={vi.fn()} />);
+
+      const rows = screen.getAllByTestId('employee-table-row');
+      expect(rows).toHaveLength(1000);
+    },
+    20000
+  );
+
+  test('search filtering narrows the virtualized row count', () => {
+    const employees = makeEmployees(50);
+    render(<EmployeeList employees={employees} onAddEmployee={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('Search employees'), {
+      target: { value: 'Employee 4' },
+    });
+
+    // "Employee 4" matches Employee 4, 40-49 (11 rows).
+    return waitFor(() => {
+      const rows = screen.getAllByTestId('employee-table-row');
+      expect(rows.length).toBeGreaterThan(0);
+      rows.forEach((row) => expect(row.textContent).toMatch(/Employee 4/));
+    });
+  });
+
+  test('arrow keys move focus between virtualized rows', async () => {
+    const employees = makeEmployees(5);
+    render(<EmployeeList employees={employees} onAddEmployee={vi.fn()} />);
+
+    const rows = screen.getAllByTestId('employee-table-row');
+    expect(rows).toHaveLength(5);
+
+    rows[0].focus();
+    expect(rows[0]).toHaveFocus();
+
+    fireEvent.keyDown(rows[0], { key: 'ArrowDown' });
+    await waitFor(() => expect(rows[1]).toHaveFocus());
+
+    fireEvent.keyDown(rows[1], { key: 'ArrowDown' });
+    await waitFor(() => expect(rows[2]).toHaveFocus());
+
+    fireEvent.keyDown(rows[2], { key: 'ArrowUp' });
+    await waitFor(() => expect(rows[1]).toHaveFocus());
+  });
+
+  test('Home and End jump to the first and last row', async () => {
+    const employees = makeEmployees(5);
+    render(<EmployeeList employees={employees} onAddEmployee={vi.fn()} />);
+    const rows = screen.getAllByTestId('employee-table-row');
+
+    rows[2].focus();
+    fireEvent.keyDown(rows[2], { key: 'End' });
+    await waitFor(() => expect(rows[4]).toHaveFocus());
+
+    fireEvent.keyDown(rows[4], { key: 'Home' });
+    await waitFor(() => expect(rows[0]).toHaveFocus());
+  });
+
+  test('Page Down/Up move by a full viewport of rows', async () => {
+    const employees = makeEmployees(5);
+    render(<EmployeeList employees={employees} onAddEmployee={vi.fn()} />);
+    const rows = screen.getAllByTestId('employee-table-row');
+
+    rows[0].focus();
+    // The mock reports all 5 rows as the visible viewport.
+    fireEvent.keyDown(rows[0], { key: 'PageDown' });
+    await waitFor(() => expect(rows[4]).toHaveFocus());
+
+    fireEvent.keyDown(rows[4], { key: 'PageUp' });
+    await waitFor(() => expect(rows[0]).toHaveFocus());
+  });
+
+  test('keyboard navigation clamps to the row count after a filter shrinks the list', async () => {
+    const employees = makeEmployees(10);
+    render(<EmployeeList employees={employees} onAddEmployee={vi.fn()} />);
+
+    let rows = screen.getAllByTestId('employee-table-row');
+    rows[9].focus();
+    expect(rows[9]).toHaveFocus();
+
+    fireEvent.change(screen.getByLabelText('Search employees'), {
+      target: { value: 'Employee 1' },
+    });
+
+    // Only "Employee 1" remains; the focused index must clamp into range
+    // rather than pointing past the end of the new, shorter list.
+    await waitFor(() => {
+      rows = screen.getAllByTestId('employee-table-row');
+      expect(rows).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/src/components/__tests__/FeeEstimationConfirmModal.test.tsx
+++ b/frontend/src/components/__tests__/FeeEstimationConfirmModal.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { I18nextProvider } from 'react-i18next';
@@ -239,6 +239,128 @@ describe('FeeEstimationConfirmModal', () => {
     expect(congestionBadge).toHaveAttribute('aria-label');
   });
 
+  it('moves focus into the dialog when it opens', async () => {
+    render(<FeeEstimationConfirmModal {...defaultProps} />, { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toHaveFocus();
+    });
+  });
+
+  it('restores focus to the previously focused element when the dialog closes', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    const { rerender } = render(<FeeEstimationConfirmModal {...defaultProps} />, {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toHaveFocus();
+    });
+
+    rerender(<FeeEstimationConfirmModal {...defaultProps} isOpen={false} />);
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+    document.body.removeChild(trigger);
+  });
+
+  it('traps Tab focus within the dialog', () => {
+    render(<FeeEstimationConfirmModal {...defaultProps} />, { wrapper: Wrapper });
+    const dialog = screen.getByRole('dialog');
+    const focusable = dialog.querySelectorAll<HTMLElement>('button:not([disabled])');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    last.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(first).toHaveFocus();
+
+    first.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(last).toHaveFocus();
+  });
+
+  it('has aria-busy set while fees are loading and cleared once ready', () => {
+    vi.spyOn(feeEstimationHook, 'useFeeEstimation').mockReturnValue({
+      feeRecommendation: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      estimateBatch: vi.fn(),
+    });
+    const { rerender } = render(<FeeEstimationConfirmModal {...defaultProps} />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-busy', 'true');
+
+    vi.spyOn(feeEstimationHook, 'useFeeEstimation').mockReturnValue({
+      feeRecommendation: mockFeeRecommendation,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      estimateBatch: vi.fn(),
+    });
+    rerender(<FeeEstimationConfirmModal {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('announces loading, ready, and error states via a live region', () => {
+    vi.spyOn(feeEstimationHook, 'useFeeEstimation').mockReturnValue({
+      feeRecommendation: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      estimateBatch: vi.fn(),
+    });
+    const { rerender, container } = render(<FeeEstimationConfirmModal {...defaultProps} />, {
+      wrapper: Wrapper,
+    });
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+    expect(liveRegion?.textContent).toMatch(/loading/i);
+
+    vi.spyOn(feeEstimationHook, 'useFeeEstimation').mockReturnValue({
+      feeRecommendation: mockFeeRecommendation,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      estimateBatch: vi.fn(),
+    });
+    rerender(<FeeEstimationConfirmModal {...defaultProps} />);
+    expect(container.querySelector('[aria-live="polite"]')?.textContent).toMatch(
+      /fee estimate ready/i
+    );
+
+    vi.spyOn(feeEstimationHook, 'useFeeEstimation').mockReturnValue({
+      feeRecommendation: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Network error'),
+      refetch: vi.fn(),
+      estimateBatch: vi.fn(),
+    });
+    rerender(<FeeEstimationConfirmModal {...defaultProps} />);
+    expect(container.querySelector('[aria-live="polite"]')?.textContent).toMatch(
+      /fee estimate failed/i
+    );
+  });
+
+  it('links fee amounts to their explanation via aria-describedby', () => {
+    render(<FeeEstimationConfirmModal {...defaultProps} />, { wrapper: Wrapper });
+    const baseFeeValue = screen.getByText(/^0\.0000100 XLM$/);
+    const describedById = baseFeeValue.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+    expect(document.getElementById(describedById!)?.textContent).toMatch(/minimum fee/i);
+  });
+
   // ─────────────────────────────────────────────────────────────────────────
   // Loading & Error States
   // ─────────────────────────────────────────────────────────────────────────
@@ -269,8 +391,11 @@ describe('FeeEstimationConfirmModal', () => {
     });
 
     render(<FeeEstimationConfirmModal {...defaultProps} />, { wrapper: Wrapper });
-    expect(screen.getByRole('alert')).toBeInTheDocument();
-    expect(screen.getByText(/network error/i)).toBeInTheDocument();
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    // Scoped to the visible alert: the SR-only status live region also
+    // mentions the error message text, so an unscoped query would be ambiguous.
+    expect(within(alert).getByText(/network error/i)).toBeInTheDocument();
   });
 
   it('should call refetch when retry button is clicked', async () => {

--- a/frontend/src/components/__tests__/FeeEstimationPanel.test.tsx
+++ b/frontend/src/components/__tests__/FeeEstimationPanel.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * FeeEstimationPanel.test.tsx
+ *
+ * Accessibility-focused tests for the FeeEstimationPanel: ARIA live regions,
+ * aria-busy loading states, and aria-describedby links between fee amounts
+ * and their explanations.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import { FeeEstimationPanel } from '../FeeEstimationPanel';
+import * as feeEstimationHook from '../../hooks/useFeeEstimation';
+import type { FeeRecommendation } from '../../services/feeEstimation';
+
+const mockFeeRecommendation: FeeRecommendation = {
+  baseFee: 100,
+  recommendedFee: 1000,
+  maxFee: 5000,
+  congestionLevel: 'moderate',
+  shouldBumpFee: false,
+  ledgerCapacityUsage: 0.5,
+  lastLedger: 12345,
+  recommendedFeeXLM: { asset: { code: 'XLM' }, value: '0.0001000' },
+  maxFeeXLM: { asset: { code: 'XLM' }, value: '0.0001500' },
+  baseFeeXLM: { asset: { code: 'XLM' }, value: '0.0000100' },
+};
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={createQueryClient()}>
+    <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+  </QueryClientProvider>
+);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('FeeEstimationPanel — accessibility', () => {
+  describe('loading state', () => {
+    beforeEach(() => {
+      vi.spyOn(feeEstimationHook, 'useFeeEstimation').mockReturnValue({
+        feeRecommendation: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+        estimateBatch: vi.fn(),
+      });
+    });
+
+    it('marks the results region as busy', () => {
+      const { container } = render(<FeeEstimationPanel />, { wrapper: Wrapper });
+      expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+    });
+
+    it('announces that the fee estimate is loading via a live region', () => {
+      render(<FeeEstimationPanel />, { wrapper: Wrapper });
+      const liveRegion = screen.getByRole('status');
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+      expect(liveRegion.textContent).toMatch(/loading/i);
+    });
+  });
+
+  describe('ready state', () => {
+    beforeEach(() => {
+      vi.spyOn(feeEstimationHook, 'useFeeEstimation').mockReturnValue({
+        feeRecommendation: mockFeeRecommendation,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+        estimateBatch: vi.fn(),
+      });
+    });
+
+    it('clears aria-busy once the estimate has loaded', () => {
+      const { container } = render(<FeeEstimationPanel />, { wrapper: Wrapper });
+      expect(container.querySelector('[aria-busy="true"]')).not.toBeInTheDocument();
+      expect(container.querySelector('[aria-busy="false"]')).toBeInTheDocument();
+    });
+
+    it('announces the estimated fee amount and congestion level', () => {
+      render(<FeeEstimationPanel />, { wrapper: Wrapper });
+      const liveRegion = screen.getByRole('status');
+      expect(liveRegion.textContent).toMatch(/1,000 stroops/i);
+      expect(liveRegion.textContent).toMatch(/moderate/i);
+    });
+
+    it('links the base fee, recommended fee, and max fee to explanatory text', () => {
+      render(<FeeEstimationPanel />, { wrapper: Wrapper });
+
+      const baseFeeValue = screen.getByText(/^100 stroops/).closest('span');
+      const recommendedFeeValue = screen.getByText(/^1,000 stroops/).closest('span');
+      const maxFeeValue = screen.getByText(/^5,000 stroops/).closest('span');
+
+      for (const value of [baseFeeValue, recommendedFeeValue, maxFeeValue]) {
+        const describedById = value?.getAttribute('aria-describedby');
+        expect(describedById).toBeTruthy();
+        expect(document.getElementById(describedById!)?.textContent).toBeTruthy();
+      }
+
+      // Each description should be distinct and relevant to its metric.
+      const baseDescId = baseFeeValue!.getAttribute('aria-describedby')!;
+      const recommendedDescId = recommendedFeeValue!.getAttribute('aria-describedby')!;
+      expect(document.getElementById(baseDescId)?.textContent).toMatch(/minimum fee/i);
+      expect(document.getElementById(recommendedDescId)?.textContent).toMatch(/recommended/i);
+    });
+  });
+
+  describe('error state', () => {
+    beforeEach(() => {
+      vi.spyOn(feeEstimationHook, 'useFeeEstimation').mockReturnValue({
+        feeRecommendation: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error('Horizon unreachable'),
+        refetch: vi.fn(),
+        estimateBatch: vi.fn(),
+      });
+    });
+
+    it('renders the error as an alert and announces it via the live region', () => {
+      render(<FeeEstimationPanel />, { wrapper: Wrapper });
+
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toMatch(/horizon unreachable/i);
+
+      const liveRegion = screen.getByRole('status');
+      expect(liveRegion.textContent).toMatch(/failed/i);
+      expect(liveRegion.textContent).toMatch(/horizon unreachable/i);
+    });
+
+    it('clears aria-busy once the request has failed', () => {
+      const { container } = render(<FeeEstimationPanel />, { wrapper: Wrapper });
+      expect(container.querySelector('[aria-busy="false"]')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -6,6 +6,8 @@ export interface SocketContextType {
   connected: boolean;
   /** True when the WebSocket transport has failed and the app is using HTTP polling as a fallback */
   isPollingFallback: boolean;
+  /** True while the client is actively retrying a dropped connection (before falling back to polling) */
+  isReconnecting: boolean;
   subscribeToTransaction: (transactionId: string) => void;
   unsubscribeFromTransaction: (transactionId: string) => void;
   subscribeToBulk: (batchId: string) => void;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -174,6 +174,23 @@ h6 {
   }
 }
 
+.status-flash {
+  animation: statusFlash 1.2s ease-out;
+  border-radius: 4px;
+}
+
+@keyframes statusFlash {
+  0% {
+    background-color: rgba(74, 240, 184, 0.35);
+    box-shadow: 0 0 0 1px rgba(74, 240, 184, 0.4);
+  }
+
+  100% {
+    background-color: rgba(74, 240, 184, 0);
+    box-shadow: 0 0 0 1px rgba(74, 240, 184, 0);
+  }
+}
+
 /* ── SDS Component Fixes ── */
 select {
   appearance: none !important;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -143,7 +143,14 @@
     "loadingFeeInformation": "Loading fee information",
     "feeEstimationError": "Fee estimation error",
     "ledgerSequenceTooltipLabel": "What is a Ledger Sequence?",
-    "ledgerSequenceTooltipContent": "The Ledger Sequence (or ledger number) identifies the latest confirmed block on the Stellar network. Each ledger closes roughly every 5 seconds and bundles a set of transactions. Higher numbers mean a more recent ledger."
+    "ledgerSequenceTooltipContent": "The Ledger Sequence (or ledger number) identifies the latest confirmed block on the Stellar network. Each ledger closes roughly every 5 seconds and bundles a set of transactions. Higher numbers mean a more recent ledger.",
+    "srLoadingFee": "Loading fee estimate…",
+    "srFeeReady": "Estimated fee: {{fee}} stroops ({{xlm}} XLM). Network congestion: {{congestion}}.",
+    "srFeeError": "Fee estimate failed: {{message}}",
+    "srBatchFeeReady": "Estimated total fee: {{total}} XLM for {{count}} transactions.",
+    "baseFeeExplanation": "The minimum fee required for a transaction to be included in the ledger.",
+    "recommendedFeeExplanation": "The fee recommended for reliable, timely processing based on current network conditions.",
+    "maxFeeExplanation": "A conservative fee estimate for high congestion scenarios, at the 99th percentile."
   },
   "errorFallback": {
     "defaultTitle": "Something went wrong",
@@ -432,6 +439,8 @@
     "pollingDescription": "Using HTTP polling for updates",
     "offline": "Offline",
     "offlineDescription": "No connection - updates paused",
+    "reconnecting": "Reconnecting",
+    "reconnectingDescription": "Connection lost - attempting to reconnect",
     "ariaLabel": "Connection status: {{label}}. {{description}}"
   },
   "countdown": {
@@ -495,7 +504,13 @@
     "validRowsCount_one": "{{count}} valid row",
     "validRowsCount_other": "{{count}} valid rows",
     "rowsWithErrorsCount_one": "{{count}} row with errors",
-    "rowsWithErrorsCount_other": "{{count}} rows with errors"
+    "rowsWithErrorsCount_other": "{{count}} rows with errors",
+    "summaryValidOfTotal": "{{valid}} of {{total}} rows valid",
+    "rowErrorsHeading_one": "{{count}} Row Error",
+    "rowErrorsHeading_other": "{{count}} Row Errors",
+    "rowErrorsAriaLabel": "Table of validation errors by row and field",
+    "columnField": "Field",
+    "columnErrorMessage": "Error Message"
   },
   "breadcrumb": {
     "navigationAriaLabel": "Breadcrumb navigation",
@@ -826,7 +841,12 @@
     "totalSettled": "Total settled: {{amount}} {{asset}}",
     "amount": "Amount",
     "retrying": "Retrying...",
-    "retry": "Retry"
+    "retry": "Retry",
+    "batchCompleteTitle": "Payroll batch complete",
+    "batchCompleteBody_one": "{{count}} payment confirmed for batch {{batchId}}",
+    "batchCompleteBody_other": "{{count}} payments confirmed for batch {{batchId}}",
+    "liveConfirmed": "{{count}} confirmed",
+    "livePending": "{{count}} pending"
   },
   "employeeList": {
     "directoryUpdated": "The directory has been updated with the validated CSV records.",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -143,7 +143,14 @@
     "loadingFeeInformation": "Cargando información de comisiones",
     "feeEstimationError": "Error en la estimación de comisiones",
     "ledgerSequenceTooltipLabel": "¿Qué es una secuencia de libro mayor?",
-    "ledgerSequenceTooltipContent": "La secuencia del libro mayor (o número de libro mayor) identifica el último bloque confirmado en la red Stellar. Cada libro mayor se cierra aproximadamente cada 5 segundos y agrupa un conjunto de transacciones. Los números más altos indican un libro mayor más reciente."
+    "ledgerSequenceTooltipContent": "La secuencia del libro mayor (o número de libro mayor) identifica el último bloque confirmado en la red Stellar. Cada libro mayor se cierra aproximadamente cada 5 segundos y agrupa un conjunto de transacciones. Los números más altos indican un libro mayor más reciente.",
+    "srLoadingFee": "Cargando estimación de comisión…",
+    "srFeeReady": "Comisión estimada: {{fee}} stroops ({{xlm}} XLM). Congestión de red: {{congestion}}.",
+    "srFeeError": "La estimación de comisión falló: {{message}}",
+    "srBatchFeeReady": "Comisión total estimada: {{total}} XLM para {{count}} transacciones.",
+    "baseFeeExplanation": "La comisión mínima requerida para que una transacción se incluya en el libro mayor.",
+    "recommendedFeeExplanation": "La comisión recomendada para un procesamiento confiable y oportuno según las condiciones actuales de la red.",
+    "maxFeeExplanation": "Una estimación de comisión conservadora para escenarios de alta congestión, en el percentil 99."
   },
   "errorFallback": {
     "defaultTitle": "Algo salió mal",
@@ -432,6 +439,8 @@
     "pollingDescription": "Usando sondeo HTTP para las actualizaciones",
     "offline": "Sin conexión",
     "offlineDescription": "Sin conexión - actualizaciones en pausa",
+    "reconnecting": "Reconectando",
+    "reconnectingDescription": "Conexión perdida - intentando reconectar",
     "ariaLabel": "Estado de conexión: {{label}}. {{description}}"
   },
   "countdown": {
@@ -495,7 +504,13 @@
     "validRowsCount_one": "{{count}} fila válida",
     "validRowsCount_other": "{{count}} filas válidas",
     "rowsWithErrorsCount_one": "{{count}} fila con errores",
-    "rowsWithErrorsCount_other": "{{count}} filas con errores"
+    "rowsWithErrorsCount_other": "{{count}} filas con errores",
+    "summaryValidOfTotal": "{{valid}} de {{total}} filas válidas",
+    "rowErrorsHeading_one": "{{count}} error de fila",
+    "rowErrorsHeading_other": "{{count}} errores de fila",
+    "rowErrorsAriaLabel": "Tabla de errores de validación por fila y campo",
+    "columnField": "Campo",
+    "columnErrorMessage": "Mensaje de error"
   },
   "breadcrumb": {
     "navigationAriaLabel": "Navegación de ruta",
@@ -826,7 +841,12 @@
     "totalSettled": "Total liquidado: {{amount}} {{asset}}",
     "amount": "Monto",
     "retrying": "Reintentando...",
-    "retry": "Reintentar"
+    "retry": "Reintentar",
+    "batchCompleteTitle": "Lote de nómina completo",
+    "batchCompleteBody_one": "{{count}} pago confirmado para el lote {{batchId}}",
+    "batchCompleteBody_other": "{{count}} pagos confirmados para el lote {{batchId}}",
+    "liveConfirmed": "{{count}} confirmados",
+    "livePending": "{{count}} pendientes"
   },
   "employeeList": {
     "directoryUpdated": "El directorio se actualizó con los registros CSV validados.",

--- a/frontend/src/providers/SocketProvider.tsx
+++ b/frontend/src/providers/SocketProvider.tsx
@@ -10,6 +10,7 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [socket, setSocket] = useState<Socket | null>(null);
   const [connected, setConnected] = useState(false);
   const [isPollingFallback, setIsPollingFallback] = useState(false);
+  const [isReconnecting, setIsReconnecting] = useState(false);
   const { notifySuccess, notifyError } = useNotification();
 
   // Track whether the first successful connection has fired so we don't
@@ -31,6 +32,7 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
     newSocket.on('connect', () => {
       setConnected(true);
+      setIsReconnecting(false);
       reconnectCount.current = 0;
 
       if (!hasConnectedOnce.current) {
@@ -56,11 +58,13 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
     newSocket.on('reconnect_attempt', (attempt: number) => {
       reconnectCount.current = attempt;
+      setIsReconnecting(true);
     });
 
     newSocket.on('reconnect_failed', () => {
       // All reconnect attempts exhausted — switch to polling fallback so
       // components can activate their own HTTP polling intervals.
+      setIsReconnecting(false);
       setIsPollingFallback(true);
       notifyError(
         'Real-time updates unavailable',
@@ -110,6 +114,7 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         socket,
         connected,
         isPollingFallback,
+        isReconnecting,
         subscribeToTransaction,
         unsubscribeFromTransaction,
         subscribeToBulk,


### PR DESCRIPTION
# Pull Request

## Summary

This PR implements four frontend improvements: row-level CSV error reporting, real-time Socket.IO payroll status updates, ARIA accessibility for fee estimation, and virtualized rendering for large employee lists.

1. Row-level error reporting in CSVUploader

- Added structured CSVFieldError { field, message } on each CSVRow, plus a dedicated row/field/message error table separate from the data preview.
- Bumped file size limit to 50MB and made parsing async/chunked (500 rows/tick, yielding via setTimeout) so large files no longer block the UI thread; added a live progress bar.
- Summary bar now reads "X of Y rows valid" alongside "Z rows with errors."
- New translation keys (en/es) for the added copy.

Files: components/CSVUploader.tsx, components/__tests__/CSVUploader.test.tsx, locales/{en,es}/translation.json

2. Real-time Socket.IO updates in BulkPaymentStatusTracker

- Fixed a latent bug where the confirmation-count listener never matched the backend's actual event field (completedCount), so live progress silently never updated.
- Batch status badge now reflects the live socket status instead of a stale REST-fetched value; added live confirmed/pending counts and a completion toast (deduped against replayed/duplicate events via a ref-tracked set).
- Added a genuine isReconnecting state to useSocket/SocketProvider (previously only connected/isPollingFallback existed) and reused the existing <ConnectionStatus /> indicator.
- Per-row and per-batch status-change animation via a .status-flash CSS keyframe.

Files: components/BulkPaymentStatusTracker.tsx, components/ConnectionStatus.tsx, hooks/useSocket.ts, providers/SocketProvider.tsx, index.css, components/__tests__/BulkPaymentStatusTracker.test.tsx (new)

3. ARIA live regions for fee estimation

- FeeEstimationPanel: persistent aria-live="polite" status region announcing loading → ready → error; aria-busy on the results grid; aria-describedby linking each fee amount to a hidden explanation.
- FeeEstimationConfirmModal: real focus management (focus moves into the dialog on open, restores on close), a Tab-key focus trap, aria-busy, a live-region step announcer, and aria-describedby on fee values.
- New translation keys (en/es) for the panel; modal follows its existing inline-fallback t(key, 'default') convention.

Files: components/FeeEstimationPanel.tsx, components/FeeEstimationConfirmModal.tsx, components/__tests__/FeeEstimationConfirmModal.test.tsx, components/__tests__/FeeEstimationPanel.test.tsx (new), locales/{en,es}/translation.json

4. Virtualized EmployeeList rendering

- Integrated react-window for the normal (non-reorder) view; reorder mode and the loading skeleton keep the original full-DOM @hello-pangea/dnd table, since drag-and-drop requires every row mounted and isn't in scope here.
- Native <table> markup can't be virtualized (absolute-positioned rows break table layout), so the desktop row rendering was rebuilt as a CSS-grid div layout with full ARIA table semantics (role="table"/"row"/"columnheader"/"cell"), preserving the original column ratios and visual content.
- Added roving-tabindex keyboard navigation (Arrow keys, Home/End, PageUp/PageDown) built on react-window's onRowsRendered/scrollToRow.

Files: components/EmployeeList.tsx, components/__tests__/EmployeeList.test.tsx, components/__tests__/EmployeeListHover.test.tsx, components/__tests__/EmployeeListVirtualization.test.tsx (new)

Notable side fix

Three of the touched test files (CSVUploader, BulkPaymentStatusTracker, EmployeeList) never initialized real i18next, so t() was silently returning raw translation keys and several pre-existing tests were failing before these changes — confirmed via git stash comparison against the base branch. Fixed by adding import '../../i18n' to each.

Verification

- tsc --noEmit: clean across all changes.
- eslint: clean (no new warnings/errors).
- Full test suite: no regressions — failures dropped from 126→97 and passes rose from 556→597 comparing the base branch to this branch (git stash A/B comparison), accounting for both new tests and the i18n fixes above.

Closes #1008 
Closes #1009 
Closes #1010 
Closes #1011 