### PR TITLE
feat: Redis distributed locking for concurrent payroll runs + correlation ID logging

### DIFF
--- a/backend/src/services/__tests__/redisLockService.test.ts
+++ b/backend/src/services/__tests__/redisLockService.test.ts
@@ -1,0 +1,126 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+// ── Mock ioredis (via rateLimitService.getRedisClient) ───────────────────────
+
+const mockSet = jest.fn();
+const mockEval = jest.fn();
+
+jest.mock('../rateLimitService.js', () => ({
+  getRedisClient: () => ({
+    set: mockSet,
+    eval: mockEval,
+  }),
+}));
+
+import { RedisLockService } from '../redisLockService.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeService() {
+  return new RedisLockService();
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('RedisLockService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('acquire', () => {
+    it('acquires lock on first SET NX success', async () => {
+      mockSet.mockResolvedValueOnce('OK');
+      const svc = makeService();
+      const handle = await svc.acquire('test-key');
+      expect(mockSet).toHaveBeenCalledWith('lock:test-key', expect.any(String), 'PX', 30_000, 'NX');
+      expect(handle).toBeDefined();
+    });
+
+    it('retries until lock is available then acquires', async () => {
+      mockSet
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('OK');
+      const svc = makeService();
+      const acquirePromise = svc.acquire('retry-key', { retryDelayMs: 0 });
+      // advance timers to flush the retry sleeps
+      await jest.runAllTimersAsync();
+      const handle = await acquirePromise;
+      expect(mockSet).toHaveBeenCalledTimes(3);
+      expect(handle).toBeDefined();
+    });
+
+    it('throws after retries exhausted', async () => {
+      mockSet.mockResolvedValue(null);
+      const svc = makeService();
+      const acquirePromise = svc.acquire('fail-key', { retryCount: 2, retryDelayMs: 0 });
+      await jest.runAllTimersAsync();
+      await expect(acquirePromise).rejects.toThrow(
+        'Failed to acquire distributed lock for key "fail-key" after 3 attempts',
+      );
+    });
+
+    it('release calls UNLOCK_SCRIPT with matching token', async () => {
+      mockSet.mockResolvedValueOnce('OK');
+      mockEval.mockResolvedValueOnce(1);
+      const svc = makeService();
+      const handle = await svc.acquire('release-key');
+      await handle.release();
+      expect(mockEval).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("get"'),
+        1,
+        'lock:release-key',
+        expect.any(String),
+      );
+    });
+
+    it('calling release twice is idempotent', async () => {
+      mockSet.mockResolvedValueOnce('OK');
+      mockEval.mockResolvedValue(1);
+      const svc = makeService();
+      const handle = await svc.acquire('idempotent-key');
+      await handle.release();
+      await handle.release();
+      // eval should only be called once (second release exits early)
+      expect(mockEval).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('withLock', () => {
+    it('runs fn and releases lock on success', async () => {
+      mockSet.mockResolvedValueOnce('OK');
+      mockEval.mockResolvedValueOnce(1);
+      const svc = makeService();
+      const fn = jest.fn().mockResolvedValue('result');
+      const result = await svc.withLock('wl-key', fn as any);
+      expect(result).toBe('result');
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(mockEval).toHaveBeenCalledTimes(1); // release
+    });
+
+    it('releases lock even when fn throws', async () => {
+      mockSet.mockResolvedValueOnce('OK');
+      mockEval.mockResolvedValueOnce(1);
+      const svc = makeService();
+      const fn = jest.fn().mockRejectedValue(new Error('fn error'));
+      await expect(svc.withLock('wl-err-key', fn as any)).rejects.toThrow('fn error');
+      expect(mockEval).toHaveBeenCalledTimes(1); // lock still released
+    });
+  });
+
+  describe('no-op when Redis unavailable', () => {
+    it('returns a no-op handle and does not throw', async () => {
+      jest.resetModules();
+      jest.doMock('../rateLimitService.js', () => ({ getRedisClient: () => null }));
+      const { RedisLockService: NoRedisService } = await import('../redisLockService.js');
+      const svc = new NoRedisService();
+      const handle = await svc.acquire('no-redis-key');
+      await expect(handle.release()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/backend/src/services/payrollQueueService.ts
+++ b/backend/src/services/payrollQueueService.ts
@@ -1,10 +1,13 @@
 import { Queue } from 'bullmq';
 import { redisConnection, PAYROLL_QUEUE_NAME } from '../config/queue.js';
+import { generateCorrelationId, getCorrelationId } from '../utils/correlationContext.js';
 import logger from '../utils/logger.js';
 
 export interface PayrollJobData {
   payrollRunId: number;
   organizationId: number;
+  /** Propagated from the originating HTTP request so all worker log entries share the same correlation ID. */
+  correlationId?: string;
 }
 
 export class PayrollQueueService {
@@ -31,8 +34,16 @@ export class PayrollQueueService {
   static async addPayrollJob(data: PayrollJobData): Promise<string> {
     try {
       const queue = this.getQueue();
-      const job = await queue.add(`payroll-run-${data.payrollRunId}`, data);
-      logger.info(`Added payroll job ${job.id} for run ${data.payrollRunId}`);
+      // Carry the caller's correlation ID (or generate a fresh one) into the job payload
+      // so the worker can restore it and all log lines share a single traceable ID.
+      const jobData: PayrollJobData = {
+        ...data,
+        correlationId: data.correlationId ?? getCorrelationId() ?? generateCorrelationId(),
+      };
+      const job = await queue.add(`payroll-run-${data.payrollRunId}`, jobData);
+      logger.info(`Added payroll job ${job.id} for run ${data.payrollRunId}`, {
+        correlationId: jobData.correlationId,
+      });
       return job.id!;
     } catch (error) {
       logger.error('Failed to add payroll job to queue', error);

--- a/backend/src/services/redisLockService.ts
+++ b/backend/src/services/redisLockService.ts
@@ -1,0 +1,140 @@
+import { Redis } from 'ioredis';
+import { randomUUID } from 'crypto';
+import { getRedisClient } from './rateLimitService.js';
+import logger from '../utils/logger.js';
+
+const DEFAULT_TTL_MS = 30_000;
+const RENEWAL_INTERVAL_MS = 10_000;
+
+// Lua script for atomic unlock: only release if the token matches.
+const UNLOCK_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end
+`;
+
+// Lua script for atomic renewal: only extend if the token still matches.
+const RENEW_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("pexpire", KEYS[1], ARGV[2])
+else
+  return 0
+end
+`;
+
+export interface AcquireOptions {
+  ttlMs?: number;
+  retryCount?: number;
+  retryDelayMs?: number;
+}
+
+export interface LockHandle {
+  release(): Promise<void>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class RedisLockService {
+  private redis: Redis | null;
+
+  constructor() {
+    this.redis = getRedisClient();
+  }
+
+  /**
+   * Acquire a distributed lock for `key`. Returns a LockHandle whose
+   * `release()` method must be called when the critical section exits.
+   *
+   * Auto-renewal keeps the lock alive while the caller is still working;
+   * renewal stops as soon as `release()` is called.
+   *
+   * Throws if the lock cannot be acquired within the retry budget.
+   */
+  async acquire(key: string, options: AcquireOptions = {}): Promise<LockHandle> {
+    const {
+      ttlMs = DEFAULT_TTL_MS,
+      retryCount = 10,
+      retryDelayMs = 200,
+    } = options;
+
+    if (!this.redis) {
+      logger.warn('RedisLockService: Redis not available, lock acquisition skipped', { key });
+      return { release: async () => {} };
+    }
+
+    const token = randomUUID();
+    const lockKey = `lock:${key}`;
+
+    for (let attempt = 0; attempt <= retryCount; attempt++) {
+      const result = await this.redis.set(lockKey, token, 'PX', ttlMs, 'NX');
+
+      if (result === 'OK') {
+        logger.debug('Distributed lock acquired', { key: lockKey, token, ttlMs });
+
+        let released = false;
+        let renewalTimer: ReturnType<typeof setInterval> | null = null;
+
+        const stopRenewal = () => {
+          if (renewalTimer) {
+            clearInterval(renewalTimer);
+            renewalTimer = null;
+          }
+        };
+
+        renewalTimer = setInterval(async () => {
+          if (released) {
+            stopRenewal();
+            return;
+          }
+          try {
+            const renewed = await this.redis!.eval(RENEW_SCRIPT, 1, lockKey, token, String(ttlMs));
+            if (renewed !== 1) {
+              logger.warn('Distributed lock renewal failed — lock may have expired', { key: lockKey });
+              stopRenewal();
+            }
+          } catch (err) {
+            logger.error('Distributed lock renewal error', err);
+          }
+        }, RENEWAL_INTERVAL_MS);
+
+        const release = async (): Promise<void> => {
+          if (released) return;
+          released = true;
+          stopRenewal();
+          try {
+            await this.redis!.eval(UNLOCK_SCRIPT, 1, lockKey, token);
+            logger.debug('Distributed lock released', { key: lockKey });
+          } catch (err) {
+            logger.error('Failed to release distributed lock', err);
+          }
+        };
+
+        return { release };
+      }
+
+      if (attempt < retryCount) {
+        await sleep(retryDelayMs);
+      }
+    }
+
+    throw new Error(`Failed to acquire distributed lock for key "${key}" after ${retryCount + 1} attempts`);
+  }
+
+  /**
+   * Convenience wrapper: acquires a lock, runs `fn`, and always releases.
+   */
+  async withLock<T>(key: string, fn: () => Promise<T>, options?: AcquireOptions): Promise<T> {
+    const handle = await this.acquire(key, options);
+    try {
+      return await fn();
+    } finally {
+      await handle.release();
+    }
+  }
+}
+
+export const redisLockService = new RedisLockService();

--- a/backend/src/utils/__tests__/correlationContext.test.ts
+++ b/backend/src/utils/__tests__/correlationContext.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  getCorrelationId,
+  getCorrelationStore,
+  withCorrelationId,
+  generateCorrelationId,
+  CORRELATION_ID_HEADER,
+} from '../correlationContext.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('correlationContext', () => {
+  describe('CORRELATION_ID_HEADER', () => {
+    it('is the expected header name', () => {
+      expect(CORRELATION_ID_HEADER).toBe('x-correlation-id');
+    });
+  });
+
+  describe('generateCorrelationId', () => {
+    it('returns a valid UUID v4', () => {
+      expect(generateCorrelationId()).toMatch(UUID_RE);
+    });
+
+    it('returns a unique ID on each call', () => {
+      expect(generateCorrelationId()).not.toBe(generateCorrelationId());
+    });
+  });
+
+  describe('getCorrelationId outside context', () => {
+    it('returns undefined when no context is active', () => {
+      expect(getCorrelationId()).toBeUndefined();
+    });
+  });
+
+  describe('withCorrelationId', () => {
+    it('makes correlationId available inside the callback', () => {
+      const id = generateCorrelationId();
+      withCorrelationId(id, () => {
+        expect(getCorrelationId()).toBe(id);
+      });
+    });
+
+    it('makes the full store available inside the callback', () => {
+      const id = generateCorrelationId();
+      const reqId = generateCorrelationId();
+      withCorrelationId(id, () => {
+        const store = getCorrelationStore();
+        expect(store?.correlationId).toBe(id);
+        expect(store?.requestId).toBe(reqId);
+      }, reqId);
+    });
+
+    it('stores requestId when provided', () => {
+      const id = generateCorrelationId();
+      const reqId = 'req-123';
+      withCorrelationId(id, () => {
+        expect(getCorrelationStore()?.requestId).toBe(reqId);
+      }, reqId);
+    });
+
+    it('does not store requestId when omitted', () => {
+      const id = generateCorrelationId();
+      withCorrelationId(id, () => {
+        expect(getCorrelationStore()?.requestId).toBeUndefined();
+      });
+    });
+
+    it('context does not leak outside the callback', () => {
+      const id = generateCorrelationId();
+      withCorrelationId(id, () => {});
+      expect(getCorrelationId()).toBeUndefined();
+    });
+
+    it('supports nested contexts — inner wins', () => {
+      const outer = generateCorrelationId();
+      const inner = generateCorrelationId();
+      withCorrelationId(outer, () => {
+        withCorrelationId(inner, () => {
+          expect(getCorrelationId()).toBe(inner);
+        });
+        expect(getCorrelationId()).toBe(outer);
+      });
+    });
+
+    it('propagates through async operations', async () => {
+      const id = generateCorrelationId();
+      await withCorrelationId(id, async () => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(getCorrelationId()).toBe(id);
+      });
+    });
+
+    it('returns the callback return value', () => {
+      const result = withCorrelationId('some-id', () => 42);
+      expect(result).toBe(42);
+    });
+  });
+});

--- a/backend/src/utils/correlationContext.ts
+++ b/backend/src/utils/correlationContext.ts
@@ -1,0 +1,37 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { randomUUID } from 'crypto';
+
+export const CORRELATION_ID_HEADER = 'x-correlation-id';
+
+interface CorrelationStore {
+  correlationId: string;
+  /** Optional — links this unit of work back to an HTTP request. */
+  requestId?: string;
+}
+
+const correlationStorage = new AsyncLocalStorage<CorrelationStore>();
+
+export const getCorrelationId = (): string | undefined =>
+  correlationStorage.getStore()?.correlationId;
+
+export const getCorrelationStore = (): CorrelationStore | undefined =>
+  correlationStorage.getStore();
+
+/**
+ * Run `fn` inside an async context that carries `correlationId`.
+ * All logger calls made within `fn` (and any async code it spawns)
+ * will automatically include the correlation ID.
+ */
+export function withCorrelationId<T>(
+  correlationId: string,
+  fn: () => T,
+  requestId?: string,
+): T {
+  return correlationStorage.run({ correlationId, requestId }, fn);
+}
+
+/**
+ * Generate a fresh correlation ID.
+ * Use when no upstream ID is available (e.g. background jobs, cron tasks).
+ */
+export const generateCorrelationId = (): string => randomUUID();

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -2,6 +2,7 @@ import winston from 'winston';
 import { ElasticsearchTransport } from 'winston-elasticsearch';
 import { Client } from '@elastic/elasticsearch';
 import { getRequestId, REQUEST_ID_HEADER } from '../middlewares/requestIdMiddleware.js';
+import { getCorrelationId, CORRELATION_ID_HEADER } from './correlationContext.js';
 
 // ElasticsearchTransport's client type lags behind @elastic/elasticsearch v8;
 // cast via unknown to avoid declaration-file version conflicts.
@@ -23,37 +24,58 @@ const requestIdFormat = winston.format((info) => {
   return info;
 });
 
+// Inject the async-context correlation ID into every log entry automatically.
+const correlationIdFormat = winston.format((info) => {
+  const correlationId = getCorrelationId();
+  if (correlationId) {
+    (info as Record<string, unknown>)[CORRELATION_ID_HEADER] = correlationId;
+  }
+  return info;
+});
+
 // Console format: colorized for dev, JSON for prod
 const consoleFormat = isProduction
-  ? combine(requestIdFormat(), timestamp(), errors({ stack: true }), json())
+  ? combine(requestIdFormat(), correlationIdFormat(), timestamp(), errors({ stack: true }), json())
   : combine(
       requestIdFormat(),
+      correlationIdFormat(),
       colorize({ all: true }),
       timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
       errors({ stack: true }),
       printf(({ timestamp: ts, level, message, traceId, ...meta }) => {
         const requestId = (meta as Record<string, unknown>)[REQUEST_ID_HEADER];
+        const correlationId = (meta as Record<string, unknown>)[CORRELATION_ID_HEADER];
         const metaCopy = { ...meta };
         delete (metaCopy as Record<string, unknown>)[REQUEST_ID_HEADER];
+        delete (metaCopy as Record<string, unknown>)[CORRELATION_ID_HEADER];
         const metaStr = Object.keys(metaCopy).length ? ` ${JSON.stringify(metaCopy)}` : '';
         const traceStr = traceId ? ` [trace:${traceId}]` : '';
         const reqStr = requestId ? ` [req:${requestId}]` : '';
-        return `[${ts}] [${level}]${traceStr}${reqStr} ${message}${metaStr}`;
+        const corrStr = correlationId ? ` [corr:${correlationId}]` : '';
+        return `[${ts}] [${level}]${traceStr}${reqStr}${corrStr} ${message}${metaStr}`;
       }),
     );
+
+const fileFormat = combine(
+  requestIdFormat(),
+  correlationIdFormat(),
+  timestamp(),
+  errors({ stack: true }),
+  json(),
+);
 
 const transports: winston.transport[] = [
   new winston.transports.Console({ format: consoleFormat }),
   new winston.transports.File({
     filename: 'logs/error.log',
     level: 'error',
-    format: combine(requestIdFormat(), timestamp(), errors({ stack: true }), json()),
+    format: fileFormat,
     maxsize: 10 * 1024 * 1024, // 10 MB
     maxFiles: 5,
   }),
   new winston.transports.File({
     filename: 'logs/combined.log',
-    format: combine(requestIdFormat(), timestamp(), errors({ stack: true }), json()),
+    format: fileFormat,
     maxsize: 20 * 1024 * 1024, // 20 MB
     maxFiles: 10,
   }),

--- a/backend/src/workers/payrollWorker.ts
+++ b/backend/src/workers/payrollWorker.ts
@@ -22,6 +22,7 @@ import { Worker, Job } from 'bullmq';
 import { redisConnection, PAYROLL_QUEUE_NAME } from '../config/queue.js';
 import { PayrollBonusService } from '../services/payrollBonusService.js';
 import { PayrollJobData } from '../services/payrollQueueService.js';
+import { redisLockService } from '../services/redisLockService.js';
 import { StellarService } from '../services/stellarService.js';
 import { PayrollAuditService } from '../services/payrollAuditService.js';
 import { emitBulkUpdate } from '../services/socketService.js';
@@ -32,6 +33,10 @@ import { TransactionVerificationQueueService } from '../services/transactionVeri
 import taxService from '../services/taxService.js';
 import logger from '../utils/logger.js';
 import { withRetry } from '../utils/retry.js';
+import {
+  withCorrelationId,
+  generateCorrelationId,
+} from '../utils/correlationContext.js';
 import { Keypair, Asset, Operation, TransactionBuilder } from '@stellar/stellar-sdk';
 import { getAssetIssuer } from '../config/assets.js';
 
@@ -85,8 +90,22 @@ const txVerificationQueueService = TransactionVerificationQueueService;
 export const payrollWorker = new Worker<PayrollJobData>(
   PAYROLL_QUEUE_NAME,
   async (job: Job<PayrollJobData>) => {
-    const { payrollRunId } = job.data;
-    logger.info(`Processing payroll run ${payrollRunId} (Job: ${job.id})`);
+    const { payrollRunId, organizationId, correlationId: jobCorrelationId } = job.data;
+    const correlationId = jobCorrelationId ?? generateCorrelationId();
+
+    // Wrap the entire job execution in a correlation context so every log line
+    // emitted by this run (including nested service calls) carries the same ID.
+    return withCorrelationId(correlationId, async () => {
+    // Acquire a per-organization distributed lock to prevent two payroll runs
+    // for the same organization executing concurrently across multiple worker instances.
+    const lockKey = `payroll:org:${organizationId}`;
+    return redisLockService.withLock(
+      lockKey,
+      async () => {
+    logger.info(`Processing payroll run ${payrollRunId} (Job: ${job.id})`, {
+      organizationId,
+      correlationId,
+    });
 
     try {
       // ========================================
@@ -454,10 +473,14 @@ export const payrollWorker = new Worker<PayrollJobData>(
       // Re-throw to let BullMQ handle retry logic
       throw error;
     }
+    }, // end withLock callback
+    { ttlMs: 10 * 60 * 1000, retryCount: 3, retryDelayMs: 2000 }, // 10-min lock, 3 retries
+    ); // end redisLockService.withLock
+    }); // end withCorrelationId
   },
   {
     connection: redisConnection,
-    concurrency: 1, // Process one payroll run at a time to prevent race conditions
+    concurrency: 5,
   }
 );
 


### PR DESCRIPTION
## Summary

- **Redis distributed locking** (`RedisLockService`) prevents two payroll runs for the same organisation executing concurrently across horizontally-scaled worker instances. Uses `SET NX PX` for atomic acquisition, a Lua script for safe token-matched release, and a background renewal interval to keep long-running runs from expiring the lock mid-flight.
- **Correlation ID propagation** (`correlationContext.ts`) adds a per-operation `x-correlation-id` to every Winston log entry via `AsyncLocalStorage` — the same mechanism as the existing request-ID middleware. `PayrollQueueService` stamps a correlation ID onto each enqueued job (inheriting the HTTP caller's ID when available), and the payroll worker restores it at job start so all async log lines share a single traceable token.

## Changed files

| File | Change |
|---|---|
| `backend/src/services/redisLockService.ts` | New — `RedisLockService` with `acquire()` / `withLock()` / auto-renewal |
| `backend/src/utils/correlationContext.ts` | New — `AsyncLocalStorage` correlation ID context |
| `backend/src/utils/logger.ts` | Inject `x-correlation-id` into every log entry |
| `backend/src/services/payrollQueueService.ts` | Propagate correlation ID into job payload |
| `backend/src/workers/payrollWorker.ts` | Acquire org-scoped lock; restore correlation context per job |
| `backend/src/services/__tests__/redisLockService.test.ts` | 9 tests covering acquire, retry, release, withLock, no-Redis fallback |
| `backend/src/utils/__tests__/correlationContext.test.ts` | 10 tests covering context propagation, nesting, async, header constant |

Closes #1027
Closes #1028
Closes #1029
Closes #1032