### PR TITLE
feat(frontend): add drag-and-drop revenue split recipient reordering

### DIFF
--- a/frontend/src/__tests__/basisPointRebalance.test.ts
+++ b/frontend/src/__tests__/basisPointRebalance.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeRebalancedBasisPoints,
+  rebalanceAllocations,
+  reorderList,
+} from '../utils/basispointrebalance';
+
+describe('computeRebalancedBasisPoints', () => {
+  it('always sums to exactly 10000', () => {
+    const cases = [
+      [33.33, 33.33, 33.34],
+      [10, 20, 30, 40],
+      [1, 1, 1, 1, 1, 1, 1],
+      [0.1, 0.2, 99.7],
+      [50, 50],
+      [100],
+    ];
+
+    for (const weights of cases) {
+      const result = computeRebalancedBasisPoints(weights);
+      expect(result.reduce((a, b) => a + b, 0)).toBe(10000);
+    }
+  });
+
+  it('preserves relative proportions as closely as integer rounding allows', () => {
+    const result = computeRebalancedBasisPoints([50, 25, 25]);
+    expect(result).toEqual([5000, 2500, 2500]);
+  });
+
+  it('splits evenly when all weights are zero', () => {
+    const result = computeRebalancedBasisPoints([0, 0, 0]);
+    expect(result).toEqual([3334, 3333, 3333]);
+    expect(result.reduce((a, b) => a + b, 0)).toBe(10000);
+  });
+
+  it('returns an empty array for no entries', () => {
+    expect(computeRebalancedBasisPoints([])).toEqual([]);
+  });
+
+  it('ignores negative or non-finite weights, treating them as zero weight', () => {
+    const result = computeRebalancedBasisPoints([50, Number.NaN, -10]);
+    expect(result.reduce((a, b) => a + b, 0)).toBe(10000);
+    expect(result[0]).toBe(10000);
+  });
+
+  it('breaks remainder ties using the current (new) order', () => {
+    // Four equal weights of 25 -> each gets 2500 exactly, no remainder to distribute.
+    // Three equal weights of 33.33... -> remainder must go to earliest entries.
+    const result = computeRebalancedBasisPoints([1, 1, 1]);
+    expect(result).toEqual([3334, 3333, 3333]);
+  });
+});
+
+describe('rebalanceAllocations', () => {
+  it('rebalances percentages so basis points sum to 10000 while preserving order', () => {
+    const entries = [
+      { id: 'a', percentage: 33.33 },
+      { id: 'b', percentage: 33.33 },
+      { id: 'c', percentage: 33.33 },
+    ];
+
+    const result = rebalanceAllocations(entries);
+    const totalBasisPoints = result.reduce((sum, entry) => sum + Math.round(entry.percentage * 100), 0);
+
+    expect(totalBasisPoints).toBe(10000);
+    expect(result.map((entry) => entry.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('re-derives proportions after a reorder swap', () => {
+    const original = [
+      { id: 'a', percentage: 60 },
+      { id: 'b', percentage: 25 },
+      { id: 'c', percentage: 15 },
+    ];
+
+    const reordered = reorderList(original, 0, 2); // move 'a' to the end
+    const rebalanced = rebalanceAllocations(reordered);
+
+    expect(rebalanced.map((entry) => entry.id)).toEqual(['b', 'c', 'a']);
+    expect(rebalanced.find((entry) => entry.id === 'a')?.percentage).toBeCloseTo(60, 5);
+    const total = rebalanced.reduce((sum, entry) => sum + Math.round(entry.percentage * 100), 0);
+    expect(total).toBe(10000);
+  });
+});
+
+describe('reorderList', () => {
+  it('moves an item from source to destination index without mutating input', () => {
+    const original = ['a', 'b', 'c', 'd'];
+    const result = reorderList(original, 0, 2);
+
+    expect(result).toEqual(['b', 'c', 'a', 'd']);
+    expect(original).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('handles moving an item backwards', () => {
+    const result = reorderList(['a', 'b', 'c', 'd'], 3, 1);
+    expect(result).toEqual(['a', 'd', 'b', 'c']);
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -283,7 +283,13 @@
     "editAllocations": "Edit Allocations",
     "submitting": "Submitting...",
     "liveBalances": "Live Recipient Balances",
-    "historicalEvents": "Historical Distribution Events"
+    "historicalEvents": "Historical Distribution Events",
+    "dragToReorderAriaLabel": "Revenue split recipients — drag to reorder",
+    "dragToReorderRecipient": "Drag to reorder {{recipient}}",
+    "unnamedRecipient": "unnamed recipient",
+    "undoReorder": "Undo",
+    "reorderAnnouncement": "Moved {{recipient}} to position {{position}} of {{total}}. Basis points rebalanced.",
+    "reorderUndone": "Reorder undone. Previous order and allocations restored."
   },
   "common": {
     "defaultUserName": "User",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -283,7 +283,13 @@
     "editAllocations": "Editar asignaciones",
     "submitting": "Enviando...",
     "liveBalances": "Saldos de destinatarios en vivo",
-    "historicalEvents": "Eventos de distribución históricos"
+    "historicalEvents": "Eventos de distribución históricos",
+    "dragToReorderAriaLabel": "Destinatarios de división de ingresos — arrastrar para reordenar",
+    "dragToReorderRecipient": "Arrastrar para reordenar {{recipient}}",
+    "unnamedRecipient": "destinatario sin nombre",
+    "undoReorder": "Deshacer",
+    "reorderAnnouncement": "Se movió {{recipient}} a la posición {{position}} de {{total}}. Puntos básicos reequilibrados.",
+    "reorderUndone": "Reordenamiento deshecho. Se restauró el orden y las asignaciones anteriores."
   },
   "common": {
     "defaultUserName": "Usuario",

--- a/frontend/src/pages/RevenueSplitDashboard.tsx
+++ b/frontend/src/pages/RevenueSplitDashboard.tsx
@@ -1,10 +1,14 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
+import type { DropResult } from '@hello-pangea/dnd';
+import { GripVertical, Undo2 } from 'lucide-react';
 import { ContractErrorPanel } from '../components/ContractErrorPanel';
 import { SkeletonLoader } from '../components/SkeletonLoader';
 import { parseContractError, type ContractErrorDetail } from '../utils/contractErrorParser';
 import { getTxExplorerUrl } from '../utils/stellarExpert';
+import { rebalanceAllocations, reorderList } from '../utils/basispointrebalance';
 import { useNotification } from '../hooks/useNotification';
 import { useWallet } from '../hooks/useWallet';
 import { useWalletSigning } from '../hooks/useWalletSigning';
@@ -16,6 +20,8 @@ import {
   type DistributionEvent,
   type RevenueAllocation,
 } from '../services/revenueSplit';
+
+type AllocationRow = RevenueAllocation & { id: string };
 
 const CHART_COLORS = ['#4af0b8', '#f59e0b', '#60a5fa', '#f97316', '#f43f5e', '#a78bfa'];
 
@@ -62,12 +68,16 @@ function getOrgPublicKey(): string | null {
 }
 
 export default function RevenueSplitDashboard() {
-  const [allocations, setAllocations] = useState<(RevenueAllocation & { id: string })[]>([]);
+  const [allocations, setAllocations] = useState<AllocationRow[]>([]);
   const [events, setEvents] = useState<DistributionEvent[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [contractError, setContractError] = useState<ContractErrorDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [previousAllocations, setPreviousAllocations] = useState<AllocationRow[] | null>(null);
+  const [justDroppedId, setJustDroppedId] = useState<string | null>(null);
+  const [reorderAnnouncement, setReorderAnnouncement] = useState('');
+  const dropAnimationTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { t } = useTranslation();
   const { address, connect, requireWallet } = useWallet();
@@ -185,6 +195,51 @@ export default function RevenueSplitDashboard() {
   const removeRecipient = (index: number) => {
     setAllocations((prev) => prev.filter((_, idx) => idx !== index));
   };
+
+  const handleDragEnd = (result: DropResult) => {
+    const { source, destination, draggableId } = result;
+    if (!destination || destination.index === source.index) {
+      return;
+    }
+
+    const reordered = reorderList(allocations, source.index, destination.index);
+    const rebalanced = rebalanceAllocations(reordered);
+    setPreviousAllocations(allocations);
+    setAllocations(rebalanced);
+
+    const movedEntry = allocations[source.index];
+    const label = movedEntry?.recipient
+      ? `${movedEntry.recipient.slice(0, 6)}...${movedEntry.recipient.slice(-4)}`
+      : draggableId;
+    setReorderAnnouncement(
+      t('revenueSplitDashboard.reorderAnnouncement', {
+        recipient: label,
+        position: destination.index + 1,
+        total: allocations.length,
+      })
+    );
+
+    setJustDroppedId(draggableId);
+    if (dropAnimationTimeout.current) {
+      clearTimeout(dropAnimationTimeout.current);
+    }
+    dropAnimationTimeout.current = setTimeout(() => setJustDroppedId(null), 700);
+  };
+
+  const handleUndoReorder = () => {
+    if (!previousAllocations) return;
+    setAllocations(previousAllocations);
+    setPreviousAllocations(null);
+    setReorderAnnouncement(t('revenueSplitDashboard.reorderUndone'));
+  };
+
+  useEffect(() => {
+    return () => {
+      if (dropAnimationTimeout.current) {
+        clearTimeout(dropAnimationTimeout.current);
+      }
+    };
+  }, []);
 
   const handleSaveAllocations = async () => {
     const walletAddress = await requireWallet();
@@ -413,45 +468,104 @@ export default function RevenueSplitDashboard() {
         <section className="card glass noise xl:col-span-2 rounded-[1.5rem]">
           <div className="mb-4 flex items-center justify-between gap-3">
             <h2 className="text-lg font-bold">{t('revenueSplitDashboard.editAllocations')}</h2>
-            <button
-              type="button"
-              onClick={addRecipient}
-              className="rounded-xl border border-[var(--border-hi)] bg-black/10 px-3 py-1.5 text-xs font-semibold hover:bg-white/5"
-            >
-              Add Recipient
-            </button>
-          </div>
-
-          <div className="space-y-3">
-            {allocations.map((entry, index) => (
-              <div key={entry.id} className="grid grid-cols-1 items-center gap-3 md:grid-cols-12">
-                <input
-                  type="text"
-                  value={entry.recipient}
-                  onChange={(event) => setAllocationField(index, 'recipient', event.target.value)}
-                  placeholder="Recipient Stellar Address"
-                  className="rounded-xl border border-[var(--border-hi)] bg-black/10 px-3 py-2 text-xs md:col-span-8"
-                />
-                <input
-                  type="number"
-                  value={Number.isFinite(entry.percentage) ? entry.percentage : 0}
-                  onChange={(event) => setAllocationField(index, 'percentage', event.target.value)}
-                  min={0}
-                  max={100}
-                  step={0.01}
-                  placeholder="%"
-                  className="rounded-xl border border-[var(--border-hi)] bg-black/10 px-3 py-2 text-xs md:col-span-3"
-                />
+            <div className="flex items-center gap-2">
+              {previousAllocations ? (
                 <button
                   type="button"
-                  onClick={() => removeRecipient(index)}
-                  className="text-xs font-semibold text-red-400 md:col-span-1"
+                  onClick={handleUndoReorder}
+                  className="flex items-center gap-1.5 rounded-xl border border-[var(--border-hi)] bg-black/10 px-3 py-1.5 text-xs font-semibold hover:bg-white/5"
                 >
-                  Remove
+                  <Undo2 className="h-3.5 w-3.5" aria-hidden />
+                  {t('revenueSplitDashboard.undoReorder')}
                 </button>
-              </div>
-            ))}
+              ) : null}
+              <button
+                type="button"
+                onClick={addRecipient}
+                className="rounded-xl border border-[var(--border-hi)] bg-black/10 px-3 py-1.5 text-xs font-semibold hover:bg-white/5"
+              >
+                Add Recipient
+              </button>
+            </div>
           </div>
+
+          <div aria-live="polite" aria-atomic="true" className="sr-only">
+            {reorderAnnouncement}
+          </div>
+
+          <DragDropContext onDragEnd={handleDragEnd}>
+            <Droppable droppableId="revenue-split-recipients">
+              {(droppableProvided) => (
+                <div
+                  className="space-y-3"
+                  ref={droppableProvided.innerRef}
+                  {...droppableProvided.droppableProps}
+                  aria-label={t('revenueSplitDashboard.dragToReorderAriaLabel')}
+                >
+                  {allocations.map((entry, index) => (
+                    <Draggable key={entry.id} draggableId={entry.id} index={index}>
+                      {(dragProvided, dragSnapshot) => (
+                        <div
+                          ref={dragProvided.innerRef}
+                          {...dragProvided.draggableProps}
+                          className={`grid grid-cols-1 items-center gap-3 rounded-xl transition-all duration-300 md:grid-cols-12 ${
+                            dragSnapshot.isDragging
+                              ? 'bg-black/20 ring-1 ring-[var(--accent)]'
+                              : ''
+                          } ${
+                            justDroppedId === entry.id
+                              ? 'ring-1 ring-[var(--accent)] bg-accent/5'
+                              : ''
+                          }`}
+                        >
+                          <div
+                            {...dragProvided.dragHandleProps}
+                            className="flex touch-none items-center justify-center py-2 text-[var(--muted)] cursor-grab active:cursor-grabbing md:col-span-1"
+                            aria-label={t('revenueSplitDashboard.dragToReorderRecipient', {
+                              recipient: entry.recipient
+                                ? `${entry.recipient.slice(0, 6)}...${entry.recipient.slice(-4)}`
+                                : t('revenueSplitDashboard.unnamedRecipient'),
+                            })}
+                          >
+                            <GripVertical className="h-5 w-5" aria-hidden />
+                          </div>
+                          <input
+                            type="text"
+                            value={entry.recipient}
+                            onChange={(event) =>
+                              setAllocationField(index, 'recipient', event.target.value)
+                            }
+                            placeholder="Recipient Stellar Address"
+                            className="rounded-xl border border-[var(--border-hi)] bg-black/10 px-3 py-2 text-xs md:col-span-7"
+                          />
+                          <input
+                            type="number"
+                            value={Number.isFinite(entry.percentage) ? entry.percentage : 0}
+                            onChange={(event) =>
+                              setAllocationField(index, 'percentage', event.target.value)
+                            }
+                            min={0}
+                            max={100}
+                            step={0.01}
+                            placeholder="%"
+                            className="rounded-xl border border-[var(--border-hi)] bg-black/10 px-3 py-2 text-xs md:col-span-3"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removeRecipient(index)}
+                            className="text-xs font-semibold text-red-400 md:col-span-1"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {droppableProvided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
 
           <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
             <div className="text-xs text-zinc-300">

--- a/frontend/src/utils/basispointrebalance.ts
+++ b/frontend/src/utils/basispointrebalance.ts
@@ -1,0 +1,92 @@
+/**
+ * Basis-point rebalancing for revenue split recipients.
+ *
+ * Revenue split percentages are stored client-side as floating point values
+ * (0-100) but ultimately settle on-chain as integer basis points (0-10000)
+ * that must sum to exactly 10000. Naively converting each percentage to
+ * basis points independently (`Math.round(percentage * 100)`) can leave the
+ * total a few basis points off from 10000 due to rounding.
+ *
+ * Reordering recipients changes visual/report priority and execution order,
+ * so whenever a reorder happens we recompute the basis-point distribution
+ * using the "largest remainder" method (a.k.a. Hamilton's method): each
+ * recipient gets the floor of its proportional share, and any leftover
+ * basis points (to reach exactly 10000) are handed out one at a time to the
+ * recipients with the largest fractional remainder, using the *new* order
+ * as the tie-breaker. This keeps relative proportions intact while
+ * guaranteeing the total always equals 10000 bps.
+ */
+
+const TOTAL_BASIS_POINTS = 10000;
+
+export interface RebalanceEntry {
+  percentage: number;
+}
+
+/**
+ * Given an ordered list of relative weights (e.g. current percentages),
+ * returns integer basis points for each entry, in the same order, that
+ * always sum to exactly 10000. Relative proportions are preserved as
+ * closely as integer rounding allows.
+ */
+export function computeRebalancedBasisPoints(weights: number[]): number[] {
+  const safeWeights = weights.map((weight) => (Number.isFinite(weight) && weight > 0 ? weight : 0));
+  const totalWeight = safeWeights.reduce((sum, weight) => sum + weight, 0);
+
+  if (safeWeights.length === 0) {
+    return [];
+  }
+
+  if (totalWeight <= 0) {
+    // No usable weights (e.g. all zero) — split as evenly as possible.
+    const base = Math.floor(TOTAL_BASIS_POINTS / safeWeights.length);
+    const remainder = TOTAL_BASIS_POINTS - base * safeWeights.length;
+    return safeWeights.map((_, index) => base + (index < remainder ? 1 : 0));
+  }
+
+  const raw = safeWeights.map((weight) => (weight / totalWeight) * TOTAL_BASIS_POINTS);
+  const floors = raw.map((value) => Math.floor(value));
+  const distributed = floors.reduce((sum, value) => sum + value, 0);
+  let remainder = TOTAL_BASIS_POINTS - distributed;
+
+  const remainders = raw
+    .map((value, index) => ({ index, frac: value - floors[index] }))
+    // Largest fractional remainder first; ties broken by current (new) order
+    // so that earlier-positioned recipients win ties, matching the visual
+    // priority conveyed by the new ordering.
+    .sort((a, b) => b.frac - a.frac || a.index - b.index);
+
+  const result = [...floors];
+  for (let i = 0; i < remainders.length && remainder > 0; i += 1) {
+    result[remainders[i].index] += 1;
+    remainder -= 1;
+  }
+
+  return result;
+}
+
+/**
+ * Rebalances a list of recipients (in their new order) so the underlying
+ * basis points sum to exactly 10000, returning updated percentages
+ * (0-100, two decimal precision) alongside the original entries.
+ */
+export function rebalanceAllocations<T extends RebalanceEntry>(entries: T[]): T[] {
+  const basisPoints = computeRebalancedBasisPoints(entries.map((entry) => entry.percentage));
+
+  return entries.map((entry, index) => ({
+    ...entry,
+    percentage: basisPoints[index] / 100,
+  }));
+}
+
+/**
+ * Moves the item at `sourceIndex` to `destinationIndex` within a new array
+ * (does not mutate the input) — the standard reorder helper used by
+ * drag-and-drop reorder handlers.
+ */
+export function reorderList<T>(list: T[], sourceIndex: number, destinationIndex: number): T[] {
+  const result = [...list];
+  const [moved] = result.splice(sourceIndex, 1);
+  result.splice(destinationIndex, 0, moved);
+  return result;
+}


### PR DESCRIPTION
# Pull Request

## Summary
<!-- Provide a high-level description of what this PR does and why. Link the issue(s) it resolves. -->

Implements drag-and-drop reordering for revenue split recipients in the RevenueSplitDashboard using `@hello-pangea/dnd`.

**Fixes** #1019 

## What Changed
<!-- List the main changes organized by category. Use bullet points. -->

- Added drag-and-drop reordering for recipient rows
- Added visual drag handle for each recipient
- Preserved recipient order after drag operations
- Automatically rebalanced basis-point allocations while maintaining a total of 10,000
- Preserved relative allocation proportions after reorder
- Added undo functionality to restore the previous ordering
- Added touch-friendly drag handles for mobile devices
- Added screen reader announcements for completed reorder operations
- Added drop animations for smoother visual feedback

- **Category**: Description of change
- **Category**: Description of change

## Testing
<!-- Describe how you tested these changes. Include test commands, manual steps, or screenshots. -->

- Verified recipients can be reordered via drag-and-drop
- Verified basis-point totals remain exactly 10,000 after every reorder
- Verified allocation proportions are preserved
- Verified undo restores the previous order
- Verified drag-and-drop works on touch devices
- Verified screen readers announce the new recipient position
- Verified drop animation completes successfully


## Documentation
<!-- Note any docs that were updated, or write "N/A". -->

## Checklist
- [ ] I added or updated tests for the change.
- [ ] I updated documentation where needed, or explained why it was not needed.
- [ ] If this change touches the UI, I verified responsive behavior and accessibility.

## Accessibility / Responsiveness
<!-- If this touches the UI, describe keyboard, screen reader, and responsive checks. Otherwise write "N/A". -->

## Notes
<!-- Add migration steps, follow-up tasks, deployment notes, or anything else reviewers should know. -->

closes #1019 