### PR TITLE
Polish EmployeeProfileModal transitions & redesign EmployeeRemovalConfirmModal onto design tokens

### DIFF
--- a/frontend/src/components/EmployeeProfileModal.tsx
+++ b/frontend/src/components/EmployeeProfileModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { X, User, Mail, Phone, Briefcase, CreditCard } from 'lucide-react';
 import { FormField } from './FormField';
 
@@ -45,6 +46,8 @@ export const EmployeeProfileModal: React.FC<EmployeeProfileModalProps> = ({
   onSave,
 }) => {
   const { t } = useTranslation();
+  const prefersReducedMotion = useReducedMotion();
+  const transitionDuration = prefersReducedMotion ? 0 : 0.2;
   const [formData, setFormData] = useState<EmployeeProfileData>(
     employee || {
       firstName: '',
@@ -67,369 +70,403 @@ export const EmployeeProfileModal: React.FC<EmployeeProfileModalProps> = ({
     onClose();
   };
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
-      <div className="w-full max-w-4xl max-h-[90vh] overflow-y-auto rounded-3xl border border-hi bg-[var(--surface)] shadow-[var(--shadow-lg)]">
-        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-hi bg-[var(--surface)] px-6 py-5">
-          <div>
-            <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
-              {employee?.id ? t('employeeProfile.updateProfile') : t('employeeProfile.title')}
-            </p>
-            <h2 className="mt-1 text-2xl font-black text-[var(--text)]">
-              {employee?.id
-                ? `${employee.firstName} ${employee.lastName}`
-                : t('employeeProfile.subtitle')}
-            </h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-xl p-2 text-[var(--muted)] transition hover:bg-white/5 hover:text-[var(--text)]"
-            aria-label={t('common.close')}
+    <AnimatePresence>
+      {isOpen ? (
+        <motion.div
+          role="presentation"
+          initial={{ opacity: prefersReducedMotion ? 1 : 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: prefersReducedMotion ? 1 : 0 }}
+          transition={{ duration: transitionDuration }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+        >
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="employee-profile-title"
+            initial={{
+              opacity: prefersReducedMotion ? 1 : 0,
+              scale: prefersReducedMotion ? 1 : 0.96,
+            }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: prefersReducedMotion ? 1 : 0, scale: prefersReducedMotion ? 1 : 0.96 }}
+            transition={{ duration: transitionDuration, ease: [0.4, 0, 0.2, 1] }}
+            className="w-full max-w-4xl max-h-[90vh] overflow-y-auto rounded-3xl border border-hi bg-[var(--surface)] shadow-[var(--shadow-lg)]"
           >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
+            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-hi bg-[var(--surface)] px-6 py-5">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--muted)]">
+                  {employee?.id ? t('employeeProfile.updateProfile') : t('employeeProfile.title')}
+                </p>
+                <h2
+                  id="employee-profile-title"
+                  className="mt-1 text-2xl font-black text-[var(--text)]"
+                >
+                  {employee?.id
+                    ? `${employee.firstName} ${employee.lastName}`
+                    : t('employeeProfile.subtitle')}
+                </h2>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-xl p-2 text-[var(--muted)] transition duration-150 motion-reduce:transition-none hover:bg-white/5 hover:text-[var(--text)]"
+                aria-label={t('common.close')}
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
 
-        <form onSubmit={handleSubmit} className="p-6">
-          <div className="space-y-8">
-            {/* Personal Information */}
-            <section>
-              <div className="mb-4 flex items-center gap-2">
-                <User className="h-5 w-5 text-[var(--accent)]" />
-                <h3 className="text-lg font-bold text-[var(--text)]">
-                  {t('employeeProfile.personalInfo')}
-                </h3>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <FormField id="firstName" label={t('employeeProfile.firstName')} required>
-                  <input
-                    type="text"
-                    id="firstName"
-                    name="firstName"
-                    value={formData.firstName}
-                    onChange={handleChange}
-                    required
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField id="lastName" label={t('employeeProfile.lastName')} required>
-                  <input
-                    type="text"
-                    id="lastName"
-                    name="lastName"
-                    value={formData.lastName}
-                    onChange={handleChange}
-                    required
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField id="dateOfBirth" label={t('employeeProfile.dateOfBirth')}>
-                  <input
-                    type="date"
-                    id="dateOfBirth"
-                    name="dateOfBirth"
-                    value={formData.dateOfBirth || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-              </div>
-            </section>
+            <form onSubmit={handleSubmit} className="p-6">
+              <div className="space-y-8">
+                {/* Personal Information */}
+                <section>
+                  <div className="mb-4 flex items-center gap-2">
+                    <User className="h-5 w-5 text-[var(--accent)]" />
+                    <h3 className="text-lg font-bold text-[var(--text)]">
+                      {t('employeeProfile.personalInfo')}
+                    </h3>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <FormField id="firstName" label={t('employeeProfile.firstName')} required>
+                      <input
+                        type="text"
+                        id="firstName"
+                        name="firstName"
+                        value={formData.firstName}
+                        onChange={handleChange}
+                        required
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField id="lastName" label={t('employeeProfile.lastName')} required>
+                      <input
+                        type="text"
+                        id="lastName"
+                        name="lastName"
+                        value={formData.lastName}
+                        onChange={handleChange}
+                        required
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField id="dateOfBirth" label={t('employeeProfile.dateOfBirth')}>
+                      <input
+                        type="date"
+                        id="dateOfBirth"
+                        name="dateOfBirth"
+                        value={formData.dateOfBirth || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                  </div>
+                </section>
 
-            {/* Contact Information */}
-            <section>
-              <div className="mb-4 flex items-center gap-2">
-                <Mail className="h-5 w-5 text-[var(--accent)]" />
-                <h3 className="text-lg font-bold text-[var(--text)]">
-                  {t('employeeProfile.contactInfo')}
-                </h3>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <FormField id="email" label={t('employeeProfile.email')} required>
-                  <input
-                    type="email"
-                    id="email"
-                    name="email"
-                    value={formData.email}
-                    onChange={handleChange}
-                    required
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField id="phone" label={t('employeeProfile.phone')}>
-                  <input
-                    type="tel"
-                    id="phone"
-                    name="phone"
-                    value={formData.phone || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <div className="sm:col-span-2">
-                  <FormField id="address" label={t('employeeProfile.address')}>
-                    <input
-                      type="text"
-                      id="address"
-                      name="address"
-                      value={formData.address || ''}
+                {/* Contact Information */}
+                <section>
+                  <div className="mb-4 flex items-center gap-2">
+                    <Mail className="h-5 w-5 text-[var(--accent)]" />
+                    <h3 className="text-lg font-bold text-[var(--text)]">
+                      {t('employeeProfile.contactInfo')}
+                    </h3>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <FormField id="email" label={t('employeeProfile.email')} required>
+                      <input
+                        type="email"
+                        id="email"
+                        name="email"
+                        value={formData.email}
+                        onChange={handleChange}
+                        required
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField id="phone" label={t('employeeProfile.phone')}>
+                      <input
+                        type="tel"
+                        id="phone"
+                        name="phone"
+                        value={formData.phone || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <div className="sm:col-span-2">
+                      <FormField id="address" label={t('employeeProfile.address')}>
+                        <input
+                          type="text"
+                          id="address"
+                          name="address"
+                          value={formData.address || ''}
+                          onChange={handleChange}
+                          className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                        />
+                      </FormField>
+                    </div>
+                    <FormField id="city" label={t('employeeProfile.city')}>
+                      <input
+                        type="text"
+                        id="city"
+                        name="city"
+                        value={formData.city || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField id="state" label={t('employeeProfile.state')}>
+                      <input
+                        type="text"
+                        id="state"
+                        name="state"
+                        value={formData.state || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField id="postalCode" label={t('employeeProfile.postalCode')}>
+                      <input
+                        type="text"
+                        id="postalCode"
+                        name="postalCode"
+                        value={formData.postalCode || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField id="country" label={t('employeeProfile.country')}>
+                      <input
+                        type="text"
+                        id="country"
+                        name="country"
+                        value={formData.country || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                  </div>
+                </section>
+
+                {/* Employment Details */}
+                <section>
+                  <div className="mb-4 flex items-center gap-2">
+                    <Briefcase className="h-5 w-5 text-[var(--accent)]" />
+                    <h3 className="text-lg font-bold text-[var(--text)]">
+                      {t('employeeProfile.employmentDetails')}
+                    </h3>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <FormField id="jobTitle" label={t('employeeProfile.jobTitle')}>
+                      <input
+                        type="text"
+                        id="jobTitle"
+                        name="jobTitle"
+                        value={formData.jobTitle || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField id="department" label={t('employeeProfile.department')}>
+                      <input
+                        type="text"
+                        id="department"
+                        name="department"
+                        value={formData.department || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField id="hireDate" label={t('employeeProfile.hireDate')}>
+                      <input
+                        type="date"
+                        id="hireDate"
+                        name="hireDate"
+                        value={formData.hireDate || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                  </div>
+                </section>
+
+                {/* Emergency Contact */}
+                <section>
+                  <div className="mb-4 flex items-center gap-2">
+                    <Phone className="h-5 w-5 text-[var(--accent)]" />
+                    <h3 className="text-lg font-bold text-[var(--text)]">
+                      {t('employeeProfile.emergencyContact')}
+                    </h3>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <FormField
+                      id="emergencyContactName"
+                      label={t('employeeProfile.emergencyContactName')}
+                    >
+                      <input
+                        type="text"
+                        id="emergencyContactName"
+                        name="emergencyContactName"
+                        value={formData.emergencyContactName || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                    <FormField
+                      id="emergencyContactPhone"
+                      label={t('employeeProfile.emergencyContactPhone')}
+                    >
+                      <input
+                        type="tel"
+                        id="emergencyContactPhone"
+                        name="emergencyContactPhone"
+                        value={formData.emergencyContactPhone || ''}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      />
+                    </FormField>
+                  </div>
+                </section>
+
+                {/* Payment Preferences */}
+                <section>
+                  <div className="mb-4 flex items-center gap-2">
+                    <CreditCard className="h-5 w-5 text-[var(--accent)]" />
+                    <h3 className="text-lg font-bold text-[var(--text)]">
+                      {t('employeeProfile.paymentPreferences')}
+                    </h3>
+                  </div>
+                  <div className="grid gap-4">
+                    <FormField
+                      id="withdrawalPreference"
+                      label={t('employeeProfile.withdrawalPreference')}
+                    >
+                      <select
+                        id="withdrawalPreference"
+                        name="withdrawalPreference"
+                        value={formData.withdrawalPreference || 'crypto'}
+                        onChange={handleChange}
+                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      >
+                        <option value="crypto">{t('employeeProfile.paymentMethodCrypto')}</option>
+                        <option value="bank">{t('employeeProfile.paymentMethodBank')}</option>
+                        <option value="mobile_money">
+                          {t('employeeProfile.paymentMethodMobileMoney')}
+                        </option>
+                      </select>
+                    </FormField>
+
+                    {formData.withdrawalPreference === 'bank' && (
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <FormField id="bankName" label={t('employeeProfile.bankName')}>
+                          <input
+                            type="text"
+                            id="bankName"
+                            name="bankName"
+                            value={formData.bankName || ''}
+                            onChange={handleChange}
+                            className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                          />
+                        </FormField>
+                        <FormField
+                          id="bankAccountNumber"
+                          label={t('employeeProfile.accountNumber')}
+                        >
+                          <input
+                            type="text"
+                            id="bankAccountNumber"
+                            name="bankAccountNumber"
+                            value={formData.bankAccountNumber || ''}
+                            onChange={handleChange}
+                            className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                          />
+                        </FormField>
+                        <FormField
+                          id="bankRoutingNumber"
+                          label={t('employeeProfile.routingNumber')}
+                        >
+                          <input
+                            type="text"
+                            id="bankRoutingNumber"
+                            name="bankRoutingNumber"
+                            value={formData.bankRoutingNumber || ''}
+                            onChange={handleChange}
+                            className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                          />
+                        </FormField>
+                      </div>
+                    )}
+
+                    {formData.withdrawalPreference === 'mobile_money' && (
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <FormField
+                          id="mobileMoneyProvider"
+                          label={t('employeeProfile.mobileMoneyProvider')}
+                        >
+                          <input
+                            type="text"
+                            id="mobileMoneyProvider"
+                            name="mobileMoneyProvider"
+                            value={formData.mobileMoneyProvider || ''}
+                            onChange={handleChange}
+                            className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                          />
+                        </FormField>
+                        <FormField
+                          id="mobileMoneyAccount"
+                          label={t('employeeProfile.mobileMoneyAccount')}
+                        >
+                          <input
+                            type="text"
+                            id="mobileMoneyAccount"
+                            name="mobileMoneyAccount"
+                            value={formData.mobileMoneyAccount || ''}
+                            onChange={handleChange}
+                            className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                          />
+                        </FormField>
+                      </div>
+                    )}
+                  </div>
+                </section>
+
+                {/* Additional Notes */}
+                <section>
+                  <FormField id="notes" label={t('employeeProfile.notes')}>
+                    <textarea
+                      id="notes"
+                      name="notes"
+                      value={formData.notes || ''}
                       onChange={handleChange}
-                      className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
+                      rows={4}
+                      className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition duration-150 motion-reduce:transition-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
                     />
                   </FormField>
-                </div>
-                <FormField id="city" label={t('employeeProfile.city')}>
-                  <input
-                    type="text"
-                    id="city"
-                    name="city"
-                    value={formData.city || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField id="state" label={t('employeeProfile.state')}>
-                  <input
-                    type="text"
-                    id="state"
-                    name="state"
-                    value={formData.state || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField id="postalCode" label={t('employeeProfile.postalCode')}>
-                  <input
-                    type="text"
-                    id="postalCode"
-                    name="postalCode"
-                    value={formData.postalCode || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField id="country" label={t('employeeProfile.country')}>
-                  <input
-                    type="text"
-                    id="country"
-                    name="country"
-                    value={formData.country || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
+                </section>
               </div>
-            </section>
 
-            {/* Employment Details */}
-            <section>
-              <div className="mb-4 flex items-center gap-2">
-                <Briefcase className="h-5 w-5 text-[var(--accent)]" />
-                <h3 className="text-lg font-bold text-[var(--text)]">
-                  {t('employeeProfile.employmentDetails')}
-                </h3>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <FormField id="jobTitle" label={t('employeeProfile.jobTitle')}>
-                  <input
-                    type="text"
-                    id="jobTitle"
-                    name="jobTitle"
-                    value={formData.jobTitle || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField id="department" label={t('employeeProfile.department')}>
-                  <input
-                    type="text"
-                    id="department"
-                    name="department"
-                    value={formData.department || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField id="hireDate" label={t('employeeProfile.hireDate')}>
-                  <input
-                    type="date"
-                    id="hireDate"
-                    name="hireDate"
-                    value={formData.hireDate || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-              </div>
-            </section>
-
-            {/* Emergency Contact */}
-            <section>
-              <div className="mb-4 flex items-center gap-2">
-                <Phone className="h-5 w-5 text-[var(--accent)]" />
-                <h3 className="text-lg font-bold text-[var(--text)]">
-                  {t('employeeProfile.emergencyContact')}
-                </h3>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <FormField
-                  id="emergencyContactName"
-                  label={t('employeeProfile.emergencyContactName')}
+              <div className="mt-8 flex justify-end gap-3 border-t border-hi pt-6">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded-xl border border-hi px-6 py-3 text-sm font-semibold text-[var(--muted)] transition duration-150 motion-reduce:transition-none hover:text-[var(--text)]"
                 >
-                  <input
-                    type="text"
-                    id="emergencyContactName"
-                    name="emergencyContactName"
-                    value={formData.emergencyContactName || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
-                <FormField
-                  id="emergencyContactPhone"
-                  label={t('employeeProfile.emergencyContactPhone')}
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-xl bg-[var(--accent)] px-6 py-3 text-sm font-bold text-[var(--bg)] transition duration-150 motion-reduce:transition-none hover:brightness-110"
                 >
-                  <input
-                    type="tel"
-                    id="emergencyContactPhone"
-                    name="emergencyContactPhone"
-                    value={formData.emergencyContactPhone || ''}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  />
-                </FormField>
+                  {employee?.id
+                    ? t('employeeProfile.updateProfile')
+                    : t('employeeProfile.saveProfile')}
+                </button>
               </div>
-            </section>
-
-            {/* Payment Preferences */}
-            <section>
-              <div className="mb-4 flex items-center gap-2">
-                <CreditCard className="h-5 w-5 text-[var(--accent)]" />
-                <h3 className="text-lg font-bold text-[var(--text)]">
-                  {t('employeeProfile.paymentPreferences')}
-                </h3>
-              </div>
-              <div className="grid gap-4">
-                <FormField
-                  id="withdrawalPreference"
-                  label={t('employeeProfile.withdrawalPreference')}
-                >
-                  <select
-                    id="withdrawalPreference"
-                    name="withdrawalPreference"
-                    value={formData.withdrawalPreference || 'crypto'}
-                    onChange={handleChange}
-                    className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                  >
-                    <option value="crypto">{t('employeeProfile.paymentMethodCrypto')}</option>
-                    <option value="bank">{t('employeeProfile.paymentMethodBank')}</option>
-                    <option value="mobile_money">{t('employeeProfile.paymentMethodMobileMoney')}</option>
-                  </select>
-                </FormField>
-
-                {formData.withdrawalPreference === 'bank' && (
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <FormField id="bankName" label={t('employeeProfile.bankName')}>
-                      <input
-                        type="text"
-                        id="bankName"
-                        name="bankName"
-                        value={formData.bankName || ''}
-                        onChange={handleChange}
-                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                      />
-                    </FormField>
-                    <FormField id="bankAccountNumber" label={t('employeeProfile.accountNumber')}>
-                      <input
-                        type="text"
-                        id="bankAccountNumber"
-                        name="bankAccountNumber"
-                        value={formData.bankAccountNumber || ''}
-                        onChange={handleChange}
-                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                      />
-                    </FormField>
-                    <FormField id="bankRoutingNumber" label={t('employeeProfile.routingNumber')}>
-                      <input
-                        type="text"
-                        id="bankRoutingNumber"
-                        name="bankRoutingNumber"
-                        value={formData.bankRoutingNumber || ''}
-                        onChange={handleChange}
-                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                      />
-                    </FormField>
-                  </div>
-                )}
-
-                {formData.withdrawalPreference === 'mobile_money' && (
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <FormField
-                      id="mobileMoneyProvider"
-                      label={t('employeeProfile.mobileMoneyProvider')}
-                    >
-                      <input
-                        type="text"
-                        id="mobileMoneyProvider"
-                        name="mobileMoneyProvider"
-                        value={formData.mobileMoneyProvider || ''}
-                        onChange={handleChange}
-                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                      />
-                    </FormField>
-                    <FormField
-                      id="mobileMoneyAccount"
-                      label={t('employeeProfile.mobileMoneyAccount')}
-                    >
-                      <input
-                        type="text"
-                        id="mobileMoneyAccount"
-                        name="mobileMoneyAccount"
-                        value={formData.mobileMoneyAccount || ''}
-                        onChange={handleChange}
-                        className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                      />
-                    </FormField>
-                  </div>
-                )}
-              </div>
-            </section>
-
-            {/* Additional Notes */}
-            <section>
-              <FormField id="notes" label={t('employeeProfile.notes')}>
-                <textarea
-                  id="notes"
-                  name="notes"
-                  value={formData.notes || ''}
-                  onChange={handleChange}
-                  rows={4}
-                  className="w-full rounded-xl border border-hi bg-[var(--surface-hi)] px-4 py-3 text-[var(--text)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[color:rgba(74,240,184,0.18)]"
-                />
-              </FormField>
-            </section>
-          </div>
-
-          <div className="mt-8 flex justify-end gap-3 border-t border-hi pt-6">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-xl border border-hi px-6 py-3 text-sm font-semibold text-[var(--muted)] transition hover:text-[var(--text)]"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="rounded-xl bg-[var(--accent)] px-6 py-3 text-sm font-bold text-[var(--bg)] transition hover:brightness-110"
-            >
-              {employee?.id ? t('employeeProfile.updateProfile') : t('employeeProfile.saveProfile')}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+            </form>
+          </motion.div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
   );
 };

--- a/frontend/src/components/EmployeeRemovalConfirmModal.module.css
+++ b/frontend/src/components/EmployeeRemovalConfirmModal.module.css
@@ -6,7 +6,8 @@
  * - Fully responsive design (mobile-first)
  * - Accessible focus states and ARIA compliance
  * - Smooth animations
- * - Dark mode support via CSS variables
+ * - Themed via the app's design tokens (index.css), so it tracks the
+ *   in-app theme toggle (`data-theme`) rather than the OS color scheme
  * - WCAG 2.1 AA color contrast compliance
  */
 
@@ -20,7 +21,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
   z-index: 50;
   padding: 1rem;
@@ -35,19 +36,17 @@
 
 .modal {
   position: relative;
-  background: var(--surface, #ffffff);
-  border-radius: 0.75rem;
+  background: var(--surface);
+  border-radius: 1.5rem;
   max-width: 28rem; /* 448px */
   width: 100%;
   max-height: 90vh;
-  box-shadow:
-    0 20px 25px -5px rgba(0, 0, 0, 0.1),
-    0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  animation: slideUp 0.3s ease-out;
+  box-shadow: var(--shadow-lg);
+  animation: slideUp 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   flex-direction: column;
   outline: none;
-  border: 1px solid var(--border, #e5e7eb);
+  border: 1px solid var(--border-hi);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -105,20 +104,20 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  color: var(--text-muted, #6b7280);
-  border-radius: 0.375rem;
-  transition: all 0.2s ease;
+  color: var(--muted);
+  border-radius: 0.75rem;
+  transition: all 0.15s ease;
   z-index: 51;
   padding: 0.25rem;
 }
 
 .closeButton:hover:not(:disabled) {
-  background: var(--bg-hover, #f3f4f6);
-  color: var(--text, #1f2937);
+  background: var(--surface-hi);
+  color: var(--text);
 }
 
 .closeButton:focus {
-  outline: 2px solid var(--accent, #3b82f6);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -169,9 +168,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--danger-bg, #fee2e2);
-  border-radius: 0.75rem;
-  color: var(--danger, #dc2626);
+  background: color-mix(in srgb, var(--danger) 15%, transparent);
+  border-radius: 1rem;
+  color: var(--danger);
 }
 
 .title {
@@ -179,7 +178,7 @@
   font-size: 1.25rem;
   font-weight: 700;
   line-height: 1.75rem;
-  color: var(--text, #1f2937);
+  color: var(--text);
   letter-spacing: -0.01em;
 }
 
@@ -194,9 +193,9 @@
    ========================================================================== */
 
 .employeeSection {
-  background: var(--bg-secondary, #f9fafb);
-  border: 1px solid var(--border-light, #f3f4f6);
-  border-radius: 0.5rem;
+  background: var(--surface-hi);
+  border: 1px solid var(--border-hi);
+  border-radius: 0.75rem;
   padding: 1rem;
   text-align: center;
 }
@@ -205,7 +204,7 @@
   margin: 0 0 0.5rem 0;
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--text-muted, #6b7280);
+  color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -214,7 +213,7 @@
   margin: 0;
   font-size: 1.125rem;
   font-weight: 600;
-  color: var(--danger, #dc2626);
+  color: var(--danger);
   word-break: break-word;
 }
 
@@ -232,16 +231,16 @@
   margin: 0;
   font-size: 0.95rem;
   line-height: 1.5rem;
-  color: var(--text, #1f2937);
+  color: var(--text);
   font-weight: 500;
 }
 
 .warningBox {
   display: flex;
   gap: 0.75rem;
-  background: var(--danger-bg, #fee2e2);
-  border: 1px solid var(--danger-border, #fca5a5);
-  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
+  border-radius: 0.75rem;
   padding: 1rem;
   align-items: flex-start;
 }
@@ -253,7 +252,7 @@
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
-  color: var(--danger, #dc2626);
+  color: var(--danger);
   margin-top: 0.125rem;
 }
 
@@ -268,21 +267,21 @@
   margin: 0;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--danger, #dc2626);
+  color: var(--danger);
 }
 
 .warningText {
   margin: 0;
   font-size: 0.875rem;
   line-height: 1.375rem;
-  color: var(--danger, #991b1b);
+  color: var(--danger);
 }
 
 .confirmationText {
   margin: 0;
   font-size: 0.875rem;
   line-height: 1.375rem;
-  color: var(--text-muted, #6b7280);
+  color: var(--muted);
   font-style: italic;
 }
 
@@ -312,10 +311,10 @@
   font-size: 0.95rem;
   font-weight: 500;
   line-height: 1.5;
-  border-radius: 0.375rem;
+  border-radius: 0.75rem;
   border: none;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.15s ease;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -334,18 +333,17 @@
 
 /* Cancel Button */
 .cancelButton {
-  background: var(--bg-secondary, #f3f4f6);
-  color: var(--text, #1f2937);
-  border: 1px solid var(--border-light, #e5e7eb);
+  background: var(--surface-hi);
+  color: var(--text);
+  border: 1px solid var(--border-hi);
 }
 
 .cancelButton:hover:not(:disabled) {
-  background: var(--bg-tertiary, #e5e7eb);
-  border-color: var(--border, #d1d5db);
+  background: var(--border-hi);
 }
 
 .cancelButton:focus {
-  outline: 2px solid var(--accent, #3b82f6);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -360,22 +358,20 @@
 
 /* Remove Button (Danger/Primary Action) */
 .removeButton {
-  background: var(--danger, #dc2626);
-  color: white;
-  border: 1px solid var(--danger, #dc2626);
-  font-weight: 600;
+  background: var(--danger);
+  color: var(--bg);
+  border: 1px solid var(--danger);
+  font-weight: 700;
 }
 
 .removeButton:hover:not(:disabled) {
-  background: var(--danger-hover, #b91c1c);
-  border-color: var(--danger-hover, #b91c1c);
-  box-shadow: 0 4px 6px -1px rgba(220, 38, 38, 0.2);
+  filter: brightness(1.1);
 }
 
 .removeButton:focus {
-  outline: 2px solid white;
+  outline: 2px solid var(--danger);
   outline-offset: 2px;
-  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.3);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger) 30%, transparent);
 }
 
 .removeButton:focus:not(:focus-visible) {
@@ -393,8 +389,8 @@
   display: inline-block;
   width: 1rem;
   height: 1rem;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: white;
+  border: 2px solid color-mix(in srgb, var(--bg) 30%, transparent);
+  border-top-color: var(--bg);
   border-radius: 50%;
   animation: spin 0.6s linear infinite;
 }
@@ -402,7 +398,7 @@
 @media (prefers-reduced-motion: reduce) {
   .loadingSpinner {
     animation: none;
-    border: 2px solid white;
+    border: 2px solid var(--bg);
   }
 }
 
@@ -412,7 +408,7 @@
 
 /* Focus visible states */
 *:focus-visible {
-  outline: 2px solid var(--accent, #3b82f6);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -434,56 +430,16 @@
 /* High contrast mode support */
 @media (prefers-contrast: more) {
   .iconWrapper {
-    border: 2px solid var(--danger, #dc2626);
+    border: 2px solid var(--danger);
   }
 
   .warningBox {
-    border: 2px solid var(--danger, #dc2626);
+    border: 2px solid var(--danger);
   }
 
   .cancelButton,
   .removeButton {
     border-width: 2px;
-  }
-}
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-  .modal {
-    background: var(--surface-dark, #1f2937);
-    border-color: var(--border-dark, #374151);
-  }
-
-  .closeButton {
-    color: var(--text-muted-dark, #9ca3af);
-  }
-
-  .closeButton:hover:not(:disabled) {
-    background: var(--bg-hover-dark, #374151);
-    color: var(--text-dark, #f3f4f6);
-  }
-
-  .employeeSection {
-    background: var(--bg-secondary-dark, #111827);
-    border-color: var(--border-light-dark, #374151);
-  }
-
-  .label {
-    color: var(--text-muted-dark, #9ca3af);
-  }
-
-  .subtitle {
-    color: var(--text-dark, #f3f4f6);
-  }
-
-  .cancelButton {
-    background: var(--bg-secondary-dark, #374151);
-    color: var(--text-dark, #f3f4f6);
-    border-color: var(--border-dark, #4b5563);
-  }
-
-  .cancelButton:hover:not(:disabled) {
-    background: var(--bg-tertiary-dark, #4b5563);
   }
 }
 


### PR DESCRIPTION
## Summary

- Closes #1421: `EmployeeProfileModal` now uses `framer-motion` (`AnimatePresence`/`motion`) for its open/close and backdrop transitions, matching the motion token conventions (duration, `[0.4, 0, 0.2, 1]` easing, `useReducedMotion`) already used by the other modals in `EmployeeList.tsx` and `CSVUploader.tsx`. Hover/focus transitions on inputs and buttons now also respect `prefers-reduced-motion` via `motion-reduce:transition-none`. No layout shift or functional changes.
- Closes #1422: `EmployeeRemovalConfirmModal.module.css` now sources its colors, borders, and shadows from the app's design tokens (`--surface`, `--text`, `--muted`, `--danger`, `--border-hi`, `--shadow-lg`, etc., via the same `color-mix()` pattern used in `OfflineBanner.tsx`/`EmployeeList.tsx`) instead of hardcoded hex fallbacks. Removed the `@media (prefers-color-scheme: dark)` block, since it tracked the OS color scheme rather than the app's `data-theme` toggle (`ThemeProvider.tsx`), which could cause the modal to disagree with the rest of the app's theme. No class names, markup, or props changed.

## Test plan

- [x] `npx vitest run src/components/__tests__/EmployeeProfileModal.test.tsx` — 8/9 pass (1 pre-existing failure on `main`, unrelated to this change — verified via `git stash`)
- [x] `npx vitest run src/components/__tests__/EmployeeRemovalConfirmModal.test.tsx` — 47/47 pass
- [x] `npx eslint` on changed files — clean
- [x] `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors on `main` untouched)
- [x] `npm run build` — succeeds