### PR TITLE
Redesign ContractErrorPanel & ContractMetricsPanel with design tokens and polished transitions

### DIFF
--- a/frontend/src/components/ContractErrorPanel.module.css
+++ b/frontend/src/components/ContractErrorPanel.module.css
@@ -1,14 +1,14 @@
 .container {
   display: flex;
   flex-direction: column;
-  background-color: color-mix(in srgb, var(--accent) 5%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent) 15%, transparent);
+  background-color: color-mix(in srgb, var(--danger) 5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 15%, transparent);
   border-radius: 12px;
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
   overflow: hidden;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: var(--shadow-card);
   backdrop-filter: blur(10px);
 }
 
@@ -18,13 +18,13 @@
   align-items: center;
   padding: 12px 16px;
   cursor: pointer;
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--accent) 10%, transparent);
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--danger) 10%, transparent);
   transition: background-color 0.2s;
 }
 
 .header:hover {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
 }
 
 .titleArea {
@@ -36,13 +36,13 @@
 .title {
   font-weight: 700;
   font-size: 0.875rem;
-  color: var(--accent);
+  color: var(--danger);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .errorIcon {
-  color: var(--accent);
+  color: var(--danger);
   width: 18px;
   height: 18px;
 }
@@ -76,7 +76,7 @@
 
 .clearBtn:focus {
   outline: none;
-  ring: 2px var(--accent);
+  box-shadow: 0 0 0 2px var(--accent);
 }
 
 .content {
@@ -89,6 +89,17 @@
   grid-template-columns: 140px 1fr;
   row-gap: 12px;
   column-gap: 16px;
+}
+
+@media (max-width: 640px) {
+  .errorGrid {
+    grid-template-columns: 1fr;
+    row-gap: 4px;
+  }
+
+  .label {
+    padding-top: 8px;
+  }
 }
 
 .label {
@@ -109,8 +120,8 @@
 .valueCode {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.8125rem;
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
   padding: 2px 6px;
   border-radius: 4px;
   width: fit-content;
@@ -119,7 +130,7 @@
 .valueHighlight {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--danger);
   line-height: 1.5;
 }
 
@@ -186,7 +197,7 @@
 }
 
 .successIcon {
-  color: var(--accent);
+  color: var(--success);
 }
 
 @keyframes slideDown {

--- a/frontend/src/components/ContractErrorPanel.module.css
+++ b/frontend/src/components/ContractErrorPanel.module.css
@@ -81,7 +81,20 @@
 
 .content {
   padding: 16px;
-  animation: slideDown 0.3s ease-out;
+}
+
+.chevron {
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevron {
+    transition: none;
+  }
 }
 
 .errorGrid {
@@ -198,15 +211,4 @@
 
 .successIcon {
   color: var(--success);
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }

--- a/frontend/src/components/ContractErrorPanel.tsx
+++ b/frontend/src/components/ContractErrorPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { AlertCircle, ChevronDown, ChevronUp, Copy, CheckCircle2 } from 'lucide-react';
+import { AlertCircle, ChevronDown, Copy, CheckCircle2 } from 'lucide-react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import type { ContractErrorDetail } from '../utils/contractErrorParser';
 import { useTranslation } from 'react-i18next';
 import { useNotification } from '../hooks/useNotification';
@@ -20,6 +21,7 @@ export const ContractErrorPanel: React.FC<Props> = ({ error, title, onClear }) =
   const [isOpen, setIsOpen] = useState(true);
   const [isCopied, setIsCopied] = useState(false);
   const { notifySuccess, notifyError } = useNotification();
+  const prefersReducedMotion = useReducedMotion();
 
   if (!error) return null;
 
@@ -55,47 +57,60 @@ export const ContractErrorPanel: React.FC<Props> = ({ error, title, onClear }) =
               {t('common.dismiss')}
             </button>
           )}
-          {isOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+          <ChevronDown
+            size={16}
+            className={`${styles.chevron} ${isOpen ? styles.chevronOpen : ''}`}
+          />
         </div>
       </div>
 
-      {isOpen && (
-        <div className={styles.content}>
-          <div className={styles.errorGrid}>
-            <div className={styles.label}>{t('contractError.errorCode')}</div>
-            <div className={styles.valueCode}>{error.code}</div>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.2 }}
+            style={{ overflow: 'hidden' }}
+          >
+            <div className={styles.content}>
+              <div className={styles.errorGrid}>
+                <div className={styles.label}>{t('contractError.errorCode')}</div>
+                <div className={styles.valueCode}>{error.code}</div>
 
-            <div className={styles.label}>{t('contractError.description')}</div>
-            <div className={styles.value}>{error.message}</div>
+                <div className={styles.label}>{t('contractError.description')}</div>
+                <div className={styles.value}>{error.message}</div>
 
-            <div className={styles.label}>{t('contractError.suggestedAction')}</div>
-            <div className={styles.valueHighlight}>{error.suggestedAction}</div>
-          </div>
-
-          {error.rawXdr && (
-            <div className={styles.xdrSection}>
-              <div className={styles.xdrHeader}>
-                <span className={styles.xdrLabel}>{t('contractError.rawXdrResult')}</span>
-                <button
-                  className={styles.copyBtn}
-                  onClick={() => {
-                    void handleCopyXdr();
-                  }}
-                  title={t('contractError.copyXdrToClipboard')}
-                >
-                  {isCopied ? (
-                    <CheckCircle2 size={14} className={styles.successIcon} />
-                  ) : (
-                    <Copy size={14} />
-                  )}
-                  {isCopied ? t('contractError.copied') : t('contractError.copyXdr')}
-                </button>
+                <div className={styles.label}>{t('contractError.suggestedAction')}</div>
+                <div className={styles.valueHighlight}>{error.suggestedAction}</div>
               </div>
-              <div className={styles.xdrValue}>{error.rawXdr}</div>
+
+              {error.rawXdr && (
+                <div className={styles.xdrSection}>
+                  <div className={styles.xdrHeader}>
+                    <span className={styles.xdrLabel}>{t('contractError.rawXdrResult')}</span>
+                    <button
+                      className={styles.copyBtn}
+                      onClick={() => {
+                        void handleCopyXdr();
+                      }}
+                      title={t('contractError.copyXdrToClipboard')}
+                    >
+                      {isCopied ? (
+                        <CheckCircle2 size={14} className={styles.successIcon} />
+                      ) : (
+                        <Copy size={14} />
+                      )}
+                      {isCopied ? t('contractError.copied') : t('contractError.copyXdr')}
+                    </button>
+                  </div>
+                  <div className={styles.xdrValue}>{error.rawXdr}</div>
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      )}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/frontend/src/components/ContractMetricsPanel.tsx
+++ b/frontend/src/components/ContractMetricsPanel.tsx
@@ -10,9 +10,9 @@ interface MetricRowProps {
 
 function MetricRow({ metric }: MetricRowProps) {
   const statusIcon = {
-    ok: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400" aria-hidden />,
+    ok: <CheckCircle2 className="h-3.5 w-3.5 text-success" aria-hidden />,
     warn: <AlertCircle className="h-3.5 w-3.5 text-amber-400" aria-hidden />,
-    error: <AlertCircle className="h-3.5 w-3.5 text-red-400" aria-hidden />,
+    error: <AlertCircle className="h-3.5 w-3.5 text-danger" aria-hidden />,
     loading: <Loader2 className="h-3.5 w-3.5 animate-spin text-muted" aria-hidden />,
   }[metric.status];
 
@@ -25,7 +25,7 @@ function MetricRow({ metric }: MetricRowProps) {
       <span
         className={`text-xs font-mono font-semibold ${
           metric.status === 'error'
-            ? 'text-red-400'
+            ? 'text-danger'
             : metric.status === 'warn'
               ? 'text-amber-400'
               : 'text-text'
@@ -111,7 +111,7 @@ export function ContractMetricsPanel({
       {error ? (
         <div
           role="alert"
-          className="flex items-center gap-2 rounded-lg border border-red-800/50 bg-red-950/30 px-3 py-2 text-xs text-red-400"
+          className="flex items-center gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger"
         >
           <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden />
           {error}

--- a/frontend/src/components/ContractMetricsPanel.tsx
+++ b/frontend/src/components/ContractMetricsPanel.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef, useState } from 'react';
 import { Activity, AlertCircle, CheckCircle2, Loader2, RefreshCw } from 'lucide-react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { ContractMetric, ContractMetrics } from '../hooks/useContractMetrics';
 
@@ -9,11 +11,29 @@ interface MetricRowProps {
 }
 
 function MetricRow({ metric }: MetricRowProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const previousValueRef = useRef(metric.value);
+  const [justUpdated, setJustUpdated] = useState(false);
+
+  useEffect(() => {
+    if (previousValueRef.current === metric.value) return;
+    previousValueRef.current = metric.value;
+    if (prefersReducedMotion) return;
+    setJustUpdated(true);
+    const timeout = setTimeout(() => setJustUpdated(false), 1200);
+    return () => clearTimeout(timeout);
+  }, [metric.value, prefersReducedMotion]);
+
   const statusIcon = {
     ok: <CheckCircle2 className="h-3.5 w-3.5 text-success" aria-hidden />,
     warn: <AlertCircle className="h-3.5 w-3.5 text-amber-400" aria-hidden />,
     error: <AlertCircle className="h-3.5 w-3.5 text-danger" aria-hidden />,
-    loading: <Loader2 className="h-3.5 w-3.5 animate-spin text-muted" aria-hidden />,
+    loading: (
+      <Loader2
+        className="h-3.5 w-3.5 motion-safe:animate-spin motion-reduce:animate-none text-muted"
+        aria-hidden
+      />
+    ),
   }[metric.status];
 
   return (
@@ -23,7 +43,7 @@ function MetricRow({ metric }: MetricRowProps) {
         {metric.label}
       </span>
       <span
-        className={`text-xs font-mono font-semibold ${
+        className={`text-xs font-mono font-semibold ${justUpdated ? 'status-flash' : ''} ${
           metric.status === 'error'
             ? 'text-danger'
             : metric.status === 'warn'
@@ -45,7 +65,7 @@ interface ContractCardProps {
 
 function ContractCard({ title, metrics }: ContractCardProps) {
   return (
-    <div className="rounded-xl border border-border bg-surface/50 p-4">
+    <div className="rounded-xl border border-border bg-surface/50 p-4 transition-colors duration-200 hover:border-hi hover:bg-surface/70">
       <p className="mb-3 text-[11px] font-bold uppercase tracking-widest text-muted">{title}</p>
       {metrics.map((m) => (
         <MetricRow key={m.label} metric={m} />
@@ -79,6 +99,7 @@ export function ContractMetricsPanel({
   onRefresh,
 }: ContractMetricsPanelProps) {
   const { t, i18n } = useTranslation();
+  const prefersReducedMotion = useReducedMotion();
   return (
     <section aria-label={t('contractMetrics.ariaLabel')} className="space-y-4">
       {/* Header */}
@@ -102,55 +123,90 @@ export function ContractMetricsPanel({
             aria-label={t('contractMetrics.refreshAriaLabel')}
             className="rounded-md p-1.5 text-muted hover:bg-surface-hi hover:text-text disabled:opacity-40 transition-colors"
           >
-            <RefreshCw className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} aria-hidden />
+            <RefreshCw
+              className={`h-3.5 w-3.5 ${isLoading ? 'motion-safe:animate-spin motion-reduce:animate-none' : ''}`}
+              aria-hidden
+            />
           </button>
         </div>
       </div>
 
       {/* Error banner */}
-      {error ? (
-        <div
-          role="alert"
-          className="flex items-center gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger"
-        >
-          <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden />
-          {error}
-        </div>
-      ) : null}
+      <AnimatePresence>
+        {error ? (
+          <motion.div
+            role="alert"
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.2 }}
+            style={{ overflow: 'hidden' }}
+          >
+            <div className="flex items-center gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              {error}
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
 
       {/* Metric cards grid */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        <ContractCard
-          title={t('contractMetrics.bulkPayment')}
-          metrics={[
-            metrics.bulk_payment.batchCount,
-            metrics.bulk_payment.sequence,
-            metrics.bulk_payment.isPaused,
-          ]}
-        />
-        <ContractCard
-          title={t('contractMetrics.revenueSplit')}
-          metrics={[
-            metrics.revenue_split.distributionCount,
-            metrics.revenue_split.totalDistributed,
-            metrics.revenue_split.isPaused,
-          ]}
-        />
-        <ContractCard
-          title={t('contractMetrics.vestingEscrow')}
-          metrics={[
-            metrics.vesting_escrow.isActive,
-            metrics.vesting_escrow.vestedAmount,
-            metrics.vesting_escrow.claimableAmount,
-          ]}
-        />
-        <ContractCard
-          title={t('contractMetrics.crossAssetPayment')}
-          metrics={[
-            metrics.cross_asset_payment.paymentCount,
-            metrics.cross_asset_payment.pendingAdmin,
-          ]}
-        />
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.25, delay: prefersReducedMotion ? 0 : 0 }}
+        >
+          <ContractCard
+            title={t('contractMetrics.bulkPayment')}
+            metrics={[
+              metrics.bulk_payment.batchCount,
+              metrics.bulk_payment.sequence,
+              metrics.bulk_payment.isPaused,
+            ]}
+          />
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.25, delay: prefersReducedMotion ? 0 : 0.05 }}
+        >
+          <ContractCard
+            title={t('contractMetrics.revenueSplit')}
+            metrics={[
+              metrics.revenue_split.distributionCount,
+              metrics.revenue_split.totalDistributed,
+              metrics.revenue_split.isPaused,
+            ]}
+          />
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.25, delay: prefersReducedMotion ? 0 : 0.1 }}
+        >
+          <ContractCard
+            title={t('contractMetrics.vestingEscrow')}
+            metrics={[
+              metrics.vesting_escrow.isActive,
+              metrics.vesting_escrow.vestedAmount,
+              metrics.vesting_escrow.claimableAmount,
+            ]}
+          />
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.25, delay: prefersReducedMotion ? 0 : 0.15 }}
+        >
+          <ContractCard
+            title={t('contractMetrics.crossAssetPayment')}
+            metrics={[
+              metrics.cross_asset_payment.paymentCount,
+              metrics.cross_asset_payment.pendingAdmin,
+            ]}
+          />
+        </motion.div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

- Redesign `ContractErrorPanel` to use the app's `--danger`/`--success` semantic tokens instead of the brand `--accent` color, fix a broken `ring` CSS property on the dismiss button's focus state, swap the hardcoded box-shadow for `--shadow-card`, and stack the error grid on narrow viewports.
- Add polished open/close transitions to `ContractErrorPanel` using framer-motion (matching the existing accordion pattern in `HelpCenter.tsx`), with an animated chevron and full `prefers-reduced-motion` support.
- Redesign `ContractMetricsPanel` to replace raw Tailwind color utilities (`emerald-400`, `red-400`, `red-800/50`, `red-950/30`) with the app's `--success`/`--danger` tokens so both statuses and the error banner track light/dark theme changes correctly.
- Add polished transitions to `ContractMetricsPanel`: animated error banner and card grid entrance, a brief flash on metric value changes (reusing the existing `status-flash` utility), a hover treatment on metric cards, and `prefers-reduced-motion`-gated spin/motion animations.

No functional behavior or props changed in either component.

Closes #1408, Closes #1409, Closes #1410, Closes #1411

## Test plan

- [x] `tsc --noEmit` passes with no errors in either changed file
- [x] `eslint` passes with no errors/warnings in either changed file
- [x] `vite build` production build succeeds
- [x] Verified dev server serves the app without errors
- [ ] Manual visual QA in light/dark themes at responsive breakpoints (not possible in this environment — no browser automation available; please double check visually before merging)