### PR TITLE
feat: add comprehensive dependency health checks and migration safety tooling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,9 @@
     "test:benchmark": "ts-node src/benchmarks/sds-vs-horizon.benchmark.ts",
     "lint": "eslint src/**/*.ts",
     "db:migrate": "ts-node src/db/migrate.ts",
-    "db:migrate:dry-run": "ts-node src/db/migrate.ts --dry-run"
+    "db:migrate:dry-run": "ts-node src/db/migrate.ts --dry-run",
+    "db:migrate:skip-backup": "ts-node src/db/migrate.ts --skip-backup",
+    "db:migrate:rollback": "ts-node src/db/migrate.ts --rollback"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -58,6 +58,7 @@ const envSchema = z.object({
   STELLAR_EXPLORER_URL: z.string().default('https://stellar.expert/explorer/testnet/tx'),
   STELLAR_NETWORK: z.enum(['testnet', 'mainnet', 'public']).default('testnet'),
   STELLAR_HORIZON_URL: z.string().optional(),
+  STELLAR_SOROBAN_RPC_URL: z.string().optional(),
   STELLAR_MAX_RETRIES: z.string().default('3'),
   STELLAR_RETRY_DELAY_MS: z.string().default('1000'),
   STELLAR_RETRY_DELAY_MAX_MS: z.string().default('10000'),

--- a/backend/src/controllers/__tests__/healthController.test.ts
+++ b/backend/src/controllers/__tests__/healthController.test.ts
@@ -1,20 +1,25 @@
 import request from 'supertest';
 import express from 'express';
-import { HealthController } from '../healthController.js';
-import { pool } from '../../config/database.js';
 import { Redis } from 'ioredis';
+import { Client as ElasticsearchClient } from '@elastic/elasticsearch';
 
 jest.mock('../../config/env', () => ({
   config: {
     DATABASE_URL: 'postgres://mock',
     REDIS_URL: 'redis://mock',
     NODE_ENV: 'test',
+    EMAIL_PROVIDER: 'resend',
+    RESEND_API_KEY: undefined,
+    SENDGRID_API_KEY: undefined,
   },
 }));
 
 jest.mock('../../config/database.js', () => ({
   pool: {
     query: jest.fn(),
+    totalCount: 5,
+    idleCount: 3,
+    waitingCount: 0,
   },
 }));
 
@@ -26,6 +31,21 @@ jest.mock('ioredis', () => {
   return { Redis: jest.fn(() => mRedis) };
 });
 
+jest.mock('@elastic/elasticsearch', () => {
+  const mClient = { ping: jest.fn() };
+  return { Client: jest.fn(() => mClient) };
+});
+
+jest.mock('../../stellar/index.js', () => ({
+  testConnection: jest.fn(),
+  testSorobanConnection: jest.fn(),
+}));
+
+// Imports AFTER the jest.mock calls above so the mocked modules are used.
+import { pool } from '../../config/database.js';
+import { testConnection, testSorobanConnection } from '../../stellar/index.js';
+import { HealthController, _resetHealthCacheForTests } from '../healthController.js';
+
 const app = express();
 app.get('/api/health', HealthController.getHealthStatus);
 app.get('/api/v1/health', HealthController.getHealthStatus);
@@ -35,29 +55,55 @@ app.get('/api/v1/health/ready', HealthController.getReadiness);
 app.get('/health/live', HealthController.getLiveness);
 app.get('/health/ready', HealthController.getReadiness);
 
+function mockHealthyStellar() {
+  (testConnection as jest.Mock).mockResolvedValue({
+    connected: true,
+    network: 'testnet',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    latencyMs: 12,
+    ledgerSequence: 100,
+  });
+  (testSorobanConnection as jest.Mock).mockResolvedValue({
+    configured: true,
+    connected: true,
+    network: 'testnet',
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    latencyMs: 8,
+  });
+}
+
 describe('HealthController health endpoints', () => {
   let redisClient: any;
+  let esClient: any;
 
   beforeEach(() => {
     redisClient = new Redis();
+    esClient = new ElasticsearchClient();
+    _resetHealthCacheForTests();
     jest.clearAllMocks();
+    mockHealthyStellar();
   });
 
-  it('returns 200 OK from /api/health when database and redis are healthy', async () => {
+  it('returns 200 healthy from /api/health when all dependencies are healthy', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
     redisClient.ping.mockResolvedValueOnce('PONG');
 
     const response = await request(app).get('/api/health');
 
     expect(response.status).toBe(200);
-    expect(response.body.status).toBe('ok');
+    expect(response.body.status).toBe('healthy');
     expect(response.body.environment.name).toBe('test');
     expect(response.body.system.memoryUsage).toBeDefined();
     expect(response.body.system.platform).toBeDefined();
-    expect(response.body.dependencies.database.status).toBe('connected');
+
+    expect(response.body.dependencies.database.status).toBe('healthy');
     expect(response.body.dependencies.database.latencyMs).toBeDefined();
-    expect(response.body.dependencies.redis.status).toBe('connected');
-    expect(response.body.dependencies.redis.latencyMs).toBeDefined();
+    expect(response.body.dependencies.redis.status).toBe('healthy');
+    expect(response.body.dependencies.stellarHorizon.status).toBe('healthy');
+    expect(response.body.dependencies.stellarSoroban.status).toBe('healthy');
+    // Elasticsearch and email are not configured in this mock env.
+    expect(response.body.dependencies.elasticsearch.status).toBe('not_configured');
+    expect(response.body.dependencies.email.status).toBe('not_configured');
   });
 
   it('keeps the legacy /health endpoint working', async () => {
@@ -67,43 +113,180 @@ describe('HealthController health endpoints', () => {
     const response = await request(app).get('/health');
 
     expect(response.status).toBe(200);
-    expect(response.body.status).toBe('ok');
+    expect(response.body.status).toBe('healthy');
   });
 
-  it('returns 200 OK from /api/v1/health when database and redis are healthy', async () => {
-    pool.query.mockResolvedValueOnce({ rows: [] });
+  it('returns 200 healthy from /api/v1/health when all dependencies are healthy', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
     redisClient.ping.mockResolvedValueOnce('PONG');
 
     const response = await request(app).get('/api/v1/health');
 
     expect(response.status).toBe(200);
-    expect(response.body.status).toBe('ok');
-    expect(response.body.dependencies.database.status).toBe('connected');
-    expect(response.body.dependencies.redis.status).toBe('connected');
+    expect(response.body.status).toBe('healthy');
   });
 
-  it('returns 503 Degraded when Postgres goes down', async () => {
+  it('returns 503 unhealthy when Postgres (critical) goes down', async () => {
     (pool.query as jest.Mock).mockRejectedValueOnce(new Error('Connection forced closed'));
     redisClient.ping.mockResolvedValueOnce('PONG');
 
     const response = await request(app).get('/api/health');
 
     expect(response.status).toBe(503);
-    expect(response.body.status).toBe('degraded');
-    expect(response.body.dependencies.database.status).toBe('disconnected');
+    expect(response.body.status).toBe('unhealthy');
+    expect(response.body.dependencies.database.status).toBe('unhealthy');
+    expect(response.body.dependencies.database.critical).toBe(true);
     expect(response.body.dependencies.database.error).toBe('Connection forced closed');
   });
 
-  it('returns 503 Degraded when Redis fails', async () => {
+  it('returns 503 unhealthy when Redis (critical) fails', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
     redisClient.ping.mockRejectedValueOnce(new Error('Redis timeout'));
 
     const response = await request(app).get('/api/health');
 
     expect(response.status).toBe(503);
-    expect(response.body.status).toBe('degraded');
-    expect(response.body.dependencies.redis.status).toBe('disconnected');
+    expect(response.body.status).toBe('unhealthy');
+    expect(response.body.dependencies.redis.status).toBe('unhealthy');
     expect(response.body.dependencies.redis.error).toBe('Redis timeout');
+  });
+
+  it('returns 503 unhealthy when Stellar Horizon (critical) is unreachable', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    redisClient.ping.mockResolvedValueOnce('PONG');
+    (testConnection as jest.Mock).mockResolvedValueOnce({
+      connected: false,
+      network: 'testnet',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      latencyMs: 2001,
+      error: 'timed out',
+    });
+
+    const response = await request(app).get('/api/health');
+
+    expect(response.status).toBe(503);
+    expect(response.body.status).toBe('unhealthy');
+    expect(response.body.dependencies.stellarHorizon.status).toBe('unhealthy');
+    expect(response.body.dependencies.stellarHorizon.critical).toBe(true);
+  });
+
+  it('returns 200 degraded (not unhealthy) when only Elasticsearch (non-critical) is down', async () => {
+    const originalEsEnabled = process.env.ELASTICSEARCH_ENABLED;
+    process.env.ELASTICSEARCH_ENABLED = 'true';
+
+    jest.resetModules();
+    jest.doMock('../../config/env', () => ({
+      config: {
+        DATABASE_URL: 'postgres://mock',
+        REDIS_URL: 'redis://mock',
+        NODE_ENV: 'test',
+        EMAIL_PROVIDER: 'resend',
+        RESEND_API_KEY: undefined,
+        SENDGRID_API_KEY: undefined,
+      },
+    }));
+    jest.doMock('../../config/database.js', () => ({
+      pool: { query: jest.fn().mockResolvedValue({ rows: [] }), totalCount: 1, idleCount: 1, waitingCount: 0 },
+    }));
+    jest.doMock('ioredis', () => {
+      const mRedis = { ping: jest.fn().mockResolvedValue('PONG'), on: jest.fn() };
+      return { Redis: jest.fn(() => mRedis) };
+    });
+    jest.doMock('@elastic/elasticsearch', () => {
+      const mClient = { ping: jest.fn().mockRejectedValue(new Error('ES unreachable')) };
+      return { Client: jest.fn(() => mClient) };
+    });
+    jest.doMock('../../stellar/index.js', () => ({
+      testConnection: jest.fn().mockResolvedValue({ connected: true, network: 'testnet', horizonUrl: 'x', latencyMs: 1 }),
+      testSorobanConnection: jest
+        .fn()
+        .mockResolvedValue({ configured: false, connected: false, network: 'testnet', rpcUrl: '', latencyMs: 0 }),
+    }));
+
+    const { HealthController: FreshHealthController } = await import('../healthController.js');
+    const freshApp = express();
+    freshApp.get('/api/health', FreshHealthController.getHealthStatus);
+
+    const response = await request(freshApp).get('/api/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('degraded');
+    expect(response.body.dependencies.elasticsearch.status).toBe('unhealthy');
+    expect(response.body.dependencies.elasticsearch.critical).toBe(false);
+
+    if (originalEsEnabled === undefined) delete process.env.ELASTICSEARCH_ENABLED;
+    else process.env.ELASTICSEARCH_ENABLED = originalEsEnabled;
+    jest.dontMock('../../config/env');
+    jest.dontMock('../../config/database.js');
+    jest.dontMock('ioredis');
+    jest.dontMock('@elastic/elasticsearch');
+    jest.dontMock('../../stellar/index.js');
+  });
+
+  it('marks email as unhealthy (non-critical => degraded) when the provider auth fails', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    redisClient.ping.mockResolvedValueOnce('PONG');
+
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({ status: 401 }) as any;
+
+    jest.resetModules();
+    jest.doMock('../../config/env', () => ({
+      config: {
+        DATABASE_URL: 'postgres://mock',
+        REDIS_URL: 'redis://mock',
+        NODE_ENV: 'test',
+        EMAIL_PROVIDER: 'resend',
+        RESEND_API_KEY: 'test-key',
+        SENDGRID_API_KEY: undefined,
+      },
+    }));
+    jest.doMock('../../config/database.js', () => ({
+      pool: { query: jest.fn().mockResolvedValue({ rows: [] }), totalCount: 1, idleCount: 1, waitingCount: 0 },
+    }));
+    jest.doMock('ioredis', () => {
+      const mRedis = { ping: jest.fn().mockResolvedValue('PONG'), on: jest.fn() };
+      return { Redis: jest.fn(() => mRedis) };
+    });
+    jest.doMock('../../stellar/index.js', () => ({
+      testConnection: jest.fn().mockResolvedValue({ connected: true, network: 'testnet', horizonUrl: 'x', latencyMs: 1 }),
+      testSorobanConnection: jest.fn().mockResolvedValue({ configured: false, connected: false, network: 'testnet', rpcUrl: '', latencyMs: 0 }),
+    }));
+
+    const { HealthController: FreshHealthController } = await import('../healthController.js');
+    const freshApp = express();
+    freshApp.get('/api/health', FreshHealthController.getHealthStatus);
+
+    const response = await request(freshApp).get('/api/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('degraded');
+    expect(response.body.dependencies.email.status).toBe('unhealthy');
+    expect(response.body.dependencies.email.critical).toBe(false);
+
+    global.fetch = originalFetch;
+    jest.dontMock('../../config/env');
+    jest.dontMock('../../config/database.js');
+    jest.dontMock('ioredis');
+    jest.dontMock('../../stellar/index.js');
+  });
+
+  it('serves a cached result within the 5-second TTL instead of re-checking dependencies', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [] });
+    redisClient.ping.mockResolvedValue('PONG');
+
+    const first = await request(app).get('/api/health');
+    expect(first.status).toBe(200);
+    expect(first.body.cached).toBe(false);
+
+    const callsAfterFirst = (pool.query as jest.Mock).mock.calls.length;
+
+    const second = await request(app).get('/api/health');
+    expect(second.status).toBe(200);
+    expect(second.body.cached).toBe(true);
+
+    // No additional dependency calls should have been made for the cached response.
+    expect((pool.query as jest.Mock).mock.calls.length).toBe(callsAfterFirst);
   });
 });
 
@@ -136,10 +319,12 @@ describe('HealthController readiness probe', () => {
 
   beforeEach(() => {
     redisClient = new Redis();
+    _resetHealthCacheForTests();
     jest.clearAllMocks();
+    mockHealthyStellar();
   });
 
-  it('GET /api/v1/health/ready returns 200 when database and redis are reachable', async () => {
+  it('GET /api/v1/health/ready returns 200 when all critical dependencies are reachable', async () => {
     (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
     redisClient.ping.mockResolvedValueOnce('PONG');
 
@@ -147,8 +332,8 @@ describe('HealthController readiness probe', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.status).toBe('ready');
-    expect(response.body.checks.database.status).toBe('connected');
-    expect(response.body.checks.redis.status).toBe('connected');
+    expect(response.body.checks.database.status).toBe('healthy');
+    expect(response.body.checks.redis.status).toBe('healthy');
   });
 
   it('GET /api/v1/health/ready returns 503 when database is down', async () => {
@@ -159,7 +344,7 @@ describe('HealthController readiness probe', () => {
 
     expect(response.status).toBe(503);
     expect(response.body.status).toBe('not_ready');
-    expect(response.body.checks.database.status).toBe('disconnected');
+    expect(response.body.checks.database.status).toBe('unhealthy');
     expect(response.body.checks.database.error).toBe('ECONNREFUSED');
   });
 
@@ -171,7 +356,26 @@ describe('HealthController readiness probe', () => {
 
     expect(response.status).toBe(503);
     expect(response.body.status).toBe('not_ready');
-    expect(response.body.checks.redis.status).toBe('disconnected');
+    expect(response.body.checks.redis.status).toBe('unhealthy');
+  });
+
+  it('GET /api/v1/health/ready returns 503 when Stellar Soroban RPC (critical, when configured) is unreachable', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    redisClient.ping.mockResolvedValueOnce('PONG');
+    (testSorobanConnection as jest.Mock).mockResolvedValueOnce({
+      configured: true,
+      connected: false,
+      network: 'testnet',
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      latencyMs: 2001,
+      error: 'timed out',
+    });
+
+    const response = await request(app).get('/api/v1/health/ready');
+
+    expect(response.status).toBe(503);
+    expect(response.body.status).toBe('not_ready');
+    expect(response.body.checks.stellarSoroban.status).toBe('unhealthy');
   });
 
   it('GET /health/ready also works on the short path', async () => {

--- a/backend/src/controllers/healthController.ts
+++ b/backend/src/controllers/healthController.ts
@@ -1,10 +1,11 @@
 import { Request, Response } from 'express';
 import { Redis } from 'ioredis';
+import { Client as ElasticsearchClient } from '@elastic/elasticsearch';
 import { pool } from '../config/database.js';
 import { config } from '../config/env.js';
 import logger from '../utils/logger.js';
 import { ThrottlingService } from '../services/throttlingService.js';
-import { register as metricsRegister } from '../utils/metrics.js';
+import { testConnection, testSorobanConnection } from '../stellar/index.js';
 
 // Import shutdown state from index.ts (#1048)
 let isShuttingDown = false;
@@ -38,8 +39,31 @@ if (config.REDIS_URL) {
   }
 }
 
+/**
+ * Elasticsearch (#1038) — only instantiated when explicitly enabled.
+ * Non-critical dependency: an outage degrades overall health but never
+ * takes the instance out of rotation.
+ */
+const ELASTICSEARCH_ENABLED = process.env.ELASTICSEARCH_ENABLED === 'true';
+const ELASTICSEARCH_URL = process.env.ELASTICSEARCH_URL || 'http://localhost:9200';
+let elasticsearchClient: ElasticsearchClient | null = null;
+if (ELASTICSEARCH_ENABLED) {
+  try {
+    elasticsearchClient = new ElasticsearchClient({ node: ELASTICSEARCH_URL });
+  } catch (err) {
+    logger.error('Failed to initialize Health Check Elasticsearch client', err);
+  }
+}
+
+/** Per-dependency check timeout (#1038 acceptance criterion: 2 seconds max). */
+export const DEPENDENCY_CHECK_TIMEOUT_MS = 2000;
+
+/** How long a computed health report may be served from cache (#1038: 5 seconds). */
+export const HEALTH_CACHE_TTL_MS = 5000;
+
 export interface DependencyStatus {
-  status: 'connected' | 'disconnected' | 'not_configured' | 'unknown';
+  status: 'healthy' | 'unhealthy' | 'not_configured';
+  critical: boolean;
   error?: string;
   latencyMs?: number;
 }
@@ -57,8 +81,20 @@ export interface ThrottlingStatusSummary {
   tpm: number;
 }
 
+export interface DependencyMap {
+  database: DependencyStatus;
+  redis: DependencyStatus;
+  stellarHorizon: DependencyStatus;
+  stellarSoroban: DependencyStatus;
+  elasticsearch: DependencyStatus;
+  email: DependencyStatus;
+}
+
+export type OverallHealthStatus = 'healthy' | 'degraded' | 'unhealthy';
+
 export interface HealthStatusResponse {
-  status: 'ok' | 'degraded';
+  status: OverallHealthStatus;
+  cached: boolean;
   timestamp: string;
   uptime: number;
   version: string;
@@ -73,10 +109,7 @@ export interface HealthStatusResponse {
   };
   pool?: PoolStatus;
   throttling?: ThrottlingStatusSummary;
-  dependencies: {
-    database: DependencyStatus;
-    redis: DependencyStatus;
-  };
+  dependencies: DependencyMap;
 }
 
 function measureEventLoopLag(): Promise<number> {
@@ -86,11 +119,211 @@ function measureEventLoopLag(): Promise<number> {
   });
 }
 
+/**
+ * Race a dependency check against a fixed timeout so one slow/hanging
+ * dependency can never block the whole health endpoint (#1038: 2s max).
+ */
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} check timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+// ─── Individual dependency checks ───────────────────────────────────────────
+
+async function checkDatabase(): Promise<DependencyStatus> {
+  const start = Date.now();
+  try {
+    await withTimeout(pool.query('SELECT 1'), DEPENDENCY_CHECK_TIMEOUT_MS, 'database');
+    return { status: 'healthy', critical: true, latencyMs: Date.now() - start };
+  } catch (error: any) {
+    logger.error('Health Check: Database connection failed', error);
+    return { status: 'unhealthy', critical: true, latencyMs: Date.now() - start, error: error.message };
+  }
+}
+
+async function checkRedis(): Promise<DependencyStatus> {
+  if (!redisClient) {
+    return { status: 'not_configured', critical: true };
+  }
+  const start = Date.now();
+  try {
+    await withTimeout(redisClient.ping(), DEPENDENCY_CHECK_TIMEOUT_MS, 'redis');
+    return { status: 'healthy', critical: true, latencyMs: Date.now() - start };
+  } catch (error: any) {
+    logger.error('Health Check: Redis connection failed', error);
+    return { status: 'unhealthy', critical: true, latencyMs: Date.now() - start, error: error.message };
+  }
+}
+
+async function checkStellarHorizon(): Promise<DependencyStatus> {
+  const start = Date.now();
+  try {
+    const result = await withTimeout(testConnection(), DEPENDENCY_CHECK_TIMEOUT_MS, 'stellar horizon');
+    if (!result.connected) {
+      return {
+        status: 'unhealthy',
+        critical: true,
+        latencyMs: result.latencyMs ?? Date.now() - start,
+        error: result.error || 'Stellar Horizon connection failed',
+      };
+    }
+    return { status: 'healthy', critical: true, latencyMs: result.latencyMs };
+  } catch (error: any) {
+    logger.error('Health Check: Stellar Horizon connection failed', error);
+    return { status: 'unhealthy', critical: true, latencyMs: Date.now() - start, error: error.message };
+  }
+}
+
+async function checkStellarSoroban(): Promise<DependencyStatus> {
+  const start = Date.now();
+  try {
+    const result = await withTimeout(testSorobanConnection(), DEPENDENCY_CHECK_TIMEOUT_MS, 'stellar soroban');
+    if (!result.configured) {
+      return { status: 'not_configured', critical: true };
+    }
+    if (!result.connected) {
+      return {
+        status: 'unhealthy',
+        critical: true,
+        latencyMs: result.latencyMs ?? Date.now() - start,
+        error: result.error || 'Soroban RPC connection failed',
+      };
+    }
+    return { status: 'healthy', critical: true, latencyMs: result.latencyMs };
+  } catch (error: any) {
+    logger.error('Health Check: Stellar Soroban RPC connection failed', error);
+    return { status: 'unhealthy', critical: true, latencyMs: Date.now() - start, error: error.message };
+  }
+}
+
+async function checkElasticsearch(): Promise<DependencyStatus> {
+  if (!ELASTICSEARCH_ENABLED || !elasticsearchClient) {
+    return { status: 'not_configured', critical: false };
+  }
+  const start = Date.now();
+  try {
+    await withTimeout(elasticsearchClient.ping(), DEPENDENCY_CHECK_TIMEOUT_MS, 'elasticsearch');
+    return { status: 'healthy', critical: false, latencyMs: Date.now() - start };
+  } catch (error: any) {
+    logger.warn('Health Check: Elasticsearch connection failed', { error: error.message });
+    return { status: 'unhealthy', critical: false, latencyMs: Date.now() - start, error: error.message };
+  }
+}
+
+/**
+ * Lightweight, read-only reachability check for the configured email
+ * provider (SendGrid or Resend). Deliberately does NOT reuse the providers'
+ * `validateConfig()` methods, which send a real (if intentionally-invalid)
+ * email on every call — unacceptable for a check that runs on a health-check
+ * hot path. Instead this hits a read-only, authenticated account/domains
+ * endpoint that sends nothing.
+ */
+async function checkEmail(): Promise<DependencyStatus> {
+  const provider = config.EMAIL_PROVIDER;
+  const apiKey = provider === 'sendgrid' ? config.SENDGRID_API_KEY : config.RESEND_API_KEY;
+
+  if (!apiKey) {
+    return { status: 'not_configured', critical: false };
+  }
+
+  const start = Date.now();
+  const url =
+    provider === 'sendgrid' ? 'https://api.sendgrid.com/v3/user/account' : 'https://api.resend.com/domains';
+
+  try {
+    const response = await withTimeout(
+      fetch(url, { method: 'GET', headers: { Authorization: `Bearer ${apiKey}` } }),
+      DEPENDENCY_CHECK_TIMEOUT_MS,
+      `email (${provider})`
+    );
+    const latencyMs = Date.now() - start;
+
+    // 401/403 means the configured key is invalid — a real, actionable outage.
+    if (response.status === 401 || response.status === 403) {
+      return {
+        status: 'unhealthy',
+        critical: false,
+        latencyMs,
+        error: `${provider} authentication failed (HTTP ${response.status})`,
+      };
+    }
+
+    // Any other response (including 2xx/4xx for the account/domains endpoint)
+    // means the provider is reachable and processing authenticated requests.
+    return { status: 'healthy', critical: false, latencyMs };
+  } catch (error: any) {
+    logger.warn(`Health Check: ${provider} connection failed`, { error: error.message });
+    return { status: 'unhealthy', critical: false, latencyMs: Date.now() - start, error: error.message };
+  }
+}
+
+// ─── Aggregation + 5s cache (#1038) ──────────────────────────────────────────
+
+interface CachedReport {
+  dependencies: DependencyMap;
+  overallStatus: OverallHealthStatus;
+  computedAt: number;
+}
+
+let cachedReport: CachedReport | null = null;
+
+/** Test-only hook to reset the in-memory health-check cache between tests. */
+export function _resetHealthCacheForTests(): void {
+  cachedReport = null;
+}
+
+function computeOverallStatus(dependencies: DependencyMap): OverallHealthStatus {
+  const values = Object.values(dependencies);
+  const criticalUnhealthy = values.some((d) => d.critical && d.status === 'unhealthy');
+  if (criticalUnhealthy) return 'unhealthy';
+
+  const nonCriticalUnhealthy = values.some((d) => !d.critical && d.status === 'unhealthy');
+  if (nonCriticalUnhealthy) return 'degraded';
+
+  return 'healthy';
+}
+
+/**
+ * Runs all dependency checks in parallel and caches the result for
+ * `HEALTH_CACHE_TTL_MS` (5 seconds) so repeated health/readiness probes
+ * (common under k8s, which polls every few seconds) don't hammer every
+ * external dependency on every single request (#1038).
+ */
+async function getDependencyReport(): Promise<CachedReport> {
+  const now = Date.now();
+  if (cachedReport && now - cachedReport.computedAt < HEALTH_CACHE_TTL_MS) {
+    return cachedReport;
+  }
+
+  const [database, redis, stellarHorizon, stellarSoroban, elasticsearch, email] = await Promise.all([
+    checkDatabase(),
+    checkRedis(),
+    checkStellarHorizon(),
+    checkStellarSoroban(),
+    checkElasticsearch(),
+    checkEmail(),
+  ]);
+
+  const dependencies: DependencyMap = { database, redis, stellarHorizon, stellarSoroban, elasticsearch, email };
+  const overallStatus = computeOverallStatus(dependencies);
+
+  cachedReport = { dependencies, overallStatus, computedAt: now };
+  return cachedReport;
+}
+
 export class HealthController {
   /**
    * GET /health/live  (liveness probe)
-   * Returns 200 immediately — no dependency checks. Used by k8s/Docker to
-   * confirm the process is alive. Should never block or timeout.
+   * Returns 200 immediately — no dependency checks, no cache lookup. Used by
+   * k8s/Docker to confirm the process is alive and the event loop is not
+   * deadlocked. Should never block or timeout.
    */
   static getLiveness(_req: Request, res: Response): void {
     res.status(200).json({
@@ -102,9 +335,11 @@ export class HealthController {
 
   /**
    * GET /health/ready  (readiness probe)
-   * Returns 200 if all critical dependencies are reachable, 503 otherwise.
-   * Used by load-balancers to gate traffic until the instance is ready.
-   * Returns 503 during graceful shutdown (#1048).
+   * Returns 200 only if all CRITICAL dependencies (Postgres, Redis if
+   * configured, Stellar Horizon, Stellar Soroban RPC if configured) are
+   * healthy; 503 otherwise. A non-critical dependency (Elasticsearch, email)
+   * being down never blocks readiness. Returns 503 during graceful shutdown
+   * (#1048). Shares the same 5s cache as /health (#1038).
    */
   static async getReadiness(_req: Request, res: Response): Promise<void> {
     // Return 503 if shutting down
@@ -121,48 +356,43 @@ export class HealthController {
       // If can't import, proceed with normal checks
     }
 
-    const checks: { database: DependencyStatus; redis: DependencyStatus } = {
-      database: { status: 'unknown' },
-      redis: { status: 'unknown' },
-    };
-    let ready = true;
+    const { dependencies } = await getDependencyReport();
 
-    const dbStart = Date.now();
-    try {
-      await pool.query('SELECT 1');
-      checks.database = { status: 'connected', latencyMs: Date.now() - dbStart };
-    } catch (error: any) {
-      ready = false;
-      checks.database = { status: 'disconnected', error: error.message };
-      logger.error('Readiness check: database unavailable', error);
-    }
-
-    if (redisClient) {
-      const redisStart = Date.now();
-      try {
-        await redisClient.ping();
-        checks.redis = { status: 'connected', latencyMs: Date.now() - redisStart };
-      } catch (error: any) {
-        ready = false;
-        checks.redis = { status: 'disconnected', error: error.message };
-        logger.error('Readiness check: redis unavailable', error);
-      }
-    } else {
-      checks.redis = { status: 'not_configured' };
-    }
+    // "not_configured" critical deps (e.g. Redis not wired up in this
+    // environment) are an intentional operator choice, not a failure — only
+    // an actively-unreachable critical dependency blocks readiness.
+    const ready = Object.values(dependencies).every((d) => !d.critical || d.status !== 'unhealthy');
 
     const httpStatus = ready ? 200 : 503;
     res.status(httpStatus).json({
       status: ready ? 'ready' : 'not_ready',
       timestamp: new Date().toISOString(),
-      checks,
+      checks: dependencies,
     });
   }
 
+  /**
+   * GET /health  (comprehensive health check, #1038)
+   * Returns per-dependency status (healthy/degraded/unhealthy) with latency
+   * in ms for every external dependency: PostgreSQL, Redis, Stellar Horizon,
+   * Stellar Soroban RPC, Elasticsearch, and the configured email provider.
+   * A non-critical dependency failure degrades overall status to
+   * "degraded" (still 200 OK); a critical dependency failure returns
+   * "unhealthy" (503). Cached for 5 seconds; each individual check is
+   * bounded by a 2-second timeout.
+   */
   static async getHealthStatus(_req: Request, res: Response) {
-    const start = Date.now();
+    const eventLoopLag = await measureEventLoopLag();
+    if (eventLoopLag > 1000) {
+      logger.warn('High event loop lag detected', { lagMs: eventLoopLag });
+    }
+
+    const wasCachedBefore = cachedReport !== null && Date.now() - cachedReport.computedAt < HEALTH_CACHE_TTL_MS;
+    const { dependencies, overallStatus } = await getDependencyReport();
+
     const statusReport: HealthStatusResponse = {
-      status: 'ok',
+      status: overallStatus,
+      cached: wasCachedBefore,
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
       version: process.env.npm_package_version || '1.0.0',
@@ -173,61 +403,17 @@ export class HealthController {
       system: {
         memoryUsage: process.memoryUsage(),
         platform: process.platform,
+        eventLoopLag,
       },
-      dependencies: {
-        database: { status: 'unknown' },
-        redis: { status: 'unknown' },
-      },
+      dependencies,
     };
 
-    let isHealthy = true;
-
-    const eventLoopLag = await measureEventLoopLag();
-    statusReport.system.eventLoopLag = eventLoopLag;
-
-    if (eventLoopLag > 1000) {
-      logger.warn('High event loop lag detected', { lagMs: eventLoopLag });
-    }
-
-    const dbStart = Date.now();
-    try {
-      await pool.query('SELECT 1');
-      statusReport.dependencies.database = {
-        status: 'connected',
-        latencyMs: Date.now() - dbStart,
-      };
+    if (dependencies.database.status === 'healthy') {
       statusReport.pool = {
         total: pool.totalCount,
         idle: pool.idleCount,
         waiting: pool.waitingCount,
       };
-    } catch (error: any) {
-      isHealthy = false;
-      statusReport.dependencies.database = {
-        status: 'disconnected',
-        error: error.message,
-      };
-      logger.error('Health Check: Database connection failed', error);
-    }
-
-    if (redisClient) {
-      const redisStart = Date.now();
-      try {
-        await redisClient.ping();
-        statusReport.dependencies.redis = {
-          status: 'connected',
-          latencyMs: Date.now() - redisStart,
-        };
-      } catch (error: any) {
-        isHealthy = false;
-        statusReport.dependencies.redis = {
-          status: 'disconnected',
-          error: error.message,
-        };
-        logger.error('Health Check: Redis connection failed', error);
-      }
-    } else {
-      statusReport.dependencies.redis = { status: 'not_configured' };
     }
 
     const throttlingStatus = ThrottlingService.getInstance().getStatus();
@@ -238,11 +424,7 @@ export class HealthController {
       tpm: throttlingStatus.tpm,
     };
 
-    if (!isHealthy) {
-      statusReport.status = 'degraded';
-      return res.status(503).json(statusReport);
-    }
-
-    return res.status(200).json(statusReport);
+    const httpStatus = overallStatus === 'unhealthy' ? 503 : 200;
+    return res.status(httpStatus).json(statusReport);
   }
 }

--- a/backend/src/controllers/migrationStatusController.ts
+++ b/backend/src/controllers/migrationStatusController.ts
@@ -47,4 +47,36 @@ export class MigrationStatusController {
       next(err);
     }
   }
+
+  /**
+   * GET /api/v1/migrations/history
+   * Full history of migration execution attempts (success/failure/dry-run),
+   * ordered most-recent first (#1039).
+   */
+  static async getRunHistory(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const limit = Math.min(Number(req.query['limit'] ?? 20), 100);
+      const history = await service.getRunHistory(limit);
+      res.json({ success: true, data: history, count: history.length });
+    } catch (err) {
+      logger.error({ err }, '[MigrationStatusController] getRunHistory failed');
+      next(err);
+    }
+  }
+
+  /**
+   * GET /api/v1/migrations/history/summary
+   * Aggregate success/failure counts over the most recent runs, plus the
+   * most recent failure (if any) — useful for a single at-a-glance health check.
+   */
+  static async getRunSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const limit = Math.min(Number(req.query['limit'] ?? 50), 100);
+      const summary = await service.getRunSummary(limit);
+      res.json({ success: true, data: summary });
+    } catch (err) {
+      logger.error({ err }, '[MigrationStatusController] getRunSummary failed');
+      next(err);
+    }
+  }
 }

--- a/backend/src/db/MIGRATION_GUIDE.md
+++ b/backend/src/db/MIGRATION_GUIDE.md
@@ -12,9 +12,10 @@
 3. [How to Create a New Migration](#3-how-to-create-a-new-migration)
 4. [How to Create a Rollback File](#4-how-to-create-a-rollback-file)
 5. [The Re-Sequencing Script](#5-the-re-sequencing-script)
-6. [Troubleshooting](#6-troubleshooting)
-7. [PR Checklist for Migration Authors](#7-pr-checklist-for-migration-authors)
-8. [Quick Reference](#8-quick-reference)
+6. [Migration Safety Features (#1039)](#6-migration-safety-features-1039)
+7. [Troubleshooting](#7-troubleshooting)
+8. [PR Checklist for Migration Authors](#8-pr-checklist-for-migration-authors)
+9. [Quick Reference](#9-quick-reference)
 
 ---
 
@@ -237,7 +238,36 @@ git add --renormalize backend/src/db/
 
 ---
 
-## 6. Troubleshooting
+## 6. Migration Safety Features (#1039)
+
+The runner (`backend/src/db/migrate.ts`) includes several safety nets on top of
+the checksum/idempotency guarantees described above:
+
+| Feature | Behaviour |
+|---|---|
+| **Pre-migration backup** | Before applying any pending migration, the runner shells out to `pg_dump --format=custom` and writes a timestamped backup to `MIGRATION_BACKUP_DIR` (default `backend/backups/`). On by default; skip with `--skip-backup` or `MIGRATION_SKIP_BACKUP=true` for local/dev iteration only — never in production. |
+| **Dry-run SQL plan** | `--dry-run` performs one read-only query to determine which migrations are actually pending, then renders the **literal SQL that would run** for each of them into a single reviewable file under `<backup dir>/dry-run-plans/`. If `DATABASE_URL` isn't set at all, dry-run still works fully offline (treating every file as pending) — useful for CI or reviewing a plan with no DB access. |
+| **Migration lock (30s timeout)** | Before touching the database, the runner acquires a Postgres advisory lock (`pg_try_advisory_lock`, polled) so two migration runs can never race. Gives up and aborts after 30 seconds if another run already holds it. The session `lock_timeout` is also set to 30s, bounding any row/table lock the migration's own DDL might wait on. |
+| **Post-migration verification** | After each migration's SQL runs (still inside its transaction, before COMMIT), the runner checks for any `NOT VALID` index or `NOT VALIDATED` constraint left in the database. A failure here still triggers a full `ROLLBACK` of that migration — nothing partial is ever left committed. |
+| **Run log (success + failure history)** | Every execution attempt — success, failure, or dry-run — is recorded in `migration_run_log` (bootstrapped inline, so it exists even before migration `055_create_migration_run_log.sql` itself has run). Exposed via `GET /api/v1/migrations/history` and `GET /api/v1/migrations/history/summary`. |
+| **Failure alert + auto-rollback** | A failed migration logs a loud, greppable `ALERT alert=MIGRATION_FAILED` block (the same "structured log, no external service yet" pattern used elsewhere in this codebase — see `backupVerificationWorker.ts`) and automatically attempts to execute the matching rollback script as a defense-in-depth safety net, even though the migration's own transaction has already been rolled back. |
+
+### Rollback coverage
+
+Every one of the 56 files in `migrations/` has an exact-name match in
+`rollbacks/` (verified by `assertNoDuplicatePrefixes` + the test suite). A
+2026 audit for #1039 found and fixed a real gap: migrations `047`–`051` were
+missing rollback files, and `050_auto_refund_audit_log.sql` /
+`050_email_delivery_tracking.sql` shared the same numeric prefix (a bug that
+would have made the runner's duplicate-prefix guard abort on any real
+database). The duplicate was resolved by renumbering
+`050_email_delivery_tracking.sql` → `056_email_delivery_tracking.sql` (a pure
+rename — zero SQL content changed), and the six missing rollback files were
+added.
+
+---
+
+## 7. Troubleshooting
 
 ### `DRIFT DETECTED` error
 
@@ -305,7 +335,7 @@ git commit -m "chore: renormalise SQL file line endings to LF"
 
 ---
 
-## 7. PR Checklist for Migration Authors
+## 8. PR Checklist for Migration Authors
 
 Copy this into your PR description when your PR includes a migration:
 
@@ -326,20 +356,27 @@ Copy this into your PR description when your PR includes a migration:
 
 ---
 
-## 8. Quick Reference
+## 9. Quick Reference
 
 ```bash
 # Apply all pending migrations
 cd backend && npm run db:migrate
 
-# Dry-run (preview only, no DB changes)
+# Dry-run (preview only, no DB changes — writes the full SQL plan to a file)
 cd backend && npm run db:migrate:dry-run
 
+# Apply pending migrations WITHOUT taking a pg_dump backup first (dev only!)
+cd backend && npm run db:migrate:skip-backup
+
 # Roll back the last applied migration
-cd backend && npx ts-node src/db/migrate.ts --rollback
+cd backend && npm run db:migrate:rollback
 
 # Roll back N migrations
 cd backend && npx ts-node src/db/migrate.ts --rollback <N>
+
+# Migration run history (success/failure) and aggregate summary
+curl /api/v1/migrations/history
+curl /api/v1/migrations/history/summary
 
 # Find the next available migration number
 ls backend/src/db/migrations/*.sql | sed 's/.*\///' | grep -oP '^\d+' | sort -n | tail -1

--- a/backend/src/db/__tests__/migrate.test.ts
+++ b/backend/src/db/__tests__/migrate.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for the migration safety features added for Issue #1039:
+ * pre-migration backup command construction, dry-run SQL generation,
+ * duplicate-prefix detection, the 30s advisory lock, post-migration schema
+ * verification, and the run-log / auto-rollback recording used on failure.
+ *
+ * These tests exercise only the pure/unit-testable logic with mocked
+ * pg clients and a mocked `child_process.execFile` — no real Postgres,
+ * no real `pg_dump` binary, and no real Stellar/Redis/etc. dependency is
+ * ever contacted.
+ */
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+import {
+  sha256,
+  assertNoDuplicatePrefixes,
+  buildPgDumpArgs,
+  resolveBackupDir,
+  renderDryRunPlan,
+  verifySchemaIntegrity,
+  acquireMigrationLock,
+  releaseMigrationLock,
+  recordRunLog,
+  attemptAutoRollback,
+  maskConnectionString,
+  MIGRATION_LOCK_KEY,
+  LOCK_TIMEOUT_MS,
+  type MigrationFile,
+} from '../migrate.js';
+
+function makeFile(filename: string, sql = 'SELECT 1;'): MigrationFile {
+  return { filename, absolutePath: `/fake/${filename}`, sql, checksum: sha256(sql) };
+}
+
+function makeMockClient(queryImpl: (sql: string, params?: unknown[]) => any) {
+  return { query: jest.fn(queryImpl) } as any;
+}
+
+describe('migrate.ts safety features (#1039)', () => {
+  describe('sha256', () => {
+    it('is deterministic and content-sensitive', () => {
+      expect(sha256('a')).toBe(sha256('a'));
+      expect(sha256('a')).not.toBe(sha256('b'));
+      expect(sha256('a')).toHaveLength(64);
+    });
+  });
+
+  describe('assertNoDuplicatePrefixes', () => {
+    it('does not throw when all prefixes are unique', () => {
+      const files = [makeFile('001_a.sql'), makeFile('002_b.sql'), makeFile('003_c.sql')];
+      expect(() => assertNoDuplicatePrefixes(files)).not.toThrow();
+    });
+
+    it('throws a descriptive error when two files share a numeric prefix', () => {
+      const files = [makeFile('001_a.sql'), makeFile('001_b.sql'), makeFile('002_c.sql')];
+      expect(() => assertNoDuplicatePrefixes(files)).toThrow(/Duplicate migration prefix/);
+      expect(() => assertNoDuplicatePrefixes(files)).toThrow(/001_a\.sql/);
+      expect(() => assertNoDuplicatePrefixes(files)).toThrow(/001_b\.sql/);
+    });
+
+    it('confirms the real migrations directory has no duplicate prefixes', () => {
+      // Regression guard for the 050_/050_ collision found and fixed in #1039.
+      const dir = path.resolve(__dirname, '../migrations');
+      const files = fs
+        .readdirSync(dir)
+        .filter((f) => f.endsWith('.sql'))
+        .sort()
+        .map((filename) => makeFile(filename, fs.readFileSync(path.join(dir, filename), 'utf8')));
+      expect(() => assertNoDuplicatePrefixes(files)).not.toThrow();
+    });
+  });
+
+  describe('buildPgDumpArgs', () => {
+    it('builds a custom-format pg_dump argv with the output path', () => {
+      const args = buildPgDumpArgs('postgres://user:pass@host:5432/db', '/tmp/backup.dump');
+      expect(args).toEqual([
+        'postgres://user:pass@host:5432/db',
+        '--format=custom',
+        '--no-owner',
+        '--no-privileges',
+        '--file=/tmp/backup.dump',
+      ]);
+    });
+  });
+
+  describe('resolveBackupDir', () => {
+    const original = process.env.MIGRATION_BACKUP_DIR;
+    afterEach(() => {
+      if (original === undefined) delete process.env.MIGRATION_BACKUP_DIR;
+      else process.env.MIGRATION_BACKUP_DIR = original;
+    });
+
+    it('honors MIGRATION_BACKUP_DIR when set', () => {
+      process.env.MIGRATION_BACKUP_DIR = '/tmp/custom-backups';
+      expect(resolveBackupDir()).toBe(path.resolve('/tmp/custom-backups'));
+    });
+
+    it('falls back to backend/backups when unset', () => {
+      delete process.env.MIGRATION_BACKUP_DIR;
+      expect(resolveBackupDir()).toBe(path.resolve(__dirname, '../../../backups'));
+    });
+  });
+
+  describe('renderDryRunPlan', () => {
+    it('renders the literal SQL that would run, without executing it', () => {
+      const pending = [makeFile('010_add_column.sql', 'ALTER TABLE foo ADD COLUMN bar INT;')];
+      const plan = renderDryRunPlan(pending);
+
+      expect(plan).toContain('Dry-run migration plan generated');
+      expect(plan).toContain('1 pending migration(s)');
+      expect(plan).toContain('010_add_column.sql');
+      expect(plan).toContain('ALTER TABLE foo ADD COLUMN bar INT;');
+    });
+
+    it('renders an empty plan when nothing is pending', () => {
+      const plan = renderDryRunPlan([]);
+      expect(plan).toContain('0 pending migration(s)');
+    });
+  });
+
+  describe('verifySchemaIntegrity', () => {
+    it('passes when there are no invalid indexes or unvalidated constraints', async () => {
+      const client = makeMockClient(async (sql: string) => {
+        if (sql.includes('pg_index')) return { rows: [] };
+        if (sql.includes('pg_constraint')) return { rows: [] };
+        throw new Error(`unexpected query: ${sql}`);
+      });
+
+      const result = await verifySchemaIntegrity(client);
+      expect(result.passed).toBe(true);
+      expect(result.issues).toEqual([]);
+    });
+
+    it('fails and reports issues when an invalid index or constraint is found', async () => {
+      const client = makeMockClient(async (sql: string) => {
+        if (sql.includes('pg_index')) return { rows: [{ name: 'idx_broken' }] };
+        if (sql.includes('pg_constraint')) return { rows: [{ conname: 'chk_bad', table_name: 'employees' }] };
+        throw new Error(`unexpected query: ${sql}`);
+      });
+
+      const result = await verifySchemaIntegrity(client);
+      expect(result.passed).toBe(false);
+      expect(result.issues).toEqual([
+        'Invalid (not-ready) index left behind: idx_broken',
+        'Unvalidated constraint left behind: "chk_bad" on employees',
+      ]);
+    });
+  });
+
+  describe('acquireMigrationLock / releaseMigrationLock (30s timeout)', () => {
+    it('exports a 30 second timeout constant', () => {
+      expect(LOCK_TIMEOUT_MS).toBe(30_000);
+    });
+
+    it('acquires immediately when pg_try_advisory_lock returns true', async () => {
+      const calls: string[] = [];
+      const client = makeMockClient(async (sql: string) => {
+        calls.push(sql);
+        if (sql.startsWith('SET lock_timeout')) return { rows: [] };
+        if (sql.includes('pg_try_advisory_lock')) return { rows: [{ locked: true }] };
+        return { rows: [] };
+      });
+
+      await expect(acquireMigrationLock(client, 5_000)).resolves.toBeUndefined();
+      expect(calls.some((c) => c.includes(String(MIGRATION_LOCK_KEY)) || c.includes('pg_try_advisory_lock'))).toBe(
+        true
+      );
+    });
+
+    it('gives up and throws once the timeout elapses if the lock is never free', async () => {
+      const client = makeMockClient(async (sql: string) => {
+        if (sql.startsWith('SET lock_timeout')) return { rows: [] };
+        if (sql.includes('pg_try_advisory_lock')) return { rows: [{ locked: false }] };
+        return { rows: [] };
+      });
+
+      // Use a tiny timeout so the test itself stays fast.
+      await expect(acquireMigrationLock(client, 50)).rejects.toThrow(/Could not acquire the migration advisory lock/);
+    });
+
+    it('releases the lock via pg_advisory_unlock', async () => {
+      const client = makeMockClient(async () => ({ rows: [] }));
+      await releaseMigrationLock(client);
+      expect(client.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1)', [MIGRATION_LOCK_KEY]);
+    });
+  });
+
+  describe('recordRunLog', () => {
+    it('inserts a success entry with the expected shape', async () => {
+      const client = makeMockClient(async () => ({ rows: [] }));
+      const startedAt = new Date();
+
+      await recordRunLog(client, {
+        filename: '045_add_performance_bonus_fields.sql',
+        status: 'success',
+        startedAt,
+        executionMs: 42,
+        backupTaken: true,
+        backupPath: '/backups/pre-migration-x.dump',
+        verificationPassed: true,
+        verificationIssues: [],
+      });
+
+      expect(client.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = client.query.mock.calls[0];
+      expect(sql).toMatch(/INSERT INTO migration_run_log/);
+      expect(params).toEqual([
+        '045_add_performance_bonus_fields.sql',
+        'success',
+        startedAt,
+        42,
+        true,
+        '/backups/pre-migration-x.dump',
+        true,
+        '[]',
+        null,
+        false,
+        null,
+      ]);
+    });
+
+    it('inserts a failure entry with the error message and rollback outcome', async () => {
+      const client = makeMockClient(async () => ({ rows: [] }));
+      const startedAt = new Date();
+
+      await recordRunLog(client, {
+        filename: '999_bad.sql',
+        status: 'failure',
+        startedAt,
+        executionMs: 5,
+        backupTaken: false,
+        verificationPassed: false,
+        verificationIssues: ['Invalid index: idx_x'],
+        errorMessage: 'syntax error',
+        rollbackAttempted: true,
+        rollbackSucceeded: true,
+      });
+
+      const [, params] = client.query.mock.calls[0];
+      expect(params[1]).toBe('failure');
+      expect(params[8]).toBe('syntax error');
+      expect(params[9]).toBe(true); // rollback_attempted
+      expect(params[10]).toBe(true); // rollback_succeeded
+    });
+  });
+
+  describe('attemptAutoRollback', () => {
+    it('returns false when no rollback file exists for the migration', async () => {
+      const client = makeMockClient(async () => ({ rows: [] }));
+      const result = await attemptAutoRollback(client, 'does_not_exist_999.sql');
+      expect(result).toBe(false);
+      expect(client.query).not.toHaveBeenCalled();
+    });
+
+    it('executes the real rollback file and returns true on success', async () => {
+      // Exercise this against a real, existing rollback file in the repo so the
+      // test also acts as a smoke check that the file is valid SQL text.
+      const client = makeMockClient(async () => ({ rows: [] }));
+      const result = await attemptAutoRollback(client, '045_add_performance_bonus_fields.sql');
+
+      expect(result).toBe(true);
+      const executedSql = client.query.mock.calls.map((c: any[]) => c[0]).join('\n');
+      expect(executedSql).toContain('BEGIN');
+      expect(executedSql).toContain('DROP COLUMN IF EXISTS bonus_type');
+      expect(executedSql).toContain('COMMIT');
+    });
+
+    it('rolls back its own transaction and returns false if the rollback SQL itself fails', async () => {
+      const client = makeMockClient(async (sql: string) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rows: [] };
+        throw new Error('simulated rollback failure');
+      });
+
+      const result = await attemptAutoRollback(client, '045_add_performance_bonus_fields.sql');
+      expect(result).toBe(false);
+      expect(client.query).toHaveBeenCalledWith('ROLLBACK');
+    });
+  });
+
+  describe('maskConnectionString', () => {
+    it('redacts the password segment', () => {
+      expect(maskConnectionString('postgresql://user:secret@host:5432/db')).toBe(
+        'postgresql://user:***@host:5432/db'
+      );
+    });
+
+    it('returns a redacted placeholder for an unparsable URL', () => {
+      expect(maskConnectionString('not-a-url')).toBe('[redacted]');
+    });
+  });
+});
+
+describe('runDryRun (#1039) — fully offline plan generation', () => {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+  const originalBackupDir = process.env.MIGRATION_BACKUP_DIR;
+  let scratchDir: string;
+
+  beforeEach(() => {
+    scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'payd-migrate-test-'));
+    process.env.MIGRATION_BACKUP_DIR = scratchDir;
+    delete process.env.DATABASE_URL;
+  });
+
+  afterEach(() => {
+    if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = originalDatabaseUrl;
+    if (originalBackupDir === undefined) delete process.env.MIGRATION_BACKUP_DIR;
+    else process.env.MIGRATION_BACKUP_DIR = originalBackupDir;
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  it('treats every migration as pending and writes a reviewable SQL plan file when DATABASE_URL is unset', async () => {
+    const { runDryRun } = await import('../migrate.js');
+    const result = await runDryRun();
+
+    const realMigrationCount = fs
+      .readdirSync(path.resolve(__dirname, '../migrations'))
+      .filter((f) => f.endsWith('.sql')).length;
+
+    expect(result.applied.length).toBe(realMigrationCount);
+    expect(result.failures).toEqual([]);
+    expect(result.sqlPlanPath).toBeDefined();
+    expect(fs.existsSync(result.sqlPlanPath!)).toBe(true);
+
+    const planContents = fs.readFileSync(result.sqlPlanPath!, 'utf8');
+    expect(planContents).toContain('001_create_tables.sql');
+  });
+});

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,44 +1,66 @@
 /**
  * @file src/db/migrate.ts
- * @description Production-grade PostgreSQL migration runner.
+ * @description Production-grade PostgreSQL migration runner with safety checks.
  *
  * Responsibilities
  * ────────────────
  * 1. Connect to PostgreSQL using the DATABASE_URL environment variable.
- * 2. Bootstrap the `schema_migrations` tracking table when it is absent
- *    (this handles the very first run against a blank database).
+ * 2. Bootstrap the `schema_migrations` and `migration_run_log` tracking tables
+ *    when absent (this handles the very first run against a blank database).
  * 3. Read all *.sql files from the migrations directory, sorted lexicographically
  *    so that numeric prefixes (001_, 002_, …) define strict execution order.
- * 4. For each file:
+ * 4. Acquire a Postgres advisory lock (30s timeout) so two runners never apply
+ *    migrations concurrently against the same database (#1039).
+ * 5. Take a `pg_dump` backup before applying any pending migration, unless
+ *    explicitly skipped via `--skip-backup` / `MIGRATION_SKIP_BACKUP=true` (#1039).
+ * 6. For each pending file:
  *    a. Skip if already recorded in `schema_migrations`.
  *    b. Guard against file-content drift on already-applied migrations
  *       (SHA-256 checksum comparison).
- *    c. Execute within a single SERIALIZABLE transaction so a partial failure
- *       leaves the database unchanged and the migration can be retried safely.
- *    d. Record the migration in `schema_migrations` (filename, checksum, ms).
- * 5. Support a --dry-run flag that logs the plan without executing any SQL.
- * 6. Exit 0 on success, 1 on any error.
+ *    c. Execute within a single transaction so a partial failure leaves the
+ *       database unchanged and the migration can be retried safely.
+ *    d. Run a post-migration schema-integrity verification query (#1039).
+ *    e. Record the migration in `schema_migrations` (filename, checksum, ms)
+ *       and log the attempt (success/failure) in `migration_run_log`.
+ *    f. On failure: alert (structured log), attempt to auto-run the matching
+ *       rollback script, and re-throw so the process exits non-zero (#1039).
+ * 7. Support a `--dry-run` flag that generates the SQL that WOULD run —
+ *    written to a plan file — without executing or writing anything (#1039).
+ * 8. Exit 0 on success, 1 on any error.
  *
  * Time complexity  : O(m log m + m × p)  where m = migration files, p = avg SQL ops per file.
  * Space complexity : O(m) for the applied-set lookup map (in-memory hash set).
  *
  * Usage
  * ─────
- *   ts-node src/db/migrate.ts              # run pending migrations
- *   ts-node src/db/migrate.ts --dry-run    # print plan only
- *   ts-node src/db/migrate.ts --rollback   # (reserved; not yet implemented)
+ *   ts-node src/db/migrate.ts                  # run pending migrations
+ *   ts-node src/db/migrate.ts --dry-run         # print/generate the plan only
+ *   ts-node src/db/migrate.ts --skip-backup     # skip the pre-migration pg_dump (dev only)
+ *   ts-node src/db/migrate.ts --rollback        # roll back the most recently applied migration
+ *   ts-node src/db/migrate.ts --rollback 3      # roll back the last 3 migrations
+ *   ts-node src/db/migrate.ts --rollback --dry-run
+ *
+ * Environment variables
+ * ──────────────────────
+ *   DATABASE_URL            - required for any real run or rollback
+ *   MIGRATION_SKIP_BACKUP   - 'true' to skip the pre-migration pg_dump backup
+ *   MIGRATION_BACKUP_DIR    - where pg_dump backups are written (default: backend/backups)
  */
 
+import { execFile } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
+import { promisify } from 'util';
 
 import dotenv from 'dotenv';
 import { Pool, PoolClient } from 'pg';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const execFileAsync = promisify(execFile);
 
 // ─── Bootstrap ──────────────────────────────────────────────────────────────
 
@@ -46,20 +68,26 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 const DATABASE_URL = process.env.DATABASE_URL;
 
-if (!DATABASE_URL) {
-  console.error('[migrate] ERROR: DATABASE_URL environment variable is not set.');
-  process.exit(1);
-}
-
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const MIGRATIONS_DIR = path.resolve(__dirname, 'migrations');
 const ROLLBACKS_DIR = path.resolve(__dirname, 'rollbacks');
 
+/** Postgres advisory lock key used to serialize concurrent migration runs. */
+export const MIGRATION_LOCK_KEY = 827_100_239;
+
+/** Maximum time (ms) the runner will wait to acquire the migration lock (#1039). */
+export const LOCK_TIMEOUT_MS = 30_000;
+
+/** Interval between advisory-lock acquisition attempts. */
+const LOCK_POLL_INTERVAL_MS = 250;
+
 /**
- * The tracking table is always the first thing the runner creates.
- * This DDL is intentionally inline (not read from a file) so the runner
- * can bootstrap itself before any file-based migration is evaluated.
+ * The tracking tables are always the first thing the runner creates.
+ * This DDL is intentionally inline (not read from a migration file) so the
+ * runner can bootstrap itself before any file-based migration is evaluated,
+ * and so `migration_run_log` exists even on a run that also applies the
+ * migration file which formally introduces it (055_create_migration_run_log.sql).
  */
 const BOOTSTRAP_SQL = `
   CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -72,20 +100,61 @@ const BOOTSTRAP_SQL = `
   );
   CREATE INDEX IF NOT EXISTS idx_schema_migrations_filename
     ON schema_migrations (filename);
+
+  CREATE TABLE IF NOT EXISTS migration_run_log (
+    id                  BIGSERIAL    PRIMARY KEY,
+    filename            VARCHAR(255) NOT NULL,
+    run_status          VARCHAR(20)  NOT NULL
+                         CHECK (run_status IN ('success', 'failure', 'dry_run')),
+    started_at          TIMESTAMPTZ  NOT NULL,
+    finished_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    execution_ms        INTEGER      CHECK (execution_ms >= 0),
+    backup_taken        BOOLEAN      NOT NULL DEFAULT FALSE,
+    backup_path         TEXT,
+    verification_passed BOOLEAN,
+    verification_issues JSONB,
+    error_message       TEXT,
+    rollback_attempted  BOOLEAN      NOT NULL DEFAULT FALSE,
+    rollback_succeeded  BOOLEAN
+  );
+  CREATE INDEX IF NOT EXISTS idx_migration_run_log_filename
+    ON migration_run_log (filename);
+  CREATE INDEX IF NOT EXISTS idx_migration_run_log_status_time
+    ON migration_run_log (run_status, finished_at DESC);
 `;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-interface AppliedMigration {
+export interface AppliedMigration {
   filename: string;
   checksum: string;
 }
 
-interface MigrationFile {
+export interface MigrationFile {
   filename: string;
   absolutePath: string;
   sql: string;
   checksum: string;
+}
+
+export interface VerificationResult {
+  passed: boolean;
+  issues: string[];
+}
+
+export interface BackupResult {
+  taken: boolean;
+  path?: string;
+  error?: string;
+}
+
+export interface RunResult {
+  applied: string[];
+  skipped: string[];
+  driftDetected: string[];
+  failures: string[];
+  backup?: BackupResult;
+  sqlPlanPath?: string;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -94,29 +163,33 @@ interface MigrationFile {
  * Compute the SHA-256 hex digest of a string.
  * Pure function with O(n) time and O(1) extra space (streaming hash).
  */
-function sha256(content: string): string {
+export function sha256(content: string): string {
   return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
- * Guard: scan the migration filenames and abort if any two files share the
+ * Guard: scan the migration filenames and throw if any two files share the
  * same numeric prefix (e.g. two files both starting with "010_").
  *
  * Duplicate prefixes are the primary root cause of checksum-mismatch failures
  * in CI/CD because they corrupt the deterministic sort-order contract that the
- * runner relies on.  Failing here gives the developer an immediately actionable
+ * runner relies on. Throwing here gives the developer an immediately actionable
  * error message instead of a cryptic drift error deeper in the pipeline.
  *
- * Time complexity  : O(m) — single pass over the filename array.
- * Side effects     : Writes to stderr and calls process.exit(1) on violation.
+ * Time complexity : O(m) — single pass over the filename array.
+ * @throws {Error} a formatted, multi-line description of every duplicate found.
  */
-function assertNoDuplicatePrefixes(files: MigrationFile[]): void {
+export function assertNoDuplicatePrefixes(files: MigrationFile[]): void {
   const prefixMap = new Map<string, string[]>();
 
   for (const { filename } of files) {
     const match = filename.match(/^(\d+)_/);
     if (!match) continue;
-    const prefix = match[1];
+    const prefix = match[1] as string;
     if (!prefixMap.has(prefix)) prefixMap.set(prefix, []);
     prefixMap.get(prefix)!.push(filename);
   }
@@ -125,25 +198,25 @@ function assertNoDuplicatePrefixes(files: MigrationFile[]): void {
 
   if (duplicates.length === 0) return;
 
-  console.error('[migrate] ────────────────────────────────────────────────────');
-  console.error('[migrate] FATAL: Duplicate migration prefix(es) detected.');
-  console.error('[migrate]');
-  console.error('[migrate] Two or more migration files share the same numeric');
-  console.error('[migrate] prefix. This corrupts the sort-order contract and');
-  console.error('[migrate] will cause non-deterministic checksum mismatches.');
-  console.error('[migrate]');
+  const lines: string[] = [
+    'FATAL: Duplicate migration prefix(es) detected.',
+    '',
+    'Two or more migration files share the same numeric prefix. This corrupts',
+    'the sort-order contract and will cause non-deterministic checksum mismatches.',
+    '',
+  ];
 
   for (const [prefix, names] of duplicates) {
-    console.error(`[migrate]   Prefix "${prefix}_" shared by:`);
-    for (const name of names) console.error(`[migrate]     - ${name}`);
+    lines.push(`  Prefix "${prefix}_" shared by:`);
+    for (const name of names) lines.push(`    - ${name}`);
   }
 
-  console.error('[migrate]');
-  console.error('[migrate] Fix: run the re-sequencing script from the repo root:');
-  console.error('[migrate]   node scripts/resequence-migrations.mjs --dry-run');
-  console.error('[migrate]   node scripts/resequence-migrations.mjs');
-  console.error('[migrate] ────────────────────────────────────────────────────');
-  process.exit(1);
+  lines.push('');
+  lines.push('Fix: run the re-sequencing script from the repo root:');
+  lines.push('  node scripts/resequence-migrations.mjs --dry-run');
+  lines.push('  node scripts/resequence-migrations.mjs');
+
+  throw new Error(lines.join('\n'));
 }
 
 /**
@@ -153,7 +226,7 @@ function assertNoDuplicatePrefixes(files: MigrationFile[]): void {
  *
  * @throws {Error} if the directory cannot be read.
  */
-function readMigrationFiles(dir: string): MigrationFile[] {
+export function readMigrationFiles(dir: string): MigrationFile[] {
   if (!fs.existsSync(dir)) {
     throw new Error(`Migrations directory not found: ${dir}`);
   }
@@ -204,15 +277,316 @@ async function recordMigration(
   );
 }
 
-// ─── Core runner ─────────────────────────────────────────────────────────────
-
-interface RunResult {
-  applied: string[];
-  skipped: string[];
-  driftDetected: string[];
+/**
+ * Append a row to `migration_run_log` describing one execution attempt
+ * (success, failure, or dry-run) so the migration status endpoint can
+ * surface a full history — including failures — to operators (#1039).
+ * Uses its own statement (not nested in the failed migration's now-rolled-back
+ * transaction) so the log entry always persists regardless of outcome.
+ */
+export async function recordRunLog(
+  client: PoolClient,
+  entry: {
+    filename: string;
+    status: 'success' | 'failure' | 'dry_run';
+    startedAt: Date;
+    executionMs: number;
+    backupTaken: boolean;
+    backupPath?: string;
+    verificationPassed?: boolean;
+    verificationIssues?: string[];
+    errorMessage?: string;
+    rollbackAttempted?: boolean;
+    rollbackSucceeded?: boolean;
+  }
+): Promise<void> {
+  await client.query(
+    `INSERT INTO migration_run_log
+       (filename, run_status, started_at, execution_ms, backup_taken, backup_path,
+        verification_passed, verification_issues, error_message,
+        rollback_attempted, rollback_succeeded)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+    [
+      entry.filename,
+      entry.status,
+      entry.startedAt,
+      entry.executionMs,
+      entry.backupTaken,
+      entry.backupPath ?? null,
+      entry.verificationPassed ?? null,
+      entry.verificationIssues ? JSON.stringify(entry.verificationIssues) : null,
+      entry.errorMessage ?? null,
+      entry.rollbackAttempted ?? false,
+      entry.rollbackSucceeded ?? null,
+    ]
+  );
 }
 
-async function runMigrations(isDryRun: boolean): Promise<RunResult> {
+// ─── Advisory lock (30s timeout) ─────────────────────────────────────────────
+
+/**
+ * Acquire a session-level Postgres advisory lock so two migration runners can
+ * never apply migrations concurrently against the same database. Polls
+ * `pg_try_advisory_lock` (non-blocking) and gives up after `LOCK_TIMEOUT_MS`
+ * (30 seconds) so a stuck lock-holder cannot wedge deploys indefinitely (#1039).
+ *
+ * Also sets the session `lock_timeout` so any row/table lock the migration's
+ * own DDL waits on inside its transaction is bounded by the same 30s budget.
+ */
+export async function acquireMigrationLock(
+  client: PoolClient,
+  timeoutMs: number = LOCK_TIMEOUT_MS
+): Promise<void> {
+  await client.query(`SET lock_timeout = '${timeoutMs}ms'`);
+
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const { rows } = await client.query<{ locked: boolean }>(
+      'SELECT pg_try_advisory_lock($1) AS locked',
+      [MIGRATION_LOCK_KEY]
+    );
+    if (rows[0]?.locked) return;
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Could not acquire the migration advisory lock within ${timeoutMs}ms — ` +
+          'another migration run may already be in progress against this database.'
+      );
+    }
+    await sleep(LOCK_POLL_INTERVAL_MS);
+  }
+}
+
+/** Release the migration advisory lock acquired by {@link acquireMigrationLock}. */
+export async function releaseMigrationLock(client: PoolClient): Promise<void> {
+  await client.query('SELECT pg_advisory_unlock($1)', [MIGRATION_LOCK_KEY]);
+}
+
+// ─── Pre-migration backup (pg_dump) ──────────────────────────────────────────
+
+/** Resolves the directory pg_dump backups are written to. */
+export function resolveBackupDir(): string {
+  return process.env.MIGRATION_BACKUP_DIR
+    ? path.resolve(process.env.MIGRATION_BACKUP_DIR)
+    : path.resolve(__dirname, '../../backups');
+}
+
+/**
+ * Build the `pg_dump` argv for a custom-format, pre-migration backup.
+ * Pure function — no I/O — so it can be unit tested without a real database
+ * or `pg_dump` binary.
+ */
+export function buildPgDumpArgs(databaseUrl: string, outputPath: string): string[] {
+  return [databaseUrl, '--format=custom', '--no-owner', '--no-privileges', `--file=${outputPath}`];
+}
+
+/**
+ * Take a `pg_dump` backup of the target database before running any pending
+ * migration. On by default for the real runner; skippable via `--skip-backup`
+ * or `MIGRATION_SKIP_BACKUP=true` for local/dev iteration (#1039).
+ */
+export async function takePreMigrationBackup(databaseUrl: string): Promise<BackupResult> {
+  const dir = resolveBackupDir();
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (err) {
+    return {
+      taken: false,
+      error: `Could not create backup directory "${dir}": ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const filename = `pre-migration-${new Date().toISOString().replace(/[:.]/g, '-')}.dump`;
+  const outputPath = path.join(dir, filename);
+  const args = buildPgDumpArgs(databaseUrl, outputPath);
+
+  try {
+    await execFileAsync('pg_dump', args, { timeout: 5 * 60_000 });
+    return { taken: true, path: outputPath };
+  } catch (err) {
+    return { taken: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ─── Post-migration verification ─────────────────────────────────────────────
+
+/**
+ * Post-migration schema-integrity verification. Runs generic, migration-agnostic
+ * checks that catch the most common failure modes of a partially-applied or
+ * silently-broken migration:
+ *   - Any index left `NOT VALID` (e.g. an aborted `CREATE INDEX CONCURRENTLY`).
+ *   - Any constraint left `NOT VALIDATED` (e.g. an aborted `VALIDATE CONSTRAINT`).
+ * Executed inside the migration's own transaction, before COMMIT, so a failed
+ * verification still triggers a full ROLLBACK of that migration (#1039).
+ */
+export async function verifySchemaIntegrity(client: PoolClient): Promise<VerificationResult> {
+  const issues: string[] = [];
+
+  const invalidIndexes = await client.query<{ name: string }>(
+    `SELECT indexrelid::regclass::text AS name FROM pg_index WHERE NOT indisvalid`
+  );
+  for (const row of invalidIndexes.rows) {
+    issues.push(`Invalid (not-ready) index left behind: ${row.name}`);
+  }
+
+  const invalidConstraints = await client.query<{ conname: string; table_name: string }>(
+    `SELECT conname, conrelid::regclass::text AS table_name
+     FROM pg_constraint
+     WHERE NOT convalidated`
+  );
+  for (const row of invalidConstraints.rows) {
+    issues.push(`Unvalidated constraint left behind: "${row.conname}" on ${row.table_name}`);
+  }
+
+  return { passed: issues.length === 0, issues };
+}
+
+// ─── Failure alerting + auto-rollback ────────────────────────────────────────
+
+/**
+ * Log a structured, high-visibility alert for a failed migration.
+ * Follows the same "structured log + TODO wiring" pattern used elsewhere in
+ * the codebase for ops alerts (see backupVerificationWorker.ts) — this repo
+ * has no external alerting service configured yet (no Sentry/PagerDuty), so
+ * the alert is a loud, greppable log line that a log-based alert rule (e.g.
+ * Elasticsearch/Kibana watcher on `alert: "MIGRATION_FAILED"`) can trigger on.
+ */
+export function alertMigrationFailure(filename: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error('[migrate] ────────────────────────────────────────────────────');
+  console.error(`[migrate] ALERT alert=MIGRATION_FAILED filename="${filename}"`);
+  console.error(`[migrate] ${message}`);
+  console.error(
+    '[migrate] TODO: wire this into the ops alerting channel (Slack/PagerDuty/email) — ' +
+      'see backupVerificationWorker.ts#sendVerificationNotification for the existing stub pattern.'
+  );
+  console.error('[migrate] ────────────────────────────────────────────────────');
+}
+
+/**
+ * Attempt to automatically execute the rollback script matching a failed
+ * migration. Because each migration runs inside its own transaction, a SQL
+ * error already leaves the database in its pre-migration state — this is a
+ * defense-in-depth safety net for non-transactional failure modes (e.g. a
+ * post-migration verification failure after DDL that implicitly committed,
+ * or partial application via `CREATE INDEX CONCURRENTLY`). All rollback SQL
+ * in this repo uses `IF EXISTS` guards, so re-running it is always safe.
+ */
+export async function attemptAutoRollback(client: PoolClient, filename: string): Promise<boolean> {
+  const rollbackFile = path.join(ROLLBACKS_DIR, filename);
+
+  if (!fs.existsSync(rollbackFile)) {
+    console.error(`[migrate] No rollback file found for "${filename}"; cannot auto-rollback.`);
+    return false;
+  }
+
+  try {
+    const sql = fs.readFileSync(rollbackFile, 'utf8');
+    await client.query('BEGIN');
+    await client.query(sql);
+    await client.query('COMMIT');
+    console.log(`[migrate] ↩ Auto-rollback succeeded for "${filename}".`);
+    return true;
+  } catch (rollbackErr) {
+    await client.query('ROLLBACK').catch(() => {});
+    console.error(
+      `[migrate] ✗ Auto-rollback FAILED for "${filename}":`,
+      rollbackErr instanceof Error ? rollbackErr.message : rollbackErr
+    );
+    return false;
+  }
+}
+
+// ─── Dry-run plan generation ──────────────────────────────────────────────────
+
+/**
+ * Render the full SQL that WOULD run for a set of pending migrations, as a
+ * single reviewable script — this is the literal "SQL that would run" the
+ * dry-run acceptance criterion asks for, not just a list of filenames (#1039).
+ * Pure function — no I/O — so it is unit-testable without touching disk.
+ */
+export function renderDryRunPlan(pending: MigrationFile[]): string {
+  const header =
+    `-- Dry-run migration plan generated ${new Date().toISOString()}\n` +
+    `-- ${pending.length} pending migration(s) would run, in this exact order.\n` +
+    `-- Nothing has been executed. Review before applying with: npm run db:migrate\n\n`;
+
+  const body = pending
+    .map((f) => `-- ===== ${f.filename}  (checksum ${f.checksum}) =====\n${f.sql}\n`)
+    .join('\n');
+
+  return header + body;
+}
+
+/** Write a rendered dry-run plan to `<backupDir>/dry-run-plans/`. */
+function writeDryRunPlan(planText: string): string {
+  const dir = path.join(resolveBackupDir(), 'dry-run-plans');
+  fs.mkdirSync(dir, { recursive: true });
+  const planPath = path.join(dir, `dry-run-plan-${Date.now()}.sql`);
+  fs.writeFileSync(planPath, planText, 'utf8');
+  return planPath;
+}
+
+// ─── Core runner ─────────────────────────────────────────────────────────────
+
+/**
+ * Generate (and persist to disk) the exact SQL that would run for all
+ * currently-pending migrations, without connecting for writes or executing
+ * anything. If `DATABASE_URL` is set, performs one read-only query to
+ * determine which migrations are already applied so the plan is accurate;
+ * otherwise every migration file is treated as pending.
+ */
+async function runDryRun(): Promise<RunResult> {
+  const files = readMigrationFiles(MIGRATIONS_DIR);
+  assertNoDuplicatePrefixes(files);
+
+  let applied = new Map<string, AppliedMigration>();
+
+  if (DATABASE_URL) {
+    const pool = new Pool({ connectionString: DATABASE_URL, max: 1, connectionTimeoutMillis: 10_000 });
+    const client = await pool.connect();
+    try {
+      const { rows } = await client.query<{ reg: string | null }>(
+        `SELECT to_regclass('public.schema_migrations')::text AS reg`
+      );
+      if (rows[0]?.reg) {
+        applied = await fetchAppliedMigrations(client);
+      } else {
+        console.log(
+          '[migrate] [dry-run] schema_migrations table does not exist yet — treating all files as pending.'
+        );
+      }
+    } finally {
+      client.release();
+      await pool.end();
+    }
+  } else {
+    console.log(
+      '[migrate] [dry-run] DATABASE_URL not set — cannot verify already-applied migrations; showing the full plan for all files.'
+    );
+  }
+
+  const pending = files.filter((f) => !applied.has(f.filename));
+  const planText = renderDryRunPlan(pending);
+  const planPath = writeDryRunPlan(planText);
+
+  console.log(`[migrate] [dry-run] ${pending.length} pending migration(s); full SQL plan written to:`);
+  console.log(`[migrate]   ${planPath}`);
+  for (const f of pending) {
+    console.log(`[migrate] [dry-run] Would apply: ${f.filename}  (checksum: ${f.checksum})`);
+  }
+
+  return {
+    applied: pending.map((f) => f.filename),
+    skipped: [...applied.keys()],
+    driftDetected: [],
+    failures: [],
+    sqlPlanPath: planPath,
+  };
+}
+
+async function runMigrations(skipBackup: boolean): Promise<RunResult> {
   const pool = new Pool({
     connectionString: DATABASE_URL,
     // Keep the pool minimal; the runner is a CLI tool, not a long-lived server.
@@ -221,29 +595,24 @@ async function runMigrations(isDryRun: boolean): Promise<RunResult> {
     connectionTimeoutMillis: 10_000,
   });
 
-  const result: RunResult = { applied: [], skipped: [], driftDetected: [] };
+  const result: RunResult = { applied: [], skipped: [], driftDetected: [], failures: [] };
 
   const client = await pool.connect();
 
   try {
-    // ── Step 1: Bootstrap tracking table ──────────────────────────────────
-    // Always run inline, outside a migration transaction, so it is safe even
-    // on a completely blank database.
-    if (!isDryRun) {
-      await client.query(BOOTSTRAP_SQL);
-      console.log('[migrate] ✓ schema_migrations table ready');
-    } else {
-      console.log('[migrate] [dry-run] Would bootstrap schema_migrations table');
-    }
+    // ── Step 0: Acquire the migration advisory lock (30s timeout, #1039) ──
+    await acquireMigrationLock(client);
+    console.log('[migrate] ✓ Acquired migration advisory lock');
+
+    // ── Step 1: Bootstrap tracking tables ──────────────────────────────────
+    await client.query(BOOTSTRAP_SQL);
+    console.log('[migrate] ✓ schema_migrations / migration_run_log tables ready');
 
     // ── Step 2: Read migration files ──────────────────────────────────────
     const files = readMigrationFiles(MIGRATIONS_DIR);
     console.log(`[migrate] Found ${files.length} migration file(s) in ${MIGRATIONS_DIR}`);
 
     // ── Step 2a: Guard against duplicate numeric prefixes ────────────────
-    // This check runs before any SQL is executed.  A duplicate prefix means
-    // two contributors merged migrations with the same number, which will
-    // produce non-deterministic sort ordering and eventual checksum drift.
     assertNoDuplicatePrefixes(files);
 
     if (files.length === 0) {
@@ -252,9 +621,26 @@ async function runMigrations(isDryRun: boolean): Promise<RunResult> {
     }
 
     // ── Step 3: Fetch already-applied set (O(m) time / space) ─────────────
-    const applied = isDryRun
-      ? new Map<string, AppliedMigration>()
-      : await fetchAppliedMigrations(client);
+    const applied = await fetchAppliedMigrations(client);
+    const pendingFiles = files.filter((f) => !applied.has(f.filename));
+
+    // ── Step 3a: Pre-migration backup (pg_dump), on by default (#1039) ────
+    if (pendingFiles.length > 0) {
+      if (skipBackup) {
+        console.log('[migrate] ⚠ Backup skipped (--skip-backup / MIGRATION_SKIP_BACKUP). Not recommended in production.');
+      } else {
+        console.log('[migrate] Taking pre-migration pg_dump backup...');
+        const backup = await takePreMigrationBackup(DATABASE_URL!);
+        result.backup = backup;
+        if (!backup.taken) {
+          throw new Error(
+            `Pre-migration backup failed: ${backup.error}. Aborting migration run. ` +
+              'Pass --skip-backup (not recommended in production) to override.'
+          );
+        }
+        console.log(`[migrate] ✓ Pre-migration backup captured: ${backup.path}`);
+      }
+    }
 
     // ── Step 4: Evaluate each migration ───────────────────────────────────
     for (const file of files) {
@@ -270,7 +656,6 @@ async function runMigrations(isDryRun: boolean): Promise<RunResult> {
             `Aborting to protect database integrity.`;
           console.error(msg);
           result.driftDetected.push(file.filename);
-          // Accumulate all drifted files before throwing so the log is complete.
           continue;
         }
 
@@ -280,19 +665,22 @@ async function runMigrations(isDryRun: boolean): Promise<RunResult> {
       }
 
       // ── Step 5: Apply pending migration in an atomic transaction ─────────
-      if (isDryRun) {
-        console.log(
-          `[migrate] [dry-run] Would apply: ${file.filename}  (checksum: ${file.checksum})`
-        );
-        result.applied.push(file.filename);
-        continue;
-      }
-
+      const startedAt = new Date();
       const startMs = Date.now();
       await client.query('BEGIN');
 
+      let verification: VerificationResult | null = null;
+
       try {
         await client.query(file.sql);
+
+        // ── Step 5a: Post-migration verification (#1039) ───────────────────
+        verification = await verifySchemaIntegrity(client);
+        if (!verification.passed) {
+          throw new Error(
+            `Post-migration verification failed for "${file.filename}": ${verification.issues.join('; ')}`
+          );
+        }
 
         const executionMs = Date.now() - startMs;
 
@@ -302,11 +690,45 @@ async function runMigrations(isDryRun: boolean): Promise<RunResult> {
 
         await client.query('COMMIT');
 
+        await recordRunLog(client, {
+          filename: file.filename,
+          status: 'success',
+          startedAt,
+          executionMs,
+          backupTaken: result.backup?.taken ?? false,
+          backupPath: result.backup?.path,
+          verificationPassed: true,
+          verificationIssues: [],
+        });
+
         console.log(`[migrate] ✓ Applied   ${file.filename}  (${executionMs} ms)`);
         result.applied.push(file.filename);
       } catch (err) {
-        await client.query('ROLLBACK');
+        await client.query('ROLLBACK').catch(() => {});
+        const executionMs = Date.now() - startMs;
+
         console.error(`[migrate] ✗ Failed   ${file.filename}`);
+        alertMigrationFailure(file.filename, err);
+
+        const rollbackSucceeded = await attemptAutoRollback(client, file.filename);
+
+        await recordRunLog(client, {
+          filename: file.filename,
+          status: 'failure',
+          startedAt,
+          executionMs,
+          backupTaken: result.backup?.taken ?? false,
+          backupPath: result.backup?.path,
+          verificationPassed: verification ? verification.passed : false,
+          verificationIssues: verification?.issues ?? [],
+          errorMessage: err instanceof Error ? err.message : String(err),
+          rollbackAttempted: true,
+          rollbackSucceeded,
+        }).catch((logErr) => {
+          console.error('[migrate] Failed to record failure in migration_run_log:', logErr);
+        });
+
+        result.failures.push(file.filename);
         throw err; // Surface to outer try/catch; unconditionally exit(1).
       }
     }
@@ -319,6 +741,9 @@ async function runMigrations(isDryRun: boolean): Promise<RunResult> {
       );
     }
   } finally {
+    await releaseMigrationLock(client).catch(() => {
+      // Best-effort: the session ending will also release the lock.
+    });
     client.release();
     await pool.end();
   }
@@ -333,9 +758,9 @@ async function runMigrations(isDryRun: boolean): Promise<RunResult> {
  *
  * For each migration to be rolled back (in reverse-applied-at order) the
  * runner looks for a matching file in the `rollbacks/` directory next to
- * `migrations/`.  The rollback SQL is executed inside a SERIALIZABLE
- * transaction and the corresponding `schema_migrations` row is deleted on
- * success so the migration can be re-applied later.
+ * `migrations/`. The rollback SQL is executed inside a transaction and the
+ * corresponding `schema_migrations` row is deleted on success so the
+ * migration can be re-applied later.
  *
  * Usage:
  *   ts-node src/db/migrate.ts --rollback         # roll back 1 migration
@@ -400,8 +825,18 @@ async function runRollback(steps: number, isDryRun: boolean): Promise<void> {
         await client.query('COMMIT');
         const executionMs = Date.now() - startMs;
         console.log(`[migrate] ↩ Rolled back  ${filename}  (${executionMs} ms)`);
+
+        await client
+          .query(
+            `INSERT INTO migration_rollback_log (filename, execution_ms, reason)
+             VALUES ($1, $2, $3)`,
+            [filename, executionMs, 'Manual rollback via migrate.ts --rollback']
+          )
+          .catch(() => {
+            // migration_rollback_log may not exist yet (pre-044 database); non-fatal.
+          });
       } catch (err) {
-        await client.query('ROLLBACK');
+        await client.query('ROLLBACK').catch(() => {});
         console.error(`[migrate] ✗ Rollback failed for  ${filename}`);
         throw err;
       }
@@ -416,11 +851,24 @@ async function runRollback(steps: number, isDryRun: boolean): Promise<void> {
 
 async function main(): Promise<void> {
   const isDryRun = process.argv.includes('--dry-run');
+  const skipBackup = process.argv.includes('--skip-backup') || process.env.MIGRATION_SKIP_BACKUP === 'true';
   const rollbackIdx = process.argv.indexOf('--rollback');
   const isRollback = rollbackIdx !== -1;
 
   console.log(`[migrate] Starting migration runner${isDryRun ? ' (DRY RUN)' : ''}`);
-  console.log(`[migrate] Target database: ${maskConnectionString(DATABASE_URL!)}`);
+
+  // A pure forward dry-run can run entirely offline; everything else needs DATABASE_URL.
+  const requiresDatabaseUrl = isRollback || !isDryRun;
+  if (requiresDatabaseUrl && !DATABASE_URL) {
+    console.error('[migrate] ERROR: DATABASE_URL environment variable is not set.');
+    process.exit(1);
+  }
+
+  console.log(
+    DATABASE_URL
+      ? `[migrate] Target database: ${maskConnectionString(DATABASE_URL)}`
+      : '[migrate] Target database: N/A (dry-run, no DB connection required)'
+  );
 
   const startMs = Date.now();
 
@@ -431,8 +879,10 @@ async function main(): Promise<void> {
       const steps = nextArg && /^\d+$/.test(nextArg) ? parseInt(nextArg, 10) : 1;
       console.log(`[migrate] Mode: ROLLBACK (${steps} step${steps === 1 ? '' : 's'})`);
       await runRollback(steps, isDryRun);
+    } else if (isDryRun) {
+      await runDryRun();
     } else {
-      const result = await runMigrations(isDryRun);
+      const result = await runMigrations(skipBackup);
 
       const totalMs = Date.now() - startMs;
 
@@ -441,6 +891,7 @@ async function main(): Promise<void> {
       console.log(`[migrate] Summary  (${totalMs} ms total)`);
       console.log(`  Applied : ${result.applied.length}`);
       console.log(`  Skipped : ${result.skipped.length}`);
+      console.log(`  Failed  : ${result.failures.length}`);
       console.log(`  Drift   : ${result.driftDetected.length}`);
       console.log('─────────────────────────────────────────');
     }
@@ -459,7 +910,7 @@ async function main(): Promise<void> {
  * is safe to print in logs.
  * e.g. postgresql://user:secret@host:5432/db → postgresql://user:***@host:5432/db
  */
-function maskConnectionString(url: string): string {
+export function maskConnectionString(url: string): string {
   try {
     const parsed = new URL(url);
     if (parsed.password) parsed.password = '***';
@@ -470,4 +921,13 @@ function maskConnectionString(url: string): string {
   }
 }
 
-main();
+// Only auto-run when this file is executed directly (e.g. `ts-node src/db/migrate.ts`),
+// never when imported by another module (such as a Jest test importing the
+// exported pure helpers above) — this is the standard Node/ESM "is main module" check.
+const isMainModule = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+
+if (isMainModule) {
+  main();
+}
+
+export { main, runMigrations, runRollback, runDryRun };

--- a/backend/src/db/migrations/055_create_migration_run_log.sql
+++ b/backend/src/db/migrations/055_create_migration_run_log.sql
@@ -1,0 +1,42 @@
+-- =============================================================================
+-- Migration 055: Migration Run Log
+-- Purpose : Persist an audit trail of every migration EXECUTION ATTEMPT (not
+--           just successful applies) so operators can see failures, dry-runs,
+--           backup status, and post-migration verification results.
+--           Closes Issue #1039 – Database migration safety checks and rollback
+--           scripts.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS migration_run_log (
+  id                  BIGSERIAL    PRIMARY KEY,
+  filename            VARCHAR(255) NOT NULL,
+  run_status          VARCHAR(20)  NOT NULL
+                       CHECK (run_status IN ('success', 'failure', 'dry_run')),
+  started_at          TIMESTAMPTZ  NOT NULL,
+  finished_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  execution_ms        INTEGER      CHECK (execution_ms >= 0),
+  backup_taken        BOOLEAN      NOT NULL DEFAULT FALSE,
+  backup_path         TEXT,
+  verification_passed BOOLEAN,
+  verification_issues JSONB,
+  error_message       TEXT,
+  rollback_attempted  BOOLEAN      NOT NULL DEFAULT FALSE,
+  rollback_succeeded  BOOLEAN
+);
+
+CREATE INDEX IF NOT EXISTS idx_migration_run_log_filename
+  ON migration_run_log (filename);
+
+CREATE INDEX IF NOT EXISTS idx_migration_run_log_status_time
+  ON migration_run_log (run_status, finished_at DESC);
+
+COMMENT ON TABLE migration_run_log IS
+  'Audit trail of every migration execution attempt (success, failure, or dry-run), including backup and post-migration verification outcomes.';
+COMMENT ON COLUMN migration_run_log.run_status IS
+  'Outcome of this migration attempt: success, failure, or dry_run (planning only, nothing executed).';
+COMMENT ON COLUMN migration_run_log.backup_taken IS
+  'Whether a pg_dump backup was successfully captured before this migration ran.';
+COMMENT ON COLUMN migration_run_log.verification_passed IS
+  'Whether the post-migration schema verification query passed (NULL if not run, e.g. dry-run).';
+COMMENT ON COLUMN migration_run_log.rollback_attempted IS
+  'Whether the runner automatically attempted to execute the matching rollback script after a failure.';

--- a/backend/src/db/migrations/056_email_delivery_tracking.sql
+++ b/backend/src/db/migrations/056_email_delivery_tracking.sql
@@ -1,4 +1,7 @@
--- Email Delivery Tracking Tables (#1050)
+-- Migration 056: Email Delivery Tracking Tables (#1050)
+-- Note: renumbered from 050 -> 056 to resolve a duplicate numeric prefix with
+-- 050_auto_refund_audit_log.sql (both files were previously named "050_"),
+-- which broke the migration runner's duplicate-prefix guard. See Issue #1039.
 
 -- Email delivery logs table
 CREATE TABLE IF NOT EXISTS email_delivery_logs (

--- a/backend/src/db/rollbacks/047_api_database_scaling_part33.sql
+++ b/backend/src/db/rollbacks/047_api_database_scaling_part33.sql
@@ -1,0 +1,24 @@
+-- Rollback for Migration 047: API & Database Scaling – Part 33 (Issue #278)
+
+DROP FUNCTION IF EXISTS prune_query_plan_cache();
+DROP FUNCTION IF EXISTS prune_deadlock_history();
+
+DROP INDEX IF EXISTS idx_circuit_breaker_open;
+DROP INDEX IF EXISTS idx_webhook_subs_active_event;
+DROP INDEX IF EXISTS idx_bulk_items_batch_envelope;
+DROP INDEX IF EXISTS idx_payroll_items_run_status;
+
+DROP INDEX IF EXISTS idx_query_plan_cache_resets;
+DROP INDEX IF EXISTS idx_query_plan_cache_hash;
+DROP TABLE IF EXISTS db_query_plan_cache;
+
+DROP INDEX IF EXISTS idx_deadlock_history_ts;
+DROP TABLE IF EXISTS db_deadlock_history;
+
+-- Reset idle_in_transaction_session_timeout back to the cluster default (disabled).
+DO $$
+BEGIN
+  EXECUTE 'ALTER DATABASE ' || current_database()
+       || ' SET idle_in_transaction_session_timeout = ''0''';
+END;
+$$;

--- a/backend/src/db/rollbacks/048_create_admin_audit_log.sql
+++ b/backend/src/db/rollbacks/048_create_admin_audit_log.sql
@@ -1,0 +1,13 @@
+-- Rollback for Migration 048: Advanced Admin Audit Log (Issue #696)
+
+DROP INDEX IF EXISTS idx_admin_audit_request_id;
+DROP INDEX IF EXISTS idx_admin_audit_severity;
+DROP INDEX IF EXISTS idx_admin_audit_actor;
+DROP INDEX IF EXISTS idx_admin_audit_resource;
+DROP INDEX IF EXISTS idx_admin_audit_action;
+DROP INDEX IF EXISTS idx_admin_audit_org_time;
+
+DROP RULE IF EXISTS admin_audit_log_no_delete ON admin_audit_log;
+DROP RULE IF EXISTS admin_audit_log_no_update ON admin_audit_log;
+
+DROP TABLE IF EXISTS admin_audit_log;

--- a/backend/src/db/rollbacks/049_api_database_scaling_part24.sql
+++ b/backend/src/db/rollbacks/049_api_database_scaling_part24.sql
@@ -1,0 +1,18 @@
+-- Rollback for Migration 049: API & Database Scaling – Part 24 (Issue #269)
+
+DROP FUNCTION IF EXISTS prune_org_query_throughput();
+DROP FUNCTION IF EXISTS prune_pool_utilisation();
+
+DROP INDEX IF EXISTS idx_bulk_batches_org_status;
+DROP INDEX IF EXISTS idx_payroll_items_failed;
+DROP INDEX IF EXISTS idx_payroll_audit_org_action_date;
+DROP INDEX IF EXISTS idx_payroll_runs_org_status_period;
+
+DROP INDEX IF EXISTS idx_org_throughput_high_error;
+DROP INDEX IF EXISTS idx_org_throughput_window;
+DROP INDEX IF EXISTS idx_org_throughput_org_window;
+DROP TABLE IF EXISTS org_query_throughput;
+
+DROP INDEX IF EXISTS idx_pool_utilisation_high;
+DROP INDEX IF EXISTS idx_pool_utilisation_sampled_at;
+DROP TABLE IF EXISTS db_pool_utilisation;

--- a/backend/src/db/rollbacks/050_auto_refund_audit_log.sql
+++ b/backend/src/db/rollbacks/050_auto_refund_audit_log.sql
@@ -1,0 +1,6 @@
+-- Rollback for Migration 050: Auto Refund Audit Log (Issue #600)
+
+DROP INDEX IF EXISTS idx_auto_refund_log_created;
+DROP INDEX IF EXISTS idx_auto_refund_log_org;
+
+DROP TABLE IF EXISTS auto_refund_log;

--- a/backend/src/db/rollbacks/051_batch_archive_tracking.sql
+++ b/backend/src/db/rollbacks/051_batch_archive_tracking.sql
@@ -1,0 +1,7 @@
+-- Rollback for Migration 051: Batch Archive Tracking (Issue #599)
+
+DROP INDEX IF EXISTS idx_batch_archive_date;
+DROP INDEX IF EXISTS idx_batch_archive_org;
+DROP INDEX IF EXISTS idx_batch_archive_batch_id;
+
+DROP TABLE IF EXISTS batch_archive;

--- a/backend/src/db/rollbacks/055_create_migration_run_log.sql
+++ b/backend/src/db/rollbacks/055_create_migration_run_log.sql
@@ -1,0 +1,6 @@
+-- Rollback for Migration 055: Migration Run Log
+
+DROP INDEX IF EXISTS idx_migration_run_log_status_time;
+DROP INDEX IF EXISTS idx_migration_run_log_filename;
+
+DROP TABLE IF EXISTS migration_run_log;

--- a/backend/src/db/rollbacks/056_email_delivery_tracking.sql
+++ b/backend/src/db/rollbacks/056_email_delivery_tracking.sql
@@ -1,0 +1,23 @@
+-- Rollback for Migration 056: Email Delivery Tracking Tables (#1050)
+-- (renumbered from 050 -> 056; see migrations/056_email_delivery_tracking.sql)
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'employees' AND column_name = 'email_invalid_reason') THEN
+    ALTER TABLE employees DROP COLUMN email_invalid_reason;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'employees' AND column_name = 'email_status') THEN
+    ALTER TABLE employees DROP COLUMN email_status;
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS idx_invalid_emails_email;
+DROP TABLE IF EXISTS invalid_emails;
+
+DROP INDEX IF EXISTS idx_email_delivery_logs_created_at;
+DROP INDEX IF EXISTS idx_email_delivery_logs_status;
+DROP INDEX IF EXISTS idx_email_delivery_logs_email;
+DROP INDEX IF EXISTS idx_email_delivery_logs_message_id;
+DROP TABLE IF EXISTS email_delivery_logs;

--- a/backend/src/routes/migrationStatusRoutes.ts
+++ b/backend/src/routes/migrationStatusRoutes.ts
@@ -62,4 +62,46 @@ router.get('/applied', MigrationStatusController.getApplied);
  */
 router.get('/rollbacks', MigrationStatusController.getRollbackHistory);
 
+/**
+ * @swagger
+ * /api/v1/migrations/history:
+ *   get:
+ *     summary: Migration execution history (success/failure/dry-run)
+ *     tags: [Migrations]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *           maximum: 100
+ *     responses:
+ *       200:
+ *         description: Migration run log, most recent first (#1039)
+ */
+router.get('/history', MigrationStatusController.getRunHistory);
+
+/**
+ * @swagger
+ * /api/v1/migrations/history/summary:
+ *   get:
+ *     summary: Aggregate success/failure counts for recent migration runs
+ *     tags: [Migrations]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *           maximum: 100
+ *     responses:
+ *       200:
+ *         description: Success/failure summary plus the most recent failure, if any (#1039)
+ */
+router.get('/history/summary', MigrationStatusController.getRunSummary);
+
 export default router;

--- a/backend/src/services/__tests__/migrationStatusService.test.ts
+++ b/backend/src/services/__tests__/migrationStatusService.test.ts
@@ -86,7 +86,8 @@ describe('MigrationStatusService', () => {
 
       mockPool.query
         .mockResolvedValueOnce({ rows: appliedRows }) // schema_migrations
-        .mockResolvedValueOnce({ rows: [] }); // migration_rollback_log
+        .mockResolvedValueOnce({ rows: [] }) // migration_rollback_log
+        .mockResolvedValueOnce({ rows: [] }); // migration_run_log
 
       // 003_pending_migration.sql has no rollback
       mockFs.existsSync.mockImplementation((p: string) => {
@@ -100,16 +101,29 @@ describe('MigrationStatusService', () => {
       expect(report.pendingCount).toBe(1);
       expect(report.pending[0]!.filename).toBe('003_pending_migration.sql');
       expect(report.pending[0]!.hasRollback).toBe(false);
+      expect(report.runHistory).toEqual([]);
     });
 
     it('handles missing migration_rollback_log table gracefully', async () => {
       mockPool.query
         .mockResolvedValueOnce({ rows: [] })
-        .mockRejectedValueOnce(new Error('relation "migration_rollback_log" does not exist'));
+        .mockRejectedValueOnce(new Error('relation "migration_rollback_log" does not exist'))
+        .mockResolvedValueOnce({ rows: [] }); // migration_run_log
 
       const report = await service.getStatus();
 
       expect(report.rollbackHistory).toEqual([]);
+    });
+
+    it('handles missing migration_run_log table gracefully', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [] }) // schema_migrations
+        .mockResolvedValueOnce({ rows: [] }) // migration_rollback_log
+        .mockRejectedValueOnce(new Error('relation "migration_run_log" does not exist'));
+
+      const report = await service.getStatus();
+
+      expect(report.runHistory).toEqual([]);
     });
   });
 
@@ -145,6 +159,88 @@ describe('MigrationStatusService', () => {
       mockPool.query.mockRejectedValueOnce(new Error('relation does not exist'));
       const result = await service.getRollbackHistory();
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getRunHistory', () => {
+    it('returns migration run events ordered most-recent first', async () => {
+      const events = [
+        {
+          id: 2,
+          filename: '055_create_migration_run_log.sql',
+          run_status: 'success',
+          started_at: new Date(),
+          finished_at: new Date(),
+          execution_ms: 12,
+          backup_taken: true,
+          backup_path: '/backups/pre-migration-x.dump',
+          verification_passed: true,
+          verification_issues: [],
+          error_message: null,
+          rollback_attempted: false,
+          rollback_succeeded: null,
+        },
+        {
+          id: 1,
+          filename: '054_create_invites.sql',
+          run_status: 'failure',
+          started_at: new Date(),
+          finished_at: new Date(),
+          execution_ms: 30,
+          backup_taken: true,
+          backup_path: '/backups/pre-migration-y.dump',
+          verification_passed: false,
+          verification_issues: ['Invalid index: idx_foo'],
+          error_message: 'Post-migration verification failed',
+          rollback_attempted: true,
+          rollback_succeeded: true,
+        },
+      ];
+      mockPool.query.mockResolvedValueOnce({ rows: events });
+
+      const result = await service.getRunHistory();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]!.run_status).toBe('success');
+      expect(result[1]!.run_status).toBe('failure');
+      expect(result[1]!.error_message).toBe('Post-migration verification failed');
+    });
+
+    it('clamps limit to 100', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+      await service.getRunHistory(9999);
+      const callArgs = mockPool.query.mock.calls[0];
+      expect(callArgs[1]).toEqual([100]);
+    });
+
+    it('returns empty array when migration_run_log does not exist', async () => {
+      mockPool.query.mockRejectedValueOnce(new Error('relation "migration_run_log" does not exist'));
+      const result = await service.getRunHistory();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getRunSummary', () => {
+    it('summarizes success/failure counts and surfaces the last failure', async () => {
+      const events = [
+        { id: 3, filename: 'c.sql', run_status: 'success', started_at: new Date(), finished_at: new Date(), execution_ms: 5, backup_taken: true, backup_path: null, verification_passed: true, verification_issues: [], error_message: null, rollback_attempted: false, rollback_succeeded: null },
+        { id: 2, filename: 'b.sql', run_status: 'failure', started_at: new Date(), finished_at: new Date(), execution_ms: 5, backup_taken: true, backup_path: null, verification_passed: false, verification_issues: ['bad'], error_message: 'boom', rollback_attempted: true, rollback_succeeded: true },
+        { id: 1, filename: 'a.sql', run_status: 'success', started_at: new Date(), finished_at: new Date(), execution_ms: 5, backup_taken: true, backup_path: null, verification_passed: true, verification_issues: [], error_message: null, rollback_attempted: false, rollback_succeeded: null },
+      ];
+      mockPool.query.mockResolvedValueOnce({ rows: events });
+
+      const summary = await service.getRunSummary();
+
+      expect(summary.total).toBe(3);
+      expect(summary.succeeded).toBe(2);
+      expect(summary.failed).toBe(1);
+      expect(summary.lastFailure?.filename).toBe('b.sql');
+    });
+
+    it('returns zeroed summary when no run history exists', async () => {
+      mockPool.query.mockRejectedValueOnce(new Error('relation does not exist'));
+      const summary = await service.getRunSummary();
+      expect(summary).toEqual({ total: 0, succeeded: 0, failed: 0, lastFailure: null });
     });
   });
 });

--- a/backend/src/services/migrationStatusService.ts
+++ b/backend/src/services/migrationStatusService.ts
@@ -32,6 +32,7 @@ export interface MigrationStatusReport {
   applied: AppliedMigration[];
   pending: MigrationFileInfo[];
   rollbackHistory: RollbackEvent[];
+  runHistory: MigrationRunEvent[];
 }
 
 export interface RollbackEvent {
@@ -41,6 +42,27 @@ export interface RollbackEvent {
   rolled_back_by: string;
   reason: string | null;
   execution_ms: number | null;
+}
+
+/**
+ * One row of `migration_run_log` — a record of a single migration execution
+ * attempt (success, failure, or dry-run), including backup and post-migration
+ * verification outcomes. Populated by `backend/src/db/migrate.ts` (#1039).
+ */
+export interface MigrationRunEvent {
+  id: number;
+  filename: string;
+  run_status: 'success' | 'failure' | 'dry_run';
+  started_at: Date;
+  finished_at: Date;
+  execution_ms: number | null;
+  backup_taken: boolean;
+  backup_path: string | null;
+  verification_passed: boolean | null;
+  verification_issues: string[] | null;
+  error_message: string | null;
+  rollback_attempted: boolean;
+  rollback_succeeded: boolean | null;
 }
 
 function sha256(content: string): string {
@@ -95,12 +117,15 @@ export class MigrationStatusService {
       logger.debug('migration_rollback_log table not yet available');
     }
 
+    const runHistory = await this.getRunHistory(50);
+
     return {
       appliedCount: appliedRows.rows.length,
       pendingCount: pending.length,
       applied: appliedRows.rows,
       pending,
       rollbackHistory,
+      runHistory,
     };
   }
 
@@ -125,5 +150,43 @@ export class MigrationStatusService {
       logger.debug('migration_rollback_log table not yet available');
       return [];
     }
+  }
+
+  /**
+   * History of every migration EXECUTION ATTEMPT (success, failure, or
+   * dry-run), most-recent first. Sourced from `migration_run_log`, written by
+   * `backend/src/db/migrate.ts` on every real run (#1039). Gracefully returns
+   * an empty array if the table has not been bootstrapped yet.
+   */
+  async getRunHistory(limit = 20): Promise<MigrationRunEvent[]> {
+    try {
+      const result = await pool.query<MigrationRunEvent>(
+        `SELECT id, filename, run_status, started_at, finished_at, execution_ms,
+                backup_taken, backup_path, verification_passed, verification_issues,
+                error_message, rollback_attempted, rollback_succeeded
+         FROM migration_run_log
+         ORDER BY finished_at DESC
+         LIMIT $1`,
+        [Math.min(limit, 100)]
+      );
+      return result.rows;
+    } catch {
+      logger.debug('migration_run_log table not yet available');
+      return [];
+    }
+  }
+
+  /**
+   * Convenience summary used by the status endpoint / dashboards: how many
+   * recorded runs succeeded vs failed, out of the most recent `limit` attempts.
+   */
+  async getRunSummary(
+    limit = 50
+  ): Promise<{ total: number; succeeded: number; failed: number; lastFailure: MigrationRunEvent | null }> {
+    const history = await this.getRunHistory(limit);
+    const succeeded = history.filter((h) => h.run_status === 'success').length;
+    const failed = history.filter((h) => h.run_status === 'failure').length;
+    const lastFailure = history.find((h) => h.run_status === 'failure') ?? null;
+    return { total: history.length, succeeded, failed, lastFailure };
   }
 }

--- a/backend/src/stellar/client.ts
+++ b/backend/src/stellar/client.ts
@@ -1,8 +1,9 @@
-import { Horizon } from '@stellar/stellar-sdk';
+import { Horizon, rpc } from '@stellar/stellar-sdk';
 import { getNetworkConfig, NetworkConfig } from './network.js';
 
 let cachedServer: Horizon.Server | null = null;
 let cachedConfig: NetworkConfig | null = null;
+let cachedSorobanServer: rpc.Server | null = null;
 
 /**
  * Returns a cached Horizon server instance configured for the active
@@ -15,6 +16,20 @@ export function getStellarServer(): Horizon.Server {
     cachedConfig = config;
   }
   return cachedServer;
+}
+
+/**
+ * Returns a cached Soroban RPC server instance for the active Stellar
+ * network, or `null` if no Soroban RPC URL is configured (e.g. mainnet
+ * without `STELLAR_SOROBAN_RPC_URL` set — see network.ts).
+ */
+export function getSorobanServer(): rpc.Server | null {
+  const config = getActiveNetworkConfig();
+  if (!config.sorobanRpcUrl) return null;
+  if (!cachedSorobanServer) {
+    cachedSorobanServer = new rpc.Server(config.sorobanRpcUrl);
+  }
+  return cachedSorobanServer;
 }
 
 /**
@@ -36,4 +51,5 @@ export function getActiveNetworkConfig(): NetworkConfig {
 export function resetClient(): void {
   cachedServer = null;
   cachedConfig = null;
+  cachedSorobanServer = null;
 }

--- a/backend/src/stellar/connectionTest.ts
+++ b/backend/src/stellar/connectionTest.ts
@@ -1,4 +1,4 @@
-import { getStellarServer, getActiveNetworkConfig } from './client.js';
+import { getStellarServer, getSorobanServer, getActiveNetworkConfig } from './client.js';
 
 export interface ConnectionTestResult {
   connected: boolean;
@@ -6,6 +6,16 @@ export interface ConnectionTestResult {
   horizonUrl: string;
   latencyMs: number;
   ledgerSequence?: number;
+  error?: string;
+}
+
+export interface SorobanConnectionTestResult {
+  configured: boolean;
+  connected: boolean;
+  network: string;
+  rpcUrl: string;
+  latencyMs: number;
+  latestLedger?: number;
   error?: string;
 }
 
@@ -35,6 +45,51 @@ export async function testConnection(): Promise<ConnectionTestResult> {
       connected: false,
       network: config.network,
       horizonUrl: config.horizonUrl,
+      latencyMs: Date.now() - start,
+      error: err instanceof Error ? err.message : 'Connection failed',
+    };
+  }
+}
+
+/**
+ * Performs a basic connectivity check against the configured Soroban RPC
+ * server via its `getHealth()` method. Returns `configured: false` (rather
+ * than attempting a request) when no Soroban RPC URL is resolved for the
+ * active network — e.g. mainnet without `STELLAR_SOROBAN_RPC_URL` set.
+ */
+export async function testSorobanConnection(): Promise<SorobanConnectionTestResult> {
+  const config = getActiveNetworkConfig();
+  const server = getSorobanServer();
+
+  if (!server) {
+    return {
+      configured: false,
+      connected: false,
+      network: config.network,
+      rpcUrl: '',
+      latencyMs: 0,
+    };
+  }
+
+  const start = Date.now();
+  try {
+    const health = await server.getHealth();
+    const latencyMs = Date.now() - start;
+
+    return {
+      configured: true,
+      connected: health.status === 'healthy',
+      network: config.network,
+      rpcUrl: config.sorobanRpcUrl,
+      latencyMs,
+      latestLedger: (health as unknown as { latestLedger?: number }).latestLedger,
+    };
+  } catch (err) {
+    return {
+      configured: true,
+      connected: false,
+      network: config.network,
+      rpcUrl: config.sorobanRpcUrl,
       latencyMs: Date.now() - start,
       error: err instanceof Error ? err.message : 'Connection failed',
     };

--- a/backend/src/stellar/index.ts
+++ b/backend/src/stellar/index.ts
@@ -1,5 +1,10 @@
 export { StellarNetwork, getNetworkConfig, type NetworkConfig } from './network.js';
 
-export { getStellarServer, getActiveNetworkConfig, resetClient } from './client.js';
+export { getStellarServer, getSorobanServer, getActiveNetworkConfig, resetClient } from './client.js';
 
-export { testConnection, type ConnectionTestResult } from './connectionTest.js';
+export {
+  testConnection,
+  type ConnectionTestResult,
+  testSorobanConnection,
+  type SorobanConnectionTestResult,
+} from './connectionTest.js';

--- a/backend/src/stellar/network.ts
+++ b/backend/src/stellar/network.ts
@@ -9,16 +9,24 @@ export interface NetworkConfig {
   network: StellarNetwork;
   networkPassphrase: string;
   horizonUrl: string;
+  /** Soroban RPC URL for this network, or '' if none is configured/available. */
+  sorobanRpcUrl: string;
 }
 
 const NETWORK_DEFAULTS: Record<StellarNetwork, Omit<NetworkConfig, 'network'>> = {
   [StellarNetwork.TESTNET]: {
     networkPassphrase: Networks.TESTNET,
     horizonUrl: 'https://horizon-testnet.stellar.org',
+    sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
   },
   [StellarNetwork.MAINNET]: {
     networkPassphrase: Networks.PUBLIC,
     horizonUrl: 'https://horizon.stellar.org',
+    // There is no free, universally-available public Soroban RPC endpoint for
+    // mainnet — operators must set STELLAR_SOROBAN_RPC_URL to their provider
+    // (e.g. a self-hosted node or a paid RPC provider). Left blank so health
+    // checks correctly report "not_configured" instead of guessing a URL.
+    sorobanRpcUrl: '',
   },
 };
 
@@ -27,9 +35,10 @@ const NETWORK_DEFAULTS: Record<StellarNetwork, Omit<NetworkConfig, 'network'>> =
  * variables with sensible defaults for testnet development.
  *
  * Environment variables:
- *   STELLAR_NETWORK           - "testnet" | "mainnet" (default: "testnet")
- *   STELLAR_NETWORK_PASSPHRASE - Override the default passphrase
- *   STELLAR_HORIZON_URL        - Override the default Horizon URL
+ *   STELLAR_NETWORK             - "testnet" | "mainnet" (default: "testnet")
+ *   STELLAR_NETWORK_PASSPHRASE  - Override the default passphrase
+ *   STELLAR_HORIZON_URL         - Override the default Horizon URL
+ *   STELLAR_SOROBAN_RPC_URL     - Override the default Soroban RPC URL
  */
 export function getNetworkConfig(): NetworkConfig {
   const env = (process.env.STELLAR_NETWORK || 'testnet').toLowerCase();
@@ -42,5 +51,6 @@ export function getNetworkConfig(): NetworkConfig {
     network,
     networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE || defaults.networkPassphrase,
     horizonUrl: process.env.STELLAR_HORIZON_URL || defaults.horizonUrl,
+    sorobanRpcUrl: process.env.STELLAR_SOROBAN_RPC_URL || defaults.sorobanRpcUrl,
   };
 }


### PR DESCRIPTION
## Summary

Implements both #1038 (comprehensive dependency health checks) and #1039 (migration safety checks + rollback scripts) in the backend.

---

## #1038 — Comprehensive health checks for all external dependencies

Extends `backend/src/controllers/healthController.ts` (kept the existing Redis fail-fast setup, `pool`/`ThrottlingService` wiring) and `backend/src/stellar/*` (new Soroban RPC client) rather than replacing anything.

| Acceptance criterion | Implementation |
|---|---|
| `GET /health` returns per-dependency status (healthy/degraded/unhealthy) with latency | `healthController.ts` — `checkDatabase/checkRedis/checkStellarHorizon/checkStellarSoroban/checkElasticsearch/checkEmail`, each returning `{status, critical, latencyMs, error}`. Overall `status` field is `healthy \| degraded \| unhealthy`. |
| `/health/live` returns 200, no dependency checks | `HealthController.getLiveness` — unchanged, zero I/O. |
| `/health/ready` returns 200 only if all **critical** deps are healthy | `HealthController.getReadiness` — critical set = Postgres, Redis, Stellar Horizon, Stellar Soroban RPC. A critical dep that's simply `not_configured` (e.g. Redis not wired up in an environment) doesn't block readiness — only an actively `unhealthy` critical dep does. |
| Non-critical failure → "degraded" not "unhealthy" | `computeOverallStatus()` — critical unhealthy → `unhealthy` (503); non-critical unhealthy → `degraded` (200); else `healthy`. Non-critical = Elasticsearch, email. |
| Cached 5s | Module-level `cachedReport` + `HEALTH_CACHE_TTL_MS = 5000`, shared by `/health` and `/health/ready`. `_resetHealthCacheForTests()` exported for tests. |
| 2s timeout per check | `withTimeout()` wraps every dependency call; `DEPENDENCY_CHECK_TIMEOUT_MS = 2000`. |

Stellar: reused the existing `testConnection()` Horizon check (`backend/src/stellar/connectionTest.ts`) and added `testSorobanConnection()` alongside a new `getSorobanServer()` in `client.ts` (uses the SDK's `rpc.Server(...).getHealth()`). Added `sorobanRpcUrl` to `NetworkConfig` (`network.ts`) with a testnet default and `STELLAR_SOROBAN_RPC_URL` env override (mainnet has no free public RPC, so it's blank by default → reported as `not_configured` rather than guessing a URL).

Elasticsearch: only instantiated when `ELASTICSEARCH_ENABLED=true` (matches `logger.ts`'s existing pattern), checked via `Client.ping()`.

Email: deliberately does **not** reuse `IEmailProvider.validateConfig()` (SendGrid/Resend), because that method sends a real test email on every call — unacceptable on a health-check hot path. Instead hits a read-only, authenticated endpoint (`GET /v3/user/account` for SendGrid, `GET /domains` for Resend) that sends nothing.

---

## #1039 — Database migration safety checks and rollback scripts

`backend/src/db/migrate.ts` rewritten with real substance on top of the existing checksum/idempotency runner (kept: lexicographic ordering, `assertNoDuplicatePrefixes`, drift detection).

| Acceptance criterion | Implementation |
|---|---|
| Backup before execution | `takePreMigrationBackup()` shells out to `pg_dump --format=custom`. On by default when there's pending work; skip via `--skip-backup` / `MIGRATION_SKIP_BACKUP=true` (dev only — aborts the run if the backup fails and wasn't explicitly skipped). |
| Dry-run generates SQL without executing | `runDryRun()` — one **read-only** query to determine the real pending set (fixed a bug where the old dry-run treated every file as pending regardless of `schema_migrations`), then `renderDryRunPlan()` writes the literal SQL that would run to `<backup dir>/dry-run-plans/*.sql`. Works fully offline if `DATABASE_URL` isn't set. |
| Every migration has a rollback | **Found and fixed a real gap**: migrations `047`–`051` had no rollback files, and `050_auto_refund_audit_log.sql` / `050_email_delivery_tracking.sql` shared the same numeric prefix — which would make the runner's own duplicate-prefix guard abort on any real database. Added the 6 missing rollback files and renumbered the duplicate to `056` (pure rename, zero SQL content changed). 56/56 migrations now have an exact-name-matching rollback (verified in tests and in `MIGRATION_GUIDE.md`). Also added migration `055_create_migration_run_log.sql` (+ rollback) for the run-log table below. |
| Migration lock timeout = 30s | `acquireMigrationLock()` — polls `pg_try_advisory_lock`, gives up after `LOCK_TIMEOUT_MS = 30_000`; also sets session `lock_timeout = 30000ms` as defense-in-depth for any lock the migration's own DDL waits on. |
| Post-migration verification | `verifySchemaIntegrity()` — runs inside the migration's own transaction (before COMMIT): checks for any `NOT VALID` index or `NOT VALIDATED` constraint. A failure here still triggers a full rollback of that migration. |
| Migration status endpoint: history w/ success+failure | New `migration_run_log` table (bootstrapped inline so it exists before the migration file that formally introduces it even runs) records every attempt — success/failure/dry_run — with backup/verification/rollback outcome. `MigrationStatusService.getRunHistory()`/`getRunSummary()` + new routes `GET /api/v1/migrations/history` and `GET /api/v1/migrations/history/summary`. |
| Failed migration → alert + rollback attempt | `alertMigrationFailure()` logs a structured `ALERT alert=MIGRATION_FAILED` block (same "structured log, TODO wire real notifier" pattern already used in `backupVerificationWorker.ts` — no Sentry/PagerDuty in this codebase yet). `attemptAutoRollback()` then executes the matching rollback script as a defense-in-depth safety net. |

---

## Test plan

- `npx tsc --noEmit` — **clean** for every file this PR touches (the only remaining errors are in `authController.ts` / `fxRateService.test.ts`, both pre-existing and untouched by this PR — confirmed via `git stash`).
- Unit tests added/extended, mocking `pg`/`ioredis`/`@elastic/elasticsearch`/`fetch`/Stellar clients — no real external service is ever contacted:
  - `backend/src/controllers/__tests__/healthController.test.ts` — rewritten for the new healthy/degraded/unhealthy vocabulary; covers per-dependency status+latency, liveness, readiness (critical vs non-critical), the 5s cache, and the Elasticsearch/email degraded paths.
  - `backend/src/services/__tests__/migrationStatusService.test.ts` — extended with `getRunHistory`/`getRunSummary` coverage (including the "table not yet bootstrapped" fallback).
  - `backend/src/db/__tests__/migrate.test.ts` (new) — sha256, duplicate-prefix detection (including a regression check against the real migrations directory), `pg_dump` argv construction, backup-dir resolution, dry-run SQL rendering, schema verification pass/fail, the 30s advisory lock (immediate-acquire and timeout-and-reject), lock release, run-log insert shape, and auto-rollback (executed against the real `045_add_performance_bonus_fields.sql` rollback file).

- **Needs maintainer verification / pre-existing environment issue**: this sandbox's `npm test` currently fails to even *load* ~37 of 73 test suites on unmodified `main` (verified via `git stash` before touching anything) — e.g. `src/__tests__/swaggerDocs.test.ts` fails with `SyntaxError: Cannot use 'import.meta' outside a module` just from importing `app.ts`, and `src/services/__tests__/freezeService.test.ts` fails on an unrelated `StellarService.simulateTransaction is not a function`. This is a pre-existing `ts-jest`/`NodeNext` ESM transform issue (there's also no CI workflow that runs `cd backend && npm test` today — `.github/workflows/*.yml` only covers the Soroban contracts). My 3 test files fall into this same bucket and could not be executed via `npx jest` in this sandbox; before/after suite-wide pass/fail counts are identical (508 passed / 121 failed either way), so nothing here is a regression. To still get real execution confidence (not just code review), I ran the new `migrate.ts` logic directly via `tsx` (bypassing the broken ts-jest pipeline) — all 16 checks passed for real, including the auto-rollback path actually executing `045_add_performance_bonus_fields.sql`'s rollback SQL and the dry-run path actually writing a real SQL plan file covering all 56 real migrations to disk.
- Live-infra behavior that needs verification against real Postgres/Redis/Stellar Horizon+Soroban/Elasticsearch/SendGrid+Resend in the maintainer's environment: the actual `pg_dump` invocation, the advisory-lock behavior under real concurrent runs, and the real Horizon/Soroban/Elasticsearch/email HTTP calls (all are mocked in tests here per the task constraints — no outbound network calls were made from this sandbox).

Closes #1038
Closes #1039
Closes #1414 
Closes #1415
